### PR TITLE
Use the cc crate for building the assembly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,9 +36,19 @@ name = "c2rust_out"
 version = "0.0.0"
 dependencies = [
  "c2rust-bitfields",
+ "cc",
  "libc",
  "quickcheck",
  "xxhash-rust",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
+dependencies = [
+ "shlex",
 ]
 
 [[package]]
@@ -161,6 +171,12 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,13 @@ autobins = false
 name = "c2rust_out"
 path = "c2rust-lib.rs"
 crate-type = ["staticlib", "rlib"]
+
 [dependencies]
-c2rust-bitfields= "0.3"
-libc= "0.2"
+c2rust-bitfields = "0.3"
+libc = "0.2"
+
+[target.'cfg(target_arch = "x86_64")'.build-dependencies]
+cc = "1.2.30"
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,4 @@
-#[cfg(all(unix, not(target_os = "macos")))]
 fn main() {
-    // add unix dependencies below
-    // println!("cargo:rustc-flags=-l readline");
-}
-
-#[cfg(target_os = "macos")]
-fn main() {
-    // add macos dependencies below
-    // println!("cargo:rustc-flags=-l edit");
+    #[cfg(target_arch = "x86_64")]
+    cc::Build::new().file("lib/decompress/huf_decompress_amd64.S").compile("huf_decompress_amd64");
 }


### PR DESCRIPTION
This is more convenient than using RUSTFLAGS and unlike -Clink-arg doesn't assume gcc or clang is used as linker driver. link.exe on windows can't compile assembly.