### PR TITLE
use `export_name` instead of `no_mangle`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,8 @@ quickcheck = "1.0.3"
 [dev-dependencies.xxhash-rust]
 version = "0.8.15"
 features = ["xxh64", "xxh32"]
+
+
+[features]
+export-symbols = [] # whether the zlib api symbols are publicly exported
+semver-prefix = ["export-symbols"] # prefix all symbols in a semver-compatible way

--- a/c2rust-lib.rs
+++ b/c2rust-lib.rs
@@ -70,6 +70,29 @@ pub mod programs {
     pub mod zstdcli_trace;
 } // mod programs
 
+#[cfg(feature = "semver-prefix")]
+macro_rules! prefix {
+    ($name:expr) => {
+        concat!(
+            "LIBZ_RS_SYS_v",
+            env!("CARGO_PKG_VERSION_MAJOR"),
+            "_",
+            env!("CARGO_PKG_VERSION_MINOR"),
+            "_x_",
+            stringify!($name)
+        )
+    };
+}
+
+#[cfg(not(feature = "semver-prefix"))]
+macro_rules! prefix {
+    ($name:expr) => {
+        stringify!($name)
+    };
+}
+
+pub(crate) use prefix;
+
 #[inline]
 pub(crate) fn MEM_isLittleEndian() -> std::ffi::c_uint {
     cfg!(target_endian = "little") as _

--- a/lib/common/error_private.rs
+++ b/lib/common/error_private.rs
@@ -1,7 +1,6 @@
 use crate::lib::zstd::ZSTD_ErrorCode;
-
 pub type ERR_enum = ZSTD_ErrorCode;
-#[no_mangle]
+#[export_name = crate::prefix!(ERR_getErrorString)]
 pub unsafe extern "C" fn ERR_getErrorString(mut code: ERR_enum) -> *const std::ffi::c_char {
     static mut notErrorCode: *const std::ffi::c_char =
         b"Unspecified error code\0" as *const u8 as *const std::ffi::c_char;

--- a/lib/common/pool.rs
+++ b/lib/common/pool.rs
@@ -121,18 +121,18 @@ unsafe extern "C" fn POOL_thread(mut opaque: *mut std::ffi::c_void) -> *mut std:
         pthread_mutex_unlock(&mut (*ctx).queueMutex);
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_createThreadPool)]
 pub unsafe extern "C" fn ZSTD_createThreadPool(mut numThreads: size_t) -> *mut ZSTD_threadPool {
     POOL_create(numThreads, 0 as std::ffi::c_int as size_t)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(POOL_create)]
 pub unsafe extern "C" fn POOL_create(
     mut numThreads: size_t,
     mut queueSize: size_t,
 ) -> *mut POOL_ctx {
     POOL_create_advanced(numThreads, queueSize, ZSTD_defaultCMem)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(POOL_create_advanced)]
 pub unsafe extern "C" fn POOL_create_advanced(
     mut numThreads: size_t,
     mut queueSize: size_t,
@@ -226,7 +226,7 @@ unsafe extern "C" fn POOL_join(mut ctx: *mut POOL_ctx) {
         i;
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(POOL_free)]
 pub unsafe extern "C" fn POOL_free(mut ctx: *mut POOL_ctx) {
     if ctx.is_null() {
         return;
@@ -239,7 +239,7 @@ pub unsafe extern "C" fn POOL_free(mut ctx: *mut POOL_ctx) {
     ZSTD_customFree((*ctx).threads as *mut std::ffi::c_void, (*ctx).customMem);
     ZSTD_customFree(ctx as *mut std::ffi::c_void, (*ctx).customMem);
 }
-#[no_mangle]
+#[export_name = crate::prefix!(POOL_joinJobs)]
 pub unsafe extern "C" fn POOL_joinJobs(mut ctx: *mut POOL_ctx) {
     pthread_mutex_lock(&mut (*ctx).queueMutex);
     while (*ctx).queueEmpty == 0 || (*ctx).numThreadsBusy > 0 as std::ffi::c_int as size_t {
@@ -247,11 +247,11 @@ pub unsafe extern "C" fn POOL_joinJobs(mut ctx: *mut POOL_ctx) {
     }
     pthread_mutex_unlock(&mut (*ctx).queueMutex);
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_freeThreadPool)]
 pub unsafe extern "C" fn ZSTD_freeThreadPool(mut pool: *mut ZSTD_threadPool) {
     POOL_free(pool);
 }
-#[no_mangle]
+#[export_name = crate::prefix!(POOL_sizeof)]
 pub unsafe extern "C" fn POOL_sizeof(mut ctx: *const POOL_ctx) -> size_t {
     if ctx.is_null() {
         return 0 as std::ffi::c_int as size_t;
@@ -315,7 +315,7 @@ unsafe extern "C" fn POOL_resize_internal(
     (*ctx).threadLimit = numThreads;
     0 as std::ffi::c_int
 }
-#[no_mangle]
+#[export_name = crate::prefix!(POOL_resize)]
 pub unsafe extern "C" fn POOL_resize(
     mut ctx: *mut POOL_ctx,
     mut numThreads: size_t,
@@ -359,7 +359,7 @@ unsafe extern "C" fn POOL_add_internal(
         ((*ctx).queueTail).wrapping_add(1 as std::ffi::c_int as size_t) % (*ctx).queueSize;
     pthread_cond_signal(&mut (*ctx).queuePopCond);
 }
-#[no_mangle]
+#[export_name = crate::prefix!(POOL_add)]
 pub unsafe extern "C" fn POOL_add(
     mut ctx: *mut POOL_ctx,
     mut function: POOL_function,
@@ -372,7 +372,7 @@ pub unsafe extern "C" fn POOL_add(
     POOL_add_internal(ctx, function, opaque);
     pthread_mutex_unlock(&mut (*ctx).queueMutex);
 }
-#[no_mangle]
+#[export_name = crate::prefix!(POOL_tryAdd)]
 pub unsafe extern "C" fn POOL_tryAdd(
     mut ctx: *mut POOL_ctx,
     mut function: POOL_function,

--- a/lib/common/xxhash.rs
+++ b/lib/common/xxhash.rs
@@ -124,13 +124,10 @@ fn XXH64_endian_align(mut input: &[u8], mut seed: u64, align: Align) -> u64 {
     } else {
         h64 = seed.wrapping_add(XXH_PRIME64_5);
     }
-
     h64 = h64.wrapping_add(input.len() as u64);
-
     XXH64_finalize(h64, remainder, align)
 }
-
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_XXH64)]
 pub unsafe extern "C" fn ZSTD_XXH64(
     mut input: *const std::ffi::c_void,
     mut len: usize,
@@ -142,11 +139,9 @@ pub unsafe extern "C" fn ZSTD_XXH64(
     } else {
         core::slice::from_raw_parts(input.cast::<u8>(), len)
     };
-
     XXH64_endian_align(slice, seed, Align::Unaligned)
 }
-
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_XXH64_reset)]
 pub extern "C" fn ZSTD_XXH64_reset(state: &mut XXH64_state_t, mut seed: u64) -> XXH_errorcode {
     // SAFETY: all zeros is a valid value of type XXH64_state_t.
     unsafe {
@@ -157,11 +152,9 @@ pub extern "C" fn ZSTD_XXH64_reset(state: &mut XXH64_state_t, mut seed: u64) -> 
     state.v[1] = seed.wrapping_add(XXH_PRIME64_2);
     state.v[2] = seed.wrapping_add(0);
     state.v[3] = seed.wrapping_sub(XXH_PRIME64_1);
-
     XXH_errorcode::XXH_OK
 }
-
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_XXH64_update)]
 pub unsafe extern "C" fn ZSTD_XXH64_update(
     state: &mut XXH64_state_t,
     mut input: *const c_void,
@@ -215,14 +208,11 @@ fn ZSTD_XXH64_update_help(state: &mut XXH64_state_t, mut slice: &[u8]) -> XXH_er
         state.mem64_as_bytes_mut()[..remainder.len()].copy_from_slice(remainder);
         state.memsize = remainder.len() as u32;
     }
-
     XXH_errorcode::XXH_OK
 }
-
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_XXH64_digest)]
 pub extern "C" fn ZSTD_XXH64_digest(state: &mut XXH64_state_t) -> u64 {
     let mut h64;
-
     if state.total_len >= 32 {
         h64 = (state.v[0].rotate_left(1))
             .wrapping_add(state.v[1].rotate_left(7))

--- a/lib/common/zstd_common.rs
+++ b/lib/common/zstd_common.rs
@@ -23,31 +23,31 @@ pub const ZSTD_VERSION_NUMBER: std::ffi::c_int =
     ZSTD_VERSION_MAJOR * 100 as std::ffi::c_int * 100 as std::ffi::c_int
         + ZSTD_VERSION_MINOR * 100 as std::ffi::c_int
         + ZSTD_VERSION_RELEASE;
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_versionNumber)]
 pub unsafe extern "C" fn ZSTD_versionNumber() -> std::ffi::c_uint {
     ZSTD_VERSION_NUMBER as std::ffi::c_uint
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_versionString)]
 pub unsafe extern "C" fn ZSTD_versionString() -> *const std::ffi::c_char {
     b"1.5.8\0" as *const u8 as *const std::ffi::c_char
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_isError)]
 pub unsafe extern "C" fn ZSTD_isError(mut code: size_t) -> std::ffi::c_uint {
     ERR_isError(code)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_getErrorName)]
 pub unsafe extern "C" fn ZSTD_getErrorName(mut code: size_t) -> *const std::ffi::c_char {
     ERR_getErrorName(code)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_getErrorCode)]
 pub unsafe extern "C" fn ZSTD_getErrorCode(mut code: size_t) -> ZSTD_ErrorCode {
     ERR_getErrorCode(code)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_getErrorString)]
 pub unsafe extern "C" fn ZSTD_getErrorString(mut code: ZSTD_ErrorCode) -> *const std::ffi::c_char {
     ERR_getErrorString(code)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_isDeterministicBuild)]
 pub unsafe extern "C" fn ZSTD_isDeterministicBuild() -> std::ffi::c_int {
     1 as std::ffi::c_int
 }

--- a/lib/compress/fse_compress.rs
+++ b/lib/compress/fse_compress.rs
@@ -277,7 +277,7 @@ pub const FSE_MAX_TABLELOG: std::ffi::c_int = FSE_MAX_MEMORY_USAGE - 2 as std::f
 pub const FSE_DEFAULT_TABLELOG: std::ffi::c_int = FSE_DEFAULT_MEMORY_USAGE - 2 as std::ffi::c_int;
 pub const FSE_MIN_TABLELOG: std::ffi::c_int = 5 as std::ffi::c_int;
 pub const FSE_isError: unsafe extern "C" fn(size_t) -> std::ffi::c_uint = ERR_isError;
-#[no_mangle]
+#[export_name = crate::prefix!(FSE_buildCTable_wksp)]
 pub unsafe extern "C" fn FSE_buildCTable_wksp(
     mut ct: *mut FSE_CTable,
     mut normalizedCounter: *const std::ffi::c_short,
@@ -465,7 +465,7 @@ pub unsafe extern "C" fn FSE_buildCTable_wksp(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSE_NCountWriteBound)]
 pub unsafe extern "C" fn FSE_NCountWriteBound(
     mut maxSymbolValue: std::ffi::c_uint,
     mut tableLog: std::ffi::c_uint,
@@ -606,7 +606,7 @@ unsafe extern "C" fn FSE_writeNCount_generic(
     out = out.offset(((bitCount + 7 as std::ffi::c_int) / 8 as std::ffi::c_int) as isize);
     out.offset_from(ostart) as std::ffi::c_long as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSE_writeNCount)]
 pub unsafe extern "C" fn FSE_writeNCount(
     mut buffer: *mut std::ffi::c_void,
     mut bufferSize: size_t,
@@ -647,14 +647,13 @@ unsafe extern "C" fn FSE_minTableLog(
         (ZSTD_highbit32(srcSize as u32)).wrapping_add(1 as std::ffi::c_int as std::ffi::c_uint);
     let mut minBitsSymbols =
         (ZSTD_highbit32(maxSymbolValue)).wrapping_add(2 as std::ffi::c_int as std::ffi::c_uint);
-
     if minBitsSrc < minBitsSymbols {
         minBitsSrc
     } else {
         minBitsSymbols
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSE_optimalTableLog_internal)]
 pub unsafe extern "C" fn FSE_optimalTableLog_internal(
     mut maxTableLog: std::ffi::c_uint,
     mut srcSize: size_t,
@@ -683,7 +682,7 @@ pub unsafe extern "C" fn FSE_optimalTableLog_internal(
     }
     tableLog
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSE_optimalTableLog)]
 pub unsafe extern "C" fn FSE_optimalTableLog(
     mut maxTableLog: std::ffi::c_uint,
     mut srcSize: size_t,
@@ -811,7 +810,7 @@ unsafe extern "C" fn FSE_normalizeM2(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSE_normalizeCount)]
 pub unsafe extern "C" fn FSE_normalizeCount(
     mut normalizedCounter: *mut std::ffi::c_short,
     mut tableLog: std::ffi::c_uint,
@@ -910,7 +909,7 @@ pub unsafe extern "C" fn FSE_normalizeCount(
     }
     tableLog as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSE_buildCTable_rle)]
 pub unsafe extern "C" fn FSE_buildCTable_rle(
     mut ct: *mut FSE_CTable,
     mut symbolValue: u8,
@@ -1033,7 +1032,7 @@ unsafe extern "C" fn FSE_compress_usingCTable_generic(
     FSE_flushCState(&mut bitC, &mut CState1);
     BIT_closeCStream(&mut bitC)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSE_compress_usingCTable)]
 pub unsafe extern "C" fn FSE_compress_usingCTable(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -1067,7 +1066,7 @@ pub unsafe extern "C" fn FSE_compress_usingCTable(
         )
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSE_compressBound)]
 pub unsafe extern "C" fn FSE_compressBound(mut size: size_t) -> size_t {
     (FSE_NCOUNTBOUND as std::ffi::c_ulong).wrapping_add(
         size.wrapping_add(size >> 7 as std::ffi::c_int)

--- a/lib/compress/hist.rs
+++ b/lib/compress/hist.rs
@@ -13,11 +13,11 @@ pub const HIST_WKSP_SIZE_U32: std::ffi::c_int = 1024 as std::ffi::c_int;
 pub const HIST_WKSP_SIZE: std::ffi::c_ulong = (HIST_WKSP_SIZE_U32 as std::ffi::c_ulong)
     .wrapping_mul(::core::mem::size_of::<std::ffi::c_uint>() as std::ffi::c_ulong);
 pub const HIST_FAST_THRESHOLD: std::ffi::c_int = 1500 as std::ffi::c_int;
-#[no_mangle]
+#[export_name = crate::prefix!(HIST_isError)]
 pub unsafe extern "C" fn HIST_isError(mut code: size_t) -> std::ffi::c_uint {
     ERR_isError(code)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HIST_add)]
 pub unsafe extern "C" fn HIST_add(
     mut count: *mut std::ffi::c_uint,
     mut src: *const std::ffi::c_void,
@@ -33,7 +33,7 @@ pub unsafe extern "C" fn HIST_add(
         *fresh1;
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HIST_count_simple)]
 pub unsafe extern "C" fn HIST_count_simple(
     mut count: *mut std::ffi::c_uint,
     mut maxSymbolValuePtr: *mut std::ffi::c_uint,
@@ -215,7 +215,7 @@ unsafe extern "C" fn HIST_count_parallel_wksp(
     );
     max as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HIST_countFast_wksp)]
 pub unsafe extern "C" fn HIST_countFast_wksp(
     mut count: *mut std::ffi::c_uint,
     mut maxSymbolValuePtr: *mut std::ffi::c_uint,
@@ -242,7 +242,7 @@ pub unsafe extern "C" fn HIST_countFast_wksp(
         workSpace as *mut u32,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HIST_count_wksp)]
 pub unsafe extern "C" fn HIST_count_wksp(
     mut count: *mut std::ffi::c_uint,
     mut maxSymbolValuePtr: *mut std::ffi::c_uint,
@@ -277,7 +277,7 @@ pub unsafe extern "C" fn HIST_count_wksp(
         workSpaceSize,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HIST_countFast)]
 pub unsafe extern "C" fn HIST_countFast(
     mut count: *mut std::ffi::c_uint,
     mut maxSymbolValuePtr: *mut std::ffi::c_uint,
@@ -294,7 +294,7 @@ pub unsafe extern "C" fn HIST_countFast(
         ::core::mem::size_of::<[std::ffi::c_uint; 1024]>() as std::ffi::c_ulong,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HIST_count)]
 pub unsafe extern "C" fn HIST_count(
     mut count: *mut std::ffi::c_uint,
     mut maxSymbolValuePtr: *mut std::ffi::c_uint,

--- a/lib/compress/huf_compress.rs
+++ b/lib/compress/huf_compress.rs
@@ -303,7 +303,7 @@ unsafe extern "C" fn HUF_setValue(mut elt: *mut HUF_CElt, mut value: size_t) {
                 .wrapping_sub(nbBits);
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUF_readCTableHeader)]
 pub unsafe extern "C" fn HUF_readCTableHeader(mut ctable: *const HUF_CElt) -> HUF_CTableHeader {
     let mut header = HUF_CTableHeader {
         tableLog: 0,
@@ -340,7 +340,7 @@ unsafe extern "C" fn HUF_writeCTableHeader(
         ::core::mem::size_of::<HUF_CTableHeader>() as std::ffi::c_ulong as libc::size_t,
     );
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUF_writeCTable_wksp)]
 pub unsafe extern "C" fn HUF_writeCTable_wksp(
     mut dst: *mut std::ffi::c_void,
     mut maxDstSize: size_t,
@@ -440,7 +440,7 @@ pub unsafe extern "C" fn HUF_writeCTable_wksp(
         .wrapping_div(2 as std::ffi::c_int as std::ffi::c_uint)
         .wrapping_add(1 as std::ffi::c_int as std::ffi::c_uint) as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUF_readCTable)]
 pub unsafe extern "C" fn HUF_readCTable(
     mut CTable: *mut HUF_CElt,
     mut maxSymbolValuePtr: *mut std::ffi::c_uint,
@@ -543,7 +543,7 @@ pub unsafe extern "C" fn HUF_readCTable(
     }
     readSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUF_getNbBitsFromCTable)]
 pub unsafe extern "C" fn HUF_getNbBitsFromCTable(
     mut CTable: *const HUF_CElt,
     mut symbolValue: u32,
@@ -979,7 +979,7 @@ unsafe extern "C" fn HUF_buildCTableFromTree(
     }
     HUF_writeCTableHeader(CTable, maxNbBits, maxSymbolValue);
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUF_buildCTable_wksp)]
 pub unsafe extern "C" fn HUF_buildCTable_wksp(
     mut CTable: *mut HUF_CElt,
     mut count: *const std::ffi::c_uint,
@@ -1024,7 +1024,7 @@ pub unsafe extern "C" fn HUF_buildCTable_wksp(
     HUF_buildCTableFromTree(CTable, huffNode, nonNullRank, maxSymbolValue, maxNbBits);
     maxNbBits as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUF_estimateCompressedSize)]
 pub unsafe extern "C" fn HUF_estimateCompressedSize(
     mut CTable: *const HUF_CElt,
     mut count: *const std::ffi::c_uint,
@@ -1043,7 +1043,7 @@ pub unsafe extern "C" fn HUF_estimateCompressedSize(
     }
     nbBits >> 3 as std::ffi::c_int
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUF_validateCTable)]
 pub unsafe extern "C" fn HUF_validateCTable(
     mut CTable: *const HUF_CElt,
     mut count: *const std::ffi::c_uint,
@@ -1067,7 +1067,7 @@ pub unsafe extern "C" fn HUF_validateCTable(
     }
     (bad == 0) as std::ffi::c_int
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUF_compressBound)]
 pub unsafe extern "C" fn HUF_compressBound(mut size: size_t) -> size_t {
     (HUF_CTABLEBOUND as size_t).wrapping_add(
         size.wrapping_add(size >> 8 as std::ffi::c_int)
@@ -1486,7 +1486,7 @@ unsafe extern "C" fn HUF_compress1X_usingCTable_internal(
     }
     HUF_compress1X_usingCTable_internal_default(dst, dstSize, src, srcSize, CTable)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUF_compress1X_usingCTable)]
 pub unsafe extern "C" fn HUF_compress1X_usingCTable(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -1599,7 +1599,7 @@ unsafe extern "C" fn HUF_compress4X_usingCTable_internal(
     op = op.offset(cSize_2 as isize);
     op.offset_from(ostart) as std::ffi::c_long as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUF_compress4X_usingCTable)]
 pub unsafe extern "C" fn HUF_compress4X_usingCTable(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -1657,7 +1657,7 @@ unsafe extern "C" fn HUF_compressCTable_internal(
 }
 pub const SUSPECT_INCOMPRESSIBLE_SAMPLE_SIZE: std::ffi::c_int = 4096 as std::ffi::c_int;
 pub const SUSPECT_INCOMPRESSIBLE_SAMPLE_RATIO: std::ffi::c_int = 10 as std::ffi::c_int;
-#[no_mangle]
+#[export_name = crate::prefix!(HUF_cardinality)]
 pub unsafe extern "C" fn HUF_cardinality(
     mut count: *const std::ffi::c_uint,
     mut maxSymbolValue: std::ffi::c_uint,
@@ -1674,13 +1674,13 @@ pub unsafe extern "C" fn HUF_cardinality(
     }
     cardinality
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUF_minTableLog)]
 pub unsafe extern "C" fn HUF_minTableLog(
     mut symbolCardinality: std::ffi::c_uint,
 ) -> std::ffi::c_uint {
     (ZSTD_highbit32(symbolCardinality)).wrapping_add(1 as std::ffi::c_int as std::ffi::c_uint)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUF_optimalTableLog)]
 pub unsafe extern "C" fn HUF_optimalTableLog(
     mut maxTableLog: std::ffi::c_uint,
     mut srcSize: size_t,
@@ -1974,7 +1974,7 @@ unsafe extern "C" fn HUF_compress_internal(
         flags,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUF_compress1X_repeat)]
 pub unsafe extern "C" fn HUF_compress1X_repeat(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -2003,7 +2003,7 @@ pub unsafe extern "C" fn HUF_compress1X_repeat(
         flags,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUF_compress4X_repeat)]
 pub unsafe extern "C" fn HUF_compress4X_repeat(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,

--- a/lib/compress/zstd_compress.rs
+++ b/lib/compress/zstd_compress.rs
@@ -3069,7 +3069,7 @@ pub const ZSTD_COMPRESSBLOCK_BTULTRA2: unsafe extern "C" fn(
 pub const ZSTD_LDM_DEFAULT_WINDOW_LOG: std::ffi::c_int = 27 as std::ffi::c_int;
 pub const INT_MAX: std::ffi::c_int = __INT_MAX__;
 pub const NULL: std::ffi::c_int = 0 as std::ffi::c_int;
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBound)]
 pub unsafe extern "C" fn ZSTD_compressBound(mut srcSize: size_t) -> size_t {
     let r = if srcSize as std::ffi::c_ulonglong
         >= (if ::core::mem::size_of::<size_t>() as std::ffi::c_ulong
@@ -3098,7 +3098,7 @@ pub unsafe extern "C" fn ZSTD_compressBound(mut srcSize: size_t) -> size_t {
     }
     r
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_createCCtx)]
 pub unsafe extern "C" fn ZSTD_createCCtx() -> *mut ZSTD_CCtx {
     ZSTD_createCCtx_advanced(ZSTD_defaultCMem)
 }
@@ -3112,7 +3112,7 @@ unsafe extern "C" fn ZSTD_initCCtx(mut cctx: *mut ZSTD_CCtx, mut memManager: ZST
     (*cctx).bmi2 = ZSTD_cpuSupportsBmi2();
     let err = ZSTD_CCtx_reset(cctx, ZSTD_reset_parameters);
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_createCCtx_advanced)]
 pub unsafe extern "C" fn ZSTD_createCCtx_advanced(mut customMem: ZSTD_customMem) -> *mut ZSTD_CCtx {
     if (customMem.customAlloc).is_none() as std::ffi::c_int
         ^ (customMem.customFree).is_none() as std::ffi::c_int
@@ -3130,7 +3130,7 @@ pub unsafe extern "C" fn ZSTD_createCCtx_advanced(mut customMem: ZSTD_customMem)
     ZSTD_initCCtx(cctx, customMem);
     cctx
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_initStaticCCtx)]
 pub unsafe extern "C" fn ZSTD_initStaticCCtx(
     mut workspace: *mut std::ffi::c_void,
     mut workspaceSize: size_t,
@@ -3304,7 +3304,7 @@ unsafe extern "C" fn ZSTD_freeCCtxContent(mut cctx: *mut ZSTD_CCtx) {
     (*cctx).mtctx = NULL as *mut ZSTDMT_CCtx;
     ZSTD_cwksp_free(&mut (*cctx).workspace, (*cctx).customMem);
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_freeCCtx)]
 pub unsafe extern "C" fn ZSTD_freeCCtx(mut cctx: *mut ZSTD_CCtx) -> size_t {
     if cctx.is_null() {
         return 0 as std::ffi::c_int as size_t;
@@ -3323,7 +3323,7 @@ pub unsafe extern "C" fn ZSTD_freeCCtx(mut cctx: *mut ZSTD_CCtx) -> size_t {
 unsafe extern "C" fn ZSTD_sizeof_mtctx(mut cctx: *const ZSTD_CCtx) -> size_t {
     ZSTDMT_sizeof_CCtx((*cctx).mtctx)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_sizeof_CCtx)]
 pub unsafe extern "C" fn ZSTD_sizeof_CCtx(mut cctx: *const ZSTD_CCtx) -> size_t {
     if cctx.is_null() {
         return 0 as std::ffi::c_int as size_t;
@@ -3337,11 +3337,11 @@ pub unsafe extern "C" fn ZSTD_sizeof_CCtx(mut cctx: *const ZSTD_CCtx) -> size_t 
     .wrapping_add(ZSTD_sizeof_localDict((*cctx).localDict))
     .wrapping_add(ZSTD_sizeof_mtctx(cctx))
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_sizeof_CStream)]
 pub unsafe extern "C" fn ZSTD_sizeof_CStream(mut zcs: *const ZSTD_CStream) -> size_t {
     ZSTD_sizeof_CCtx(zcs)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_getSeqStore)]
 pub unsafe extern "C" fn ZSTD_getSeqStore(mut ctx: *const ZSTD_CCtx) -> *const SeqStore_t {
     &(*ctx).seqStore
 }
@@ -3547,11 +3547,11 @@ unsafe extern "C" fn ZSTD_createCCtxParams_advanced(
     (*params).customMem = customMem;
     params
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_createCCtxParams)]
 pub unsafe extern "C" fn ZSTD_createCCtxParams() -> *mut ZSTD_CCtx_params {
     ZSTD_createCCtxParams_advanced(ZSTD_defaultCMem)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_freeCCtxParams)]
 pub unsafe extern "C" fn ZSTD_freeCCtxParams(mut params: *mut ZSTD_CCtx_params) -> size_t {
     if params.is_null() {
         return 0 as std::ffi::c_int as size_t;
@@ -3559,11 +3559,11 @@ pub unsafe extern "C" fn ZSTD_freeCCtxParams(mut params: *mut ZSTD_CCtx_params) 
     ZSTD_customFree(params as *mut std::ffi::c_void, (*params).customMem);
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_CCtxParams_reset)]
 pub unsafe extern "C" fn ZSTD_CCtxParams_reset(mut params: *mut ZSTD_CCtx_params) -> size_t {
     ZSTD_CCtxParams_init(params, ZSTD_CLEVEL_DEFAULT)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_CCtxParams_init)]
 pub unsafe extern "C" fn ZSTD_CCtxParams_init(
     mut cctxParams: *mut ZSTD_CCtx_params,
     mut compressionLevel: std::ffi::c_int,
@@ -3608,7 +3608,7 @@ unsafe extern "C" fn ZSTD_CCtxParams_init_internal(
         compressionLevel,
     );
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_CCtxParams_init_advanced)]
 pub unsafe extern "C" fn ZSTD_CCtxParams_init_advanced(
     mut cctxParams: *mut ZSTD_CCtx_params,
     mut params: ZSTD_parameters,
@@ -3631,7 +3631,7 @@ unsafe extern "C" fn ZSTD_CCtxParams_setZstdParams(
     (*cctxParams).fParams = (*params).fParams;
     (*cctxParams).compressionLevel = ZSTD_NO_CLEVEL;
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_cParam_getBounds)]
 pub unsafe extern "C" fn ZSTD_cParam_getBounds(mut param: ZSTD_cParameter) -> ZSTD_bounds {
     let mut bounds = {
         ZSTD_bounds {
@@ -3930,7 +3930,7 @@ unsafe extern "C" fn ZSTD_isUpdateAuthorized(mut param: ZSTD_cParameter) -> std:
         | 1013 | 1014 | 1015 | 1016 | _ => 0 as std::ffi::c_int,
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_CCtx_setParameter)]
 pub unsafe extern "C" fn ZSTD_CCtx_setParameter(
     mut cctx: *mut ZSTD_CCtx,
     mut param: ZSTD_cParameter,
@@ -3956,7 +3956,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_setParameter(
     }
     ZSTD_CCtxParams_setParameter(&mut (*cctx).requestedParams, param, value)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_CCtxParams_setParameter)]
 pub unsafe extern "C" fn ZSTD_CCtxParams_setParameter(
     mut CCtxParams: *mut ZSTD_CCtx_params,
     mut param: ZSTD_cParameter,
@@ -4273,7 +4273,7 @@ pub unsafe extern "C" fn ZSTD_CCtxParams_setParameter(
         _ => -(ZSTD_error_parameter_unsupported as std::ffi::c_int) as size_t,
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_CCtx_getParameter)]
 pub unsafe extern "C" fn ZSTD_CCtx_getParameter(
     mut cctx: *const ZSTD_CCtx,
     mut param: ZSTD_cParameter,
@@ -4281,7 +4281,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_getParameter(
 ) -> size_t {
     ZSTD_CCtxParams_getParameter(&(*cctx).requestedParams, param, value)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_CCtxParams_getParameter)]
 pub unsafe extern "C" fn ZSTD_CCtxParams_getParameter(
     mut CCtxParams: *const ZSTD_CCtx_params,
     mut param: ZSTD_cParameter,
@@ -4409,7 +4409,7 @@ pub unsafe extern "C" fn ZSTD_CCtxParams_getParameter(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_CCtx_setParametersUsingCCtxParams)]
 pub unsafe extern "C" fn ZSTD_CCtx_setParametersUsingCCtxParams(
     mut cctx: *mut ZSTD_CCtx,
     mut params: *const ZSTD_CCtx_params,
@@ -4423,7 +4423,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_setParametersUsingCCtxParams(
     (*cctx).requestedParams = *params;
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_CCtx_setCParams)]
 pub unsafe extern "C" fn ZSTD_CCtx_setCParams(
     mut cctx: *mut ZSTD_CCtx,
     mut cparams: ZSTD_compressionParameters,
@@ -4472,7 +4472,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_setCParams(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_CCtx_setFParams)]
 pub unsafe extern "C" fn ZSTD_CCtx_setFParams(
     mut cctx: *mut ZSTD_CCtx,
     mut fparams: ZSTD_frameParameters,
@@ -4503,7 +4503,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_setFParams(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_CCtx_setParams)]
 pub unsafe extern "C" fn ZSTD_CCtx_setParams(
     mut cctx: *mut ZSTD_CCtx,
     mut params: ZSTD_parameters,
@@ -4522,7 +4522,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_setParams(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_CCtx_setPledgedSrcSize)]
 pub unsafe extern "C" fn ZSTD_CCtx_setPledgedSrcSize(
     mut cctx: *mut ZSTD_CCtx,
     mut pledgedSrcSize: std::ffi::c_ulonglong,
@@ -4556,7 +4556,7 @@ unsafe extern "C" fn ZSTD_initLocalDict(mut cctx: *mut ZSTD_CCtx) -> size_t {
     (*cctx).cdict = (*dl).cdict;
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_CCtx_loadDictionary_advanced)]
 pub unsafe extern "C" fn ZSTD_CCtx_loadDictionary_advanced(
     mut cctx: *mut ZSTD_CCtx,
     mut dict: *const std::ffi::c_void,
@@ -4590,7 +4590,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_loadDictionary_advanced(
     (*cctx).localDict.dictContentType = dictContentType;
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_CCtx_loadDictionary_byReference)]
 pub unsafe extern "C" fn ZSTD_CCtx_loadDictionary_byReference(
     mut cctx: *mut ZSTD_CCtx,
     mut dict: *const std::ffi::c_void,
@@ -4598,7 +4598,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_loadDictionary_byReference(
 ) -> size_t {
     ZSTD_CCtx_loadDictionary_advanced(cctx, dict, dictSize, ZSTD_dlm_byRef, ZSTD_dct_auto)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_CCtx_loadDictionary)]
 pub unsafe extern "C" fn ZSTD_CCtx_loadDictionary(
     mut cctx: *mut ZSTD_CCtx,
     mut dict: *const std::ffi::c_void,
@@ -4606,7 +4606,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_loadDictionary(
 ) -> size_t {
     ZSTD_CCtx_loadDictionary_advanced(cctx, dict, dictSize, ZSTD_dlm_byCopy, ZSTD_dct_auto)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_CCtx_refCDict)]
 pub unsafe extern "C" fn ZSTD_CCtx_refCDict(
     mut cctx: *mut ZSTD_CCtx,
     mut cdict: *const ZSTD_CDict,
@@ -4618,7 +4618,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_refCDict(
     (*cctx).cdict = cdict;
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_CCtx_refThreadPool)]
 pub unsafe extern "C" fn ZSTD_CCtx_refThreadPool(
     mut cctx: *mut ZSTD_CCtx,
     mut pool: *mut ZSTD_threadPool,
@@ -4629,7 +4629,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_refThreadPool(
     (*cctx).pool = pool;
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_CCtx_refPrefix)]
 pub unsafe extern "C" fn ZSTD_CCtx_refPrefix(
     mut cctx: *mut ZSTD_CCtx,
     mut prefix: *const std::ffi::c_void,
@@ -4637,7 +4637,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_refPrefix(
 ) -> size_t {
     ZSTD_CCtx_refPrefix_advanced(cctx, prefix, prefixSize, ZSTD_dct_rawContent)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_CCtx_refPrefix_advanced)]
 pub unsafe extern "C" fn ZSTD_CCtx_refPrefix_advanced(
     mut cctx: *mut ZSTD_CCtx,
     mut prefix: *const std::ffi::c_void,
@@ -4655,7 +4655,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_refPrefix_advanced(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_CCtx_reset)]
 pub unsafe extern "C" fn ZSTD_CCtx_reset(
     mut cctx: *mut ZSTD_CCtx,
     mut reset: ZSTD_ResetDirective,
@@ -4681,7 +4681,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_reset(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_checkCParams)]
 pub unsafe extern "C" fn ZSTD_checkCParams(mut cParams: ZSTD_compressionParameters) -> size_t {
     if ZSTD_cParam_withinBounds(ZSTD_c_windowLog, cParams.windowLog as std::ffi::c_int) == 0 {
         return -(ZSTD_error_parameter_outOfBound as std::ffi::c_int) as size_t;
@@ -4753,7 +4753,7 @@ unsafe extern "C" fn ZSTD_clampCParams(
     }
     cParams
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_cycleLog)]
 pub unsafe extern "C" fn ZSTD_cycleLog(mut hashLog: u32, mut strat: ZSTD_strategy) -> u32 {
     let btScale =
         (strat as u32 >= ZSTD_btlazy2 as std::ffi::c_int as u32) as std::ffi::c_int as u32;
@@ -4881,7 +4881,7 @@ unsafe extern "C" fn ZSTD_adjustCParams_internal(
     }
     cPar
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_adjustCParams)]
 pub unsafe extern "C" fn ZSTD_adjustCParams(
     mut cPar: ZSTD_compressionParameters,
     mut srcSize: std::ffi::c_ulonglong,
@@ -4919,7 +4919,7 @@ unsafe extern "C" fn ZSTD_overrideCParams(
         (*cParams).strategy = (*overrides).strategy;
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_getCParamsFromCCtxParams)]
 pub unsafe extern "C" fn ZSTD_getCParamsFromCCtxParams(
     mut CCtxParams: *const ZSTD_CCtx_params,
     mut srcSizeHint: u64,
@@ -5174,7 +5174,7 @@ unsafe extern "C" fn ZSTD_estimateCCtxSize_usingCCtxParams_internal(
         .wrapping_add(bufferSpace)
         .wrapping_add(externalSeqSpace)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_estimateCCtxSize_usingCCtxParams)]
 pub unsafe extern "C" fn ZSTD_estimateCCtxSize_usingCCtxParams(
     mut params: *const ZSTD_CCtx_params,
 ) -> size_t {
@@ -5200,7 +5200,7 @@ pub unsafe extern "C" fn ZSTD_estimateCCtxSize_usingCCtxParams(
         (*params).maxBlockSize,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_estimateCCtxSize_usingCParams)]
 pub unsafe extern "C" fn ZSTD_estimateCCtxSize_usingCParams(
     mut cParams: ZSTD_compressionParameters,
 ) -> size_t {
@@ -5244,7 +5244,7 @@ unsafe extern "C" fn ZSTD_estimateCCtxSize_internal(
     }
     largestSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_estimateCCtxSize)]
 pub unsafe extern "C" fn ZSTD_estimateCCtxSize(mut compressionLevel: std::ffi::c_int) -> size_t {
     let mut level: std::ffi::c_int = 0;
     let mut memBudget = 0 as std::ffi::c_int as size_t;
@@ -5263,7 +5263,7 @@ pub unsafe extern "C" fn ZSTD_estimateCCtxSize(mut compressionLevel: std::ffi::c
     }
     memBudget
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_estimateCStreamSize_usingCCtxParams)]
 pub unsafe extern "C" fn ZSTD_estimateCStreamSize_usingCCtxParams(
     mut params: *const ZSTD_CCtx_params,
 ) -> size_t {
@@ -5311,7 +5311,7 @@ pub unsafe extern "C" fn ZSTD_estimateCStreamSize_usingCCtxParams(
         (*params).maxBlockSize,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_estimateCStreamSize_usingCParams)]
 pub unsafe extern "C" fn ZSTD_estimateCStreamSize_usingCParams(
     mut cParams: ZSTD_compressionParameters,
 ) -> size_t {
@@ -5343,7 +5343,7 @@ unsafe extern "C" fn ZSTD_estimateCStreamSize_internal(
     );
     ZSTD_estimateCStreamSize_usingCParams(cParams)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_estimateCStreamSize)]
 pub unsafe extern "C" fn ZSTD_estimateCStreamSize(mut compressionLevel: std::ffi::c_int) -> size_t {
     let mut level: std::ffi::c_int = 0;
     let mut memBudget = 0 as std::ffi::c_int as size_t;
@@ -5362,7 +5362,7 @@ pub unsafe extern "C" fn ZSTD_estimateCStreamSize(mut compressionLevel: std::ffi
     }
     memBudget
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_getFrameProgression)]
 pub unsafe extern "C" fn ZSTD_getFrameProgression(
     mut cctx: *const ZSTD_CCtx,
 ) -> ZSTD_frameProgression {
@@ -5391,7 +5391,7 @@ pub unsafe extern "C" fn ZSTD_getFrameProgression(
     fp.nbActiveWorkers = 0 as std::ffi::c_int as std::ffi::c_uint;
     fp
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_toFlushNow)]
 pub unsafe extern "C" fn ZSTD_toFlushNow(mut cctx: *mut ZSTD_CCtx) -> size_t {
     if (*cctx).appliedParams.nbWorkers > 0 as std::ffi::c_int {
         return ZSTDMT_toFlushNow((*cctx).mtctx);
@@ -5403,7 +5403,7 @@ unsafe extern "C" fn ZSTD_assertEqualCParams(
     mut cParams2: ZSTD_compressionParameters,
 ) {
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_reset_compressedBlockState)]
 pub unsafe extern "C" fn ZSTD_reset_compressedBlockState(mut bs: *mut ZSTD_compressedBlockState_t) {
     let mut i: std::ffi::c_int = 0;
     i = 0 as std::ffi::c_int;
@@ -5874,7 +5874,7 @@ unsafe extern "C" fn ZSTD_resetCCtx_internal(
     (*zc).initialized = 1 as std::ffi::c_int;
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_invalidateRepCodes)]
 pub unsafe extern "C" fn ZSTD_invalidateRepCodes(mut cctx: *mut ZSTD_CCtx) {
     let mut i: std::ffi::c_int = 0;
     i = 0 as std::ffi::c_int;
@@ -6175,7 +6175,7 @@ unsafe extern "C" fn ZSTD_copyCCtx_internal(
     );
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_copyCCtx)]
 pub unsafe extern "C" fn ZSTD_copyCCtx(
     mut dstCCtx: *mut ZSTD_CCtx,
     mut srcCCtx: *const ZSTD_CCtx,
@@ -6264,7 +6264,7 @@ unsafe extern "C" fn ZSTD_reduceIndex(
         ZSTD_reduceTable((*ms).hashTable3, h3Size, reducerValue);
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_seqToCodes)]
 pub unsafe extern "C" fn ZSTD_seqToCodes(mut seqStorePtr: *const SeqStore_t) -> std::ffi::c_int {
     let sequences: *const SeqDef = (*seqStorePtr).sequencesStart;
     let llCodeTable = (*seqStorePtr).llCode;
@@ -6728,7 +6728,7 @@ unsafe extern "C" fn ZSTD_entropyCompressSeqStore(
         bmi2,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_selectBlockCompressor)]
 pub unsafe extern "C" fn ZSTD_selectBlockCompressor(
     mut strat: ZSTD_strategy,
     mut useRowMatchFinder: ZSTD_ParamSwitch_e,
@@ -6906,7 +6906,7 @@ unsafe extern "C" fn ZSTD_storeLastLiterals(
     );
     (*seqStorePtr).lit = ((*seqStorePtr).lit).offset(lastLLSize as isize);
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_resetSeqStore)]
 pub unsafe extern "C" fn ZSTD_resetSeqStore(mut ssPtr: *mut SeqStore_t) {
     (*ssPtr).lit = (*ssPtr).litStart;
     (*ssPtr).sequences = (*ssPtr).sequencesStart;
@@ -7248,7 +7248,7 @@ unsafe extern "C" fn ZSTD_copyBlockSequences(
     (*seqCollector).seqIndex = ((*seqCollector).seqIndex).wrapping_add(nbOutSequences);
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_sequenceBound)]
 pub unsafe extern "C" fn ZSTD_sequenceBound(mut srcSize: size_t) -> size_t {
     let maxNbSeq =
         (srcSize / ZSTD_MINMATCH_MIN as size_t).wrapping_add(1 as std::ffi::c_int as size_t);
@@ -7256,7 +7256,7 @@ pub unsafe extern "C" fn ZSTD_sequenceBound(mut srcSize: size_t) -> size_t {
         (srcSize / ZSTD_BLOCKSIZE_MAX_MIN as size_t).wrapping_add(1 as std::ffi::c_int as size_t);
     maxNbSeq.wrapping_add(maxNbDelims)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_generateSequences)]
 pub unsafe extern "C" fn ZSTD_generateSequences(
     mut zc: *mut ZSTD_CCtx,
     mut outSeqs: *mut ZSTD_Sequence,
@@ -7305,7 +7305,7 @@ pub unsafe extern "C" fn ZSTD_generateSequences(
     }
     (*zc).seqCollector.seqIndex
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_mergeBlockDelimiters)]
 pub unsafe extern "C" fn ZSTD_mergeBlockDelimiters(
     mut sequences: *mut ZSTD_Sequence,
     mut seqsSize: size_t,
@@ -7619,7 +7619,7 @@ unsafe extern "C" fn ZSTD_buildBlockEntropyStats_sequences(
     (*fseMetadata).lastCountSize = stats.lastCountSize;
     stats.size
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_buildBlockEntropyStats)]
 pub unsafe extern "C" fn ZSTD_buildBlockEntropyStats(
     mut seqStorePtr: *const SeqStore_t,
     mut prevEntropy: *const ZSTD_entropyCTables_t,
@@ -8864,7 +8864,7 @@ unsafe extern "C" fn ZSTD_writeFrameHeader(
     }
     pos
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_writeSkippableFrame)]
 pub unsafe extern "C" fn ZSTD_writeSkippableFrame(
     mut dst: *mut std::ffi::c_void,
     mut dstCapacity: size_t,
@@ -8897,7 +8897,7 @@ pub unsafe extern "C" fn ZSTD_writeSkippableFrame(
     );
     srcSize.wrapping_add(ZSTD_SKIPPABLEHEADERSIZE as size_t)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_writeLastEmptyBlock)]
 pub unsafe extern "C" fn ZSTD_writeLastEmptyBlock(
     mut dst: *mut std::ffi::c_void,
     mut dstCapacity: size_t,
@@ -8910,7 +8910,7 @@ pub unsafe extern "C" fn ZSTD_writeLastEmptyBlock(
     MEM_writeLE24(dst, cBlockHeader24);
     ZSTD_blockHeaderSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_referenceExternalSequences)]
 pub unsafe extern "C" fn ZSTD_referenceExternalSequences(
     mut cctx: *mut ZSTD_CCtx,
     mut seq: *mut rawSeq,
@@ -9009,7 +9009,7 @@ unsafe extern "C" fn ZSTD_compressContinue_internal(
     }
     cSize.wrapping_add(fhSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressContinue_public)]
 pub unsafe extern "C" fn ZSTD_compressContinue_public(
     mut cctx: *mut ZSTD_CCtx,
     mut dst: *mut std::ffi::c_void,
@@ -9027,7 +9027,7 @@ pub unsafe extern "C" fn ZSTD_compressContinue_public(
         0 as std::ffi::c_int as u32,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressContinue)]
 pub unsafe extern "C" fn ZSTD_compressContinue(
     mut cctx: *mut ZSTD_CCtx,
     mut dst: *mut std::ffi::c_void,
@@ -9045,11 +9045,11 @@ unsafe extern "C" fn ZSTD_getBlockSize_deprecated(mut cctx: *const ZSTD_CCtx) ->
         (1 as std::ffi::c_int as size_t) << cParams.windowLog
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_getBlockSize)]
 pub unsafe extern "C" fn ZSTD_getBlockSize(mut cctx: *const ZSTD_CCtx) -> size_t {
     ZSTD_getBlockSize_deprecated(cctx)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_deprecated)]
 pub unsafe extern "C" fn ZSTD_compressBlock_deprecated(
     mut cctx: *mut ZSTD_CCtx,
     mut dst: *mut std::ffi::c_void,
@@ -9071,7 +9071,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_deprecated(
         0 as std::ffi::c_int as u32,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock)]
 pub unsafe extern "C" fn ZSTD_compressBlock(
     mut cctx: *mut ZSTD_CCtx,
     mut dst: *mut std::ffi::c_void,
@@ -9241,7 +9241,7 @@ unsafe extern "C" fn ZSTD_dictNCountRepeat(
     }
     FSE_repeat_valid
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_loadCEntropy)]
 pub unsafe extern "C" fn ZSTD_loadCEntropy(
     mut bs: *mut ZSTD_compressedBlockState_t,
     mut workspace: *mut std::ffi::c_void,
@@ -9586,7 +9586,7 @@ unsafe extern "C" fn ZSTD_compressBegin_internal(
     (*cctx).dictContentSize = dictContentSize;
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBegin_advanced_internal)]
 pub unsafe extern "C" fn ZSTD_compressBegin_advanced_internal(
     mut cctx: *mut ZSTD_CCtx,
     mut dict: *const std::ffi::c_void,
@@ -9613,7 +9613,7 @@ pub unsafe extern "C" fn ZSTD_compressBegin_advanced_internal(
         ZSTDb_not_buffered,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBegin_advanced)]
 pub unsafe extern "C" fn ZSTD_compressBegin_advanced(
     mut cctx: *mut ZSTD_CCtx,
     mut dict: *const std::ffi::c_void,
@@ -9776,7 +9776,7 @@ unsafe extern "C" fn ZSTD_compressBegin_usingDict_deprecated(
         ZSTDb_not_buffered,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBegin_usingDict)]
 pub unsafe extern "C" fn ZSTD_compressBegin_usingDict(
     mut cctx: *mut ZSTD_CCtx,
     mut dict: *const std::ffi::c_void,
@@ -9785,7 +9785,7 @@ pub unsafe extern "C" fn ZSTD_compressBegin_usingDict(
 ) -> size_t {
     ZSTD_compressBegin_usingDict_deprecated(cctx, dict, dictSize, compressionLevel)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBegin)]
 pub unsafe extern "C" fn ZSTD_compressBegin(
     mut cctx: *mut ZSTD_CCtx,
     mut compressionLevel: std::ffi::c_int,
@@ -9845,7 +9845,7 @@ unsafe extern "C" fn ZSTD_writeEpilogue(
     (*cctx).stage = ZSTDcs_created;
     op.offset_from(ostart) as std::ffi::c_long as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_CCtx_trace)]
 pub unsafe extern "C" fn ZSTD_CCtx_trace(mut cctx: *mut ZSTD_CCtx, mut extraCSize: size_t) {
     if (*cctx).traceCtx != 0
         && (Some(
@@ -9887,7 +9887,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_trace(mut cctx: *mut ZSTD_CCtx, mut extraCSiz
     }
     (*cctx).traceCtx = 0 as std::ffi::c_int as ZSTD_TraceCtx;
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressEnd_public)]
 pub unsafe extern "C" fn ZSTD_compressEnd_public(
     mut cctx: *mut ZSTD_CCtx,
     mut dst: *mut std::ffi::c_void,
@@ -9927,7 +9927,7 @@ pub unsafe extern "C" fn ZSTD_compressEnd_public(
     ZSTD_CCtx_trace(cctx, endResult);
     cSize.wrapping_add(endResult)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressEnd)]
 pub unsafe extern "C" fn ZSTD_compressEnd(
     mut cctx: *mut ZSTD_CCtx,
     mut dst: *mut std::ffi::c_void,
@@ -9937,7 +9937,7 @@ pub unsafe extern "C" fn ZSTD_compressEnd(
 ) -> size_t {
     ZSTD_compressEnd_public(cctx, dst, dstCapacity, src, srcSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compress_advanced)]
 pub unsafe extern "C" fn ZSTD_compress_advanced(
     mut cctx: *mut ZSTD_CCtx,
     mut dst: *mut std::ffi::c_void,
@@ -9964,7 +9964,7 @@ pub unsafe extern "C" fn ZSTD_compress_advanced(
         &mut (*cctx).simpleApiParams,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compress_advanced_internal)]
 pub unsafe extern "C" fn ZSTD_compress_advanced_internal(
     mut cctx: *mut ZSTD_CCtx,
     mut dst: *mut std::ffi::c_void,
@@ -9991,7 +9991,7 @@ pub unsafe extern "C" fn ZSTD_compress_advanced_internal(
     }
     ZSTD_compressEnd_public(cctx, dst, dstCapacity, src, srcSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compress_usingDict)]
 pub unsafe extern "C" fn ZSTD_compress_usingDict(
     mut cctx: *mut ZSTD_CCtx,
     mut dst: *mut std::ffi::c_void,
@@ -10032,7 +10032,7 @@ pub unsafe extern "C" fn ZSTD_compress_usingDict(
         &mut (*cctx).simpleApiParams,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressCCtx)]
 pub unsafe extern "C" fn ZSTD_compressCCtx(
     mut cctx: *mut ZSTD_CCtx,
     mut dst: *mut std::ffi::c_void,
@@ -10052,7 +10052,7 @@ pub unsafe extern "C" fn ZSTD_compressCCtx(
         compressionLevel,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compress)]
 pub unsafe extern "C" fn ZSTD_compress(
     mut dst: *mut std::ffi::c_void,
     mut dstCapacity: size_t,
@@ -10507,7 +10507,7 @@ pub unsafe extern "C" fn ZSTD_compress(
     ZSTD_freeCCtxContent(&mut ctxBody);
     result
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_estimateCDictSize_advanced)]
 pub unsafe extern "C" fn ZSTD_estimateCDictSize_advanced(
     mut dictSize: size_t,
     mut cParams: ZSTD_compressionParameters,
@@ -10534,7 +10534,7 @@ pub unsafe extern "C" fn ZSTD_estimateCDictSize_advanced(
             },
         )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_estimateCDictSize)]
 pub unsafe extern "C" fn ZSTD_estimateCDictSize(
     mut dictSize: size_t,
     mut compressionLevel: std::ffi::c_int,
@@ -10547,7 +10547,7 @@ pub unsafe extern "C" fn ZSTD_estimateCDictSize(
     );
     ZSTD_estimateCDictSize_advanced(dictSize, cParams, ZSTD_dlm_byCopy)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_sizeof_CDict)]
 pub unsafe extern "C" fn ZSTD_sizeof_CDict(mut cdict: *const ZSTD_CDict) -> size_t {
     if cdict.is_null() {
         return 0 as std::ffi::c_int as size_t;
@@ -10693,7 +10693,7 @@ unsafe extern "C" fn ZSTD_createCDict_advanced_internal(
     (*cdict).useRowMatchFinder = useRowMatchFinder;
     cdict
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_createCDict_advanced)]
 pub unsafe extern "C" fn ZSTD_createCDict_advanced(
     mut dictBuffer: *const std::ffi::c_void,
     mut dictSize: size_t,
@@ -10774,7 +10774,7 @@ pub unsafe extern "C" fn ZSTD_createCDict_advanced(
         customMem,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_createCDict_advanced2)]
 pub unsafe extern "C" fn ZSTD_createCDict_advanced2(
     mut dict: *const std::ffi::c_void,
     mut dictSize: size_t,
@@ -10846,7 +10846,7 @@ pub unsafe extern "C" fn ZSTD_createCDict_advanced2(
     }
     cdict
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_createCDict)]
 pub unsafe extern "C" fn ZSTD_createCDict(
     mut dict: *const std::ffi::c_void,
     mut dictSize: size_t,
@@ -10875,7 +10875,7 @@ pub unsafe extern "C" fn ZSTD_createCDict(
     }
     cdict
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_createCDict_byReference)]
 pub unsafe extern "C" fn ZSTD_createCDict_byReference(
     mut dict: *const std::ffi::c_void,
     mut dictSize: size_t,
@@ -10904,7 +10904,7 @@ pub unsafe extern "C" fn ZSTD_createCDict_byReference(
     }
     cdict
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_freeCDict)]
 pub unsafe extern "C" fn ZSTD_freeCDict(mut cdict: *mut ZSTD_CDict) -> size_t {
     if cdict.is_null() {
         return 0 as std::ffi::c_int as size_t;
@@ -10918,7 +10918,7 @@ pub unsafe extern "C" fn ZSTD_freeCDict(mut cdict: *mut ZSTD_CDict) -> size_t {
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_initStaticCDict)]
 pub unsafe extern "C" fn ZSTD_initStaticCDict(
     mut workspace: *mut std::ffi::c_void,
     mut workspaceSize: size_t,
@@ -11053,13 +11053,13 @@ pub unsafe extern "C" fn ZSTD_initStaticCDict(
     }
     cdict
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_getCParamsFromCDict)]
 pub unsafe extern "C" fn ZSTD_getCParamsFromCDict(
     mut cdict: *const ZSTD_CDict,
 ) -> ZSTD_compressionParameters {
     (*cdict).matchState.cParams
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_getDictID_fromCDict)]
 pub unsafe extern "C" fn ZSTD_getDictID_fromCDict(
     mut cdict: *const ZSTD_CDict,
 ) -> std::ffi::c_uint {
@@ -11198,7 +11198,7 @@ unsafe extern "C" fn ZSTD_compressBegin_usingCDict_internal(
         ZSTDb_not_buffered,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBegin_usingCDict_advanced)]
 pub unsafe extern "C" fn ZSTD_compressBegin_usingCDict_advanced(
     cctx: *mut ZSTD_CCtx,
     cdict: *const ZSTD_CDict,
@@ -11207,7 +11207,7 @@ pub unsafe extern "C" fn ZSTD_compressBegin_usingCDict_advanced(
 ) -> size_t {
     ZSTD_compressBegin_usingCDict_internal(cctx, cdict, fParams, pledgedSrcSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBegin_usingCDict_deprecated)]
 pub unsafe extern "C" fn ZSTD_compressBegin_usingCDict_deprecated(
     mut cctx: *mut ZSTD_CCtx,
     mut cdict: *const ZSTD_CDict,
@@ -11221,7 +11221,7 @@ pub unsafe extern "C" fn ZSTD_compressBegin_usingCDict_deprecated(
     };
     ZSTD_compressBegin_usingCDict_internal(cctx, cdict, fParams, ZSTD_CONTENTSIZE_UNKNOWN)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBegin_usingCDict)]
 pub unsafe extern "C" fn ZSTD_compressBegin_usingCDict(
     mut cctx: *mut ZSTD_CCtx,
     mut cdict: *const ZSTD_CDict,
@@ -11248,7 +11248,7 @@ unsafe extern "C" fn ZSTD_compress_usingCDict_internal(
     }
     ZSTD_compressEnd_public(cctx, dst, dstCapacity, src, srcSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compress_usingCDict_advanced)]
 pub unsafe extern "C" fn ZSTD_compress_usingCDict_advanced(
     mut cctx: *mut ZSTD_CCtx,
     mut dst: *mut std::ffi::c_void,
@@ -11260,7 +11260,7 @@ pub unsafe extern "C" fn ZSTD_compress_usingCDict_advanced(
 ) -> size_t {
     ZSTD_compress_usingCDict_internal(cctx, dst, dstCapacity, src, srcSize, cdict, fParams)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compress_usingCDict)]
 pub unsafe extern "C" fn ZSTD_compress_usingCDict(
     mut cctx: *mut ZSTD_CCtx,
     mut dst: *mut std::ffi::c_void,
@@ -11278,32 +11278,32 @@ pub unsafe extern "C" fn ZSTD_compress_usingCDict(
     };
     ZSTD_compress_usingCDict_internal(cctx, dst, dstCapacity, src, srcSize, cdict, fParams)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_createCStream)]
 pub unsafe extern "C" fn ZSTD_createCStream() -> *mut ZSTD_CStream {
     ZSTD_createCStream_advanced(ZSTD_defaultCMem)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_initStaticCStream)]
 pub unsafe extern "C" fn ZSTD_initStaticCStream(
     mut workspace: *mut std::ffi::c_void,
     mut workspaceSize: size_t,
 ) -> *mut ZSTD_CStream {
     ZSTD_initStaticCCtx(workspace, workspaceSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_createCStream_advanced)]
 pub unsafe extern "C" fn ZSTD_createCStream_advanced(
     mut customMem: ZSTD_customMem,
 ) -> *mut ZSTD_CStream {
     ZSTD_createCCtx_advanced(customMem)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_freeCStream)]
 pub unsafe extern "C" fn ZSTD_freeCStream(mut zcs: *mut ZSTD_CStream) -> size_t {
     ZSTD_freeCCtx(zcs)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_CStreamInSize)]
 pub unsafe extern "C" fn ZSTD_CStreamInSize() -> size_t {
     ZSTD_BLOCKSIZE_MAX as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_CStreamOutSize)]
 pub unsafe extern "C" fn ZSTD_CStreamOutSize() -> size_t {
     (ZSTD_compressBound(ZSTD_BLOCKSIZE_MAX as size_t))
         .wrapping_add(ZSTD_blockHeaderSize)
@@ -11320,7 +11320,7 @@ unsafe extern "C" fn ZSTD_getCParamMode(
         ZSTD_cpm_noAttachDict
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_resetCStream)]
 pub unsafe extern "C" fn ZSTD_resetCStream(
     mut zcs: *mut ZSTD_CStream,
     mut pss: std::ffi::c_ulonglong,
@@ -11340,7 +11340,7 @@ pub unsafe extern "C" fn ZSTD_resetCStream(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_initCStream_internal)]
 pub unsafe extern "C" fn ZSTD_initCStream_internal(
     mut zcs: *mut ZSTD_CStream,
     mut dict: *const std::ffi::c_void,
@@ -11371,7 +11371,7 @@ pub unsafe extern "C" fn ZSTD_initCStream_internal(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_initCStream_usingCDict_advanced)]
 pub unsafe extern "C" fn ZSTD_initCStream_usingCDict_advanced(
     mut zcs: *mut ZSTD_CStream,
     mut cdict: *const ZSTD_CDict,
@@ -11393,7 +11393,7 @@ pub unsafe extern "C" fn ZSTD_initCStream_usingCDict_advanced(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_initCStream_usingCDict)]
 pub unsafe extern "C" fn ZSTD_initCStream_usingCDict(
     mut zcs: *mut ZSTD_CStream,
     mut cdict: *const ZSTD_CDict,
@@ -11408,7 +11408,7 @@ pub unsafe extern "C" fn ZSTD_initCStream_usingCDict(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_initCStream_advanced)]
 pub unsafe extern "C" fn ZSTD_initCStream_advanced(
     mut zcs: *mut ZSTD_CStream,
     mut dict: *const std::ffi::c_void,
@@ -11442,7 +11442,7 @@ pub unsafe extern "C" fn ZSTD_initCStream_advanced(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_initCStream_usingDict)]
 pub unsafe extern "C" fn ZSTD_initCStream_usingDict(
     mut zcs: *mut ZSTD_CStream,
     mut dict: *const std::ffi::c_void,
@@ -11463,7 +11463,7 @@ pub unsafe extern "C" fn ZSTD_initCStream_usingDict(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_initCStream_srcSize)]
 pub unsafe extern "C" fn ZSTD_initCStream_srcSize(
     mut zcs: *mut ZSTD_CStream,
     mut compressionLevel: std::ffi::c_int,
@@ -11492,7 +11492,7 @@ pub unsafe extern "C" fn ZSTD_initCStream_srcSize(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_initCStream)]
 pub unsafe extern "C" fn ZSTD_initCStream(
     mut zcs: *mut ZSTD_CStream,
     mut compressionLevel: std::ffi::c_int,
@@ -11810,7 +11810,7 @@ unsafe extern "C" fn ZSTD_nextInputSizeHint_MTorST(mut cctx: *const ZSTD_CCtx) -
     }
     ZSTD_nextInputSizeHint(cctx)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressStream)]
 pub unsafe extern "C" fn ZSTD_compressStream(
     mut zcs: *mut ZSTD_CStream,
     mut output: *mut ZSTD_outBuffer,
@@ -12008,7 +12008,7 @@ unsafe extern "C" fn ZSTD_CCtx_init_compressStream2(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressStream2)]
 pub unsafe extern "C" fn ZSTD_compressStream2(
     mut cctx: *mut ZSTD_CCtx,
     mut output: *mut ZSTD_outBuffer,
@@ -12117,7 +12117,7 @@ pub unsafe extern "C" fn ZSTD_compressStream2(
     ZSTD_setBufferExpectations(cctx, output, input);
     ((*cctx).outBuffContentSize).wrapping_sub((*cctx).outBuffFlushedSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressStream2_simpleArgs)]
 pub unsafe extern "C" fn ZSTD_compressStream2_simpleArgs(
     mut cctx: *mut ZSTD_CCtx,
     mut dst: *mut std::ffi::c_void,
@@ -12149,7 +12149,7 @@ pub unsafe extern "C" fn ZSTD_compressStream2_simpleArgs(
     *srcPos = input.pos;
     cErr
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compress2)]
 pub unsafe extern "C" fn ZSTD_compress2(
     mut cctx: *mut ZSTD_CCtx,
     mut dst: *mut std::ffi::c_void,
@@ -12767,7 +12767,7 @@ unsafe extern "C" fn ZSTD_compressSequences_internal(
     }
     cSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressSequences)]
 pub unsafe extern "C" fn ZSTD_compressSequences(
     mut cctx: *mut ZSTD_CCtx,
     mut dst: *mut std::ffi::c_void,
@@ -12824,7 +12824,7 @@ pub unsafe extern "C" fn ZSTD_compressSequences(
     }
     cSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(convertSequences_noRepcodes)]
 pub unsafe extern "C" fn convertSequences_noRepcodes(
     mut dstSeqs: *mut SeqDef,
     mut inSeqs: *const ZSTD_Sequence,
@@ -12860,7 +12860,7 @@ pub unsafe extern "C" fn convertSequences_noRepcodes(
     }
     longLen
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_convertBlockSequences)]
 pub unsafe extern "C" fn ZSTD_convertBlockSequences(
     mut cctx: *mut ZSTD_CCtx,
     inSeqs: *const ZSTD_Sequence,
@@ -12962,7 +12962,7 @@ unsafe extern "C" fn matchLengthHalfIsZero(mut litMatchLength: u64) -> std::ffi:
         (litMatchLength as u32 == 0 as std::ffi::c_int as u32) as std::ffi::c_int
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_get1BlockSummary)]
 pub unsafe extern "C" fn ZSTD_get1BlockSummary(
     mut seqs: *const ZSTD_Sequence,
     mut nbSeqs: size_t,
@@ -13200,7 +13200,7 @@ unsafe extern "C" fn ZSTD_compressSequencesAndLiterals_internal(
     }
     cSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressSequencesAndLiterals)]
 pub unsafe extern "C" fn ZSTD_compressSequencesAndLiterals(
     mut cctx: *mut ZSTD_CCtx,
     mut dst: *mut std::ffi::c_void,
@@ -13277,7 +13277,7 @@ unsafe extern "C" fn inBuffer_forEndFlush(mut zcs: *const ZSTD_CStream) -> ZSTD_
         nullInput
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_flushStream)]
 pub unsafe extern "C" fn ZSTD_flushStream(
     mut zcs: *mut ZSTD_CStream,
     mut output: *mut ZSTD_outBuffer,
@@ -13286,7 +13286,7 @@ pub unsafe extern "C" fn ZSTD_flushStream(
     input.size = input.pos;
     ZSTD_compressStream2(zcs, output, &mut input, ZSTD_e_flush)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_endStream)]
 pub unsafe extern "C" fn ZSTD_endStream(
     mut zcs: *mut ZSTD_CStream,
     mut output: *mut ZSTD_outBuffer,
@@ -13318,7 +13318,7 @@ pub unsafe extern "C" fn ZSTD_endStream(
 pub const fn ZSTD_maxCLevel() -> std::ffi::c_int {
     ZSTD_MAX_CLEVEL
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_defaultCLevel)]
 pub unsafe extern "C" fn ZSTD_defaultCLevel() -> std::ffi::c_int {
     ZSTD_CLEVEL_DEFAULT
 }
@@ -13363,7 +13363,7 @@ unsafe extern "C" fn ZSTD_getCParamRowSize(
         srcSizeHint.wrapping_add(dictSize).wrapping_add(addedSize) as std::ffi::c_ulonglong
     }) as u64
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_getCParams)]
 pub unsafe extern "C" fn ZSTD_getCParams(
     mut compressionLevel: std::ffi::c_int,
     mut srcSizeHint: std::ffi::c_ulonglong,
@@ -13374,7 +13374,7 @@ pub unsafe extern "C" fn ZSTD_getCParams(
     }
     ZSTD_getCParams_internal(compressionLevel, srcSizeHint, dictSize, ZSTD_cpm_unknown)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_getParams)]
 pub unsafe extern "C" fn ZSTD_getParams(
     mut compressionLevel: std::ffi::c_int,
     mut srcSizeHint: std::ffi::c_ulonglong,
@@ -14500,7 +14500,7 @@ unsafe extern "C" fn ZSTD_getParams_internal(
     params.fParams.contentSizeFlag = 1 as std::ffi::c_int;
     params
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_registerSequenceProducer)]
 pub unsafe extern "C" fn ZSTD_registerSequenceProducer(
     mut zc: *mut ZSTD_CCtx,
     mut extSeqProdState: *mut std::ffi::c_void,
@@ -14512,7 +14512,7 @@ pub unsafe extern "C" fn ZSTD_registerSequenceProducer(
         extSeqProdFunc,
     );
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_CCtxParams_registerSequenceProducer)]
 pub unsafe extern "C" fn ZSTD_CCtxParams_registerSequenceProducer(
     mut params: *mut ZSTD_CCtx_params,
     mut extSeqProdState: *mut std::ffi::c_void,

--- a/lib/compress/zstd_compress_literals.rs
+++ b/lib/compress/zstd_compress_literals.rs
@@ -102,7 +102,7 @@ unsafe extern "C" fn ZSTD_minGain(mut srcSize: size_t, mut strat: ZSTD_strategy)
 pub const LitHufLog: std::ffi::c_int = 11 as std::ffi::c_int;
 pub const HUF_SYMBOLVALUE_MAX: std::ffi::c_int = 255 as std::ffi::c_int;
 pub const HUF_OPTIMAL_DEPTH_THRESHOLD: std::ffi::c_int = ZSTD_btultra as std::ffi::c_int;
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_noCompressLiterals)]
 pub unsafe extern "C" fn ZSTD_noCompressLiterals(
     mut dst: *mut std::ffi::c_void,
     mut dstCapacity: size_t,
@@ -165,7 +165,7 @@ unsafe extern "C" fn allBytesIdentical(
     }
     1 as std::ffi::c_int
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressRleLiteralsBlock)]
 pub unsafe extern "C" fn ZSTD_compressRleLiteralsBlock(
     mut dst: *mut std::ffi::c_void,
     mut dstCapacity: size_t,
@@ -221,7 +221,7 @@ unsafe extern "C" fn ZSTD_minLiteralsToCompress(
         (8 as std::ffi::c_int as size_t) << shift
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressLiterals)]
 pub unsafe extern "C" fn ZSTD_compressLiterals(
     mut dst: *mut std::ffi::c_void,
     mut dstCapacity: size_t,

--- a/lib/compress/zstd_compress_sequences.rs
+++ b/lib/compress/zstd_compress_sequences.rs
@@ -732,7 +732,7 @@ unsafe extern "C" fn ZSTD_entropyCost(
     }
     (cost >> 8 as std::ffi::c_int) as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_fseBitCost)]
 pub unsafe extern "C" fn ZSTD_fseBitCost(
     mut ctable: *const FSE_CTable,
     mut count: *const std::ffi::c_uint,
@@ -768,7 +768,7 @@ pub unsafe extern "C" fn ZSTD_fseBitCost(
     }
     cost >> kAccuracyLog
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_crossEntropyCost)]
 pub unsafe extern "C" fn ZSTD_crossEntropyCost(
     mut norm: *const std::ffi::c_short,
     mut accuracyLog: std::ffi::c_uint,
@@ -796,7 +796,7 @@ pub unsafe extern "C" fn ZSTD_crossEntropyCost(
     }
     cost >> 8 as std::ffi::c_int
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_selectEncodingType)]
 pub unsafe extern "C" fn ZSTD_selectEncodingType(
     mut repeatMode: *mut FSE_repeat,
     mut count: *const std::ffi::c_uint,
@@ -866,7 +866,7 @@ pub unsafe extern "C" fn ZSTD_selectEncodingType(
     *repeatMode = FSE_repeat_check;
     set_compressed
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_buildCTable)]
 pub unsafe extern "C" fn ZSTD_buildCTable(
     mut dst: *mut std::ffi::c_void,
     mut dstCapacity: size_t,
@@ -1266,7 +1266,7 @@ unsafe extern "C" fn ZSTD_encodeSequences_bmi2(
         longOffsets,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_encodeSequences)]
 pub unsafe extern "C" fn ZSTD_encodeSequences(
     mut dst: *mut std::ffi::c_void,
     mut dstCapacity: size_t,

--- a/lib/compress/zstd_compress_superblock.rs
+++ b/lib/compress/zstd_compress_superblock.rs
@@ -1798,7 +1798,7 @@ unsafe extern "C" fn ZSTD_compressSubBlock_multi(
     }
     op.offset_from(ostart) as std::ffi::c_long as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressSuperBlock)]
 pub unsafe extern "C" fn ZSTD_compressSuperBlock(
     mut zc: *mut ZSTD_CCtx,
     mut dst: *mut std::ffi::c_void,

--- a/lib/compress/zstd_double_fast.rs
+++ b/lib/compress/zstd_double_fast.rs
@@ -681,7 +681,7 @@ unsafe extern "C" fn ZSTD_fillDoubleHashTableForCCtx(
         ip = ip.offset(fastHashFillStep as isize);
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_fillDoubleHashTable)]
 pub unsafe extern "C" fn ZSTD_fillDoubleHashTable(
     mut ms: *mut ZSTD_MatchState_t,
     end: *const std::ffi::c_void,
@@ -1669,7 +1669,7 @@ unsafe extern "C" fn ZSTD_compressBlock_doubleFast_dictMatchState_7(
         7 as std::ffi::c_int as u32,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_doubleFast)]
 pub unsafe extern "C" fn ZSTD_compressBlock_doubleFast(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -1685,7 +1685,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_doubleFast(
         4 | _ => ZSTD_compressBlock_doubleFast_noDict_4(ms, seqStore, rep, src, srcSize),
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_doubleFast_dictMatchState)]
 pub unsafe extern "C" fn ZSTD_compressBlock_doubleFast_dictMatchState(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -2110,7 +2110,7 @@ unsafe extern "C" fn ZSTD_compressBlock_doubleFast_extDict_7(
         7 as std::ffi::c_int as u32,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_doubleFast_extDict)]
 pub unsafe extern "C" fn ZSTD_compressBlock_doubleFast_extDict(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,

--- a/lib/compress/zstd_fast.rs
+++ b/lib/compress/zstd_fast.rs
@@ -646,7 +646,7 @@ unsafe extern "C" fn ZSTD_fillHashTableForCCtx(
         ip = ip.offset(fastHashFillStep as isize);
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_fillHashTable)]
 pub unsafe extern "C" fn ZSTD_fillHashTable(
     mut ms: *mut ZSTD_MatchState_t,
     end: *const std::ffi::c_void,
@@ -1079,7 +1079,7 @@ unsafe extern "C" fn ZSTD_compressBlock_fast_noDict_7_0(
         0 as std::ffi::c_int,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_fast)]
 pub unsafe extern "C" fn ZSTD_compressBlock_fast(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -1455,7 +1455,7 @@ unsafe extern "C" fn ZSTD_compressBlock_fast_dictMatchState_7_0(
         0 as std::ffi::c_int as u32,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_fast_dictMatchState)]
 pub unsafe extern "C" fn ZSTD_compressBlock_fast_dictMatchState(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -1844,7 +1844,7 @@ unsafe extern "C" fn ZSTD_compressBlock_fast_extDict_7_0(
         0 as std::ffi::c_int as u32,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_fast_extDict)]
 pub unsafe extern "C" fn ZSTD_compressBlock_fast_extDict(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,

--- a/lib/compress/zstd_lazy.rs
+++ b/lib/compress/zstd_lazy.rs
@@ -1067,7 +1067,7 @@ unsafe extern "C" fn ZSTD_BtFindBestMatch(
     ZSTD_updateDUBT(ms, ip, iLimit, mls);
     ZSTD_DUBT_findBestMatch(ms, ip, iLimit, offBasePtr, mls, dictMode)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_dedicatedDictSearch_lazy_loadDictionary)]
 pub unsafe extern "C" fn ZSTD_dedicatedDictSearch_lazy_loadDictionary(
     mut ms: *mut ZSTD_MatchState_t,
     ip: *const u8,
@@ -1366,7 +1366,7 @@ unsafe extern "C" fn ZSTD_insertAndFindFirstIndex_internal(
     (*ms).nextToUpdate = target;
     *hashTable.offset(ZSTD_hashPtr(ip as *const std::ffi::c_void, hashLog, mls) as isize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_insertAndFindFirstIndex)]
 pub unsafe extern "C" fn ZSTD_insertAndFindFirstIndex(
     mut ms: *mut ZSTD_MatchState_t,
     mut ip: *const u8,
@@ -1740,7 +1740,7 @@ unsafe extern "C" fn ZSTD_row_update_internal(
     ZSTD_row_update_internalImpl(ms, idx, target, mls, rowLog, rowMask, useCache);
     (*ms).nextToUpdate = target;
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_row_update)]
 pub unsafe extern "C" fn ZSTD_row_update(ms: *mut ZSTD_MatchState_t, mut ip: *const u8) {
     let rowLog = if 4 as std::ffi::c_int as std::ffi::c_uint
         > (if (*ms).cParams.searchLog < 6 as std::ffi::c_int as std::ffi::c_uint {
@@ -4024,7 +4024,7 @@ unsafe extern "C" fn ZSTD_compressBlock_lazy_generic(
     };
     iend.offset_from(anchor) as std::ffi::c_long as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_greedy)]
 pub unsafe extern "C" fn ZSTD_compressBlock_greedy(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4043,7 +4043,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_greedy(
         ZSTD_noDict,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_greedy_dictMatchState)]
 pub unsafe extern "C" fn ZSTD_compressBlock_greedy_dictMatchState(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4062,7 +4062,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_greedy_dictMatchState(
         ZSTD_dictMatchState,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_greedy_dedicatedDictSearch)]
 pub unsafe extern "C" fn ZSTD_compressBlock_greedy_dedicatedDictSearch(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4081,7 +4081,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_greedy_dedicatedDictSearch(
         ZSTD_dedicatedDictSearch,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_greedy_row)]
 pub unsafe extern "C" fn ZSTD_compressBlock_greedy_row(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4100,7 +4100,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_greedy_row(
         ZSTD_noDict,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_greedy_dictMatchState_row)]
 pub unsafe extern "C" fn ZSTD_compressBlock_greedy_dictMatchState_row(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4119,7 +4119,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_greedy_dictMatchState_row(
         ZSTD_dictMatchState,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_greedy_dedicatedDictSearch_row)]
 pub unsafe extern "C" fn ZSTD_compressBlock_greedy_dedicatedDictSearch_row(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4138,7 +4138,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_greedy_dedicatedDictSearch_row(
         ZSTD_dedicatedDictSearch,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_lazy)]
 pub unsafe extern "C" fn ZSTD_compressBlock_lazy(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4157,7 +4157,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_lazy(
         ZSTD_noDict,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_lazy_dictMatchState)]
 pub unsafe extern "C" fn ZSTD_compressBlock_lazy_dictMatchState(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4176,7 +4176,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_lazy_dictMatchState(
         ZSTD_dictMatchState,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_lazy_dedicatedDictSearch)]
 pub unsafe extern "C" fn ZSTD_compressBlock_lazy_dedicatedDictSearch(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4195,7 +4195,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_lazy_dedicatedDictSearch(
         ZSTD_dedicatedDictSearch,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_lazy_row)]
 pub unsafe extern "C" fn ZSTD_compressBlock_lazy_row(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4214,7 +4214,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_lazy_row(
         ZSTD_noDict,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_lazy_dictMatchState_row)]
 pub unsafe extern "C" fn ZSTD_compressBlock_lazy_dictMatchState_row(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4233,7 +4233,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_lazy_dictMatchState_row(
         ZSTD_dictMatchState,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_lazy_dedicatedDictSearch_row)]
 pub unsafe extern "C" fn ZSTD_compressBlock_lazy_dedicatedDictSearch_row(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4252,7 +4252,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_lazy_dedicatedDictSearch_row(
         ZSTD_dedicatedDictSearch,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_lazy2)]
 pub unsafe extern "C" fn ZSTD_compressBlock_lazy2(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4271,7 +4271,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_lazy2(
         ZSTD_noDict,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_lazy2_dictMatchState)]
 pub unsafe extern "C" fn ZSTD_compressBlock_lazy2_dictMatchState(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4290,7 +4290,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_lazy2_dictMatchState(
         ZSTD_dictMatchState,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_lazy2_dedicatedDictSearch)]
 pub unsafe extern "C" fn ZSTD_compressBlock_lazy2_dedicatedDictSearch(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4309,7 +4309,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_lazy2_dedicatedDictSearch(
         ZSTD_dedicatedDictSearch,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_lazy2_row)]
 pub unsafe extern "C" fn ZSTD_compressBlock_lazy2_row(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4328,7 +4328,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_lazy2_row(
         ZSTD_noDict,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_lazy2_dictMatchState_row)]
 pub unsafe extern "C" fn ZSTD_compressBlock_lazy2_dictMatchState_row(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4347,7 +4347,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_lazy2_dictMatchState_row(
         ZSTD_dictMatchState,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_lazy2_dedicatedDictSearch_row)]
 pub unsafe extern "C" fn ZSTD_compressBlock_lazy2_dedicatedDictSearch_row(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4366,7 +4366,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_lazy2_dedicatedDictSearch_row(
         ZSTD_dedicatedDictSearch,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_btlazy2)]
 pub unsafe extern "C" fn ZSTD_compressBlock_btlazy2(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4385,7 +4385,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_btlazy2(
         ZSTD_noDict,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_btlazy2_dictMatchState)]
 pub unsafe extern "C" fn ZSTD_compressBlock_btlazy2_dictMatchState(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4786,7 +4786,7 @@ unsafe extern "C" fn ZSTD_compressBlock_lazy_extDict_generic(
     *rep.offset(1 as std::ffi::c_int as isize) = offset_2;
     iend.offset_from(anchor) as std::ffi::c_long as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_greedy_extDict)]
 pub unsafe extern "C" fn ZSTD_compressBlock_greedy_extDict(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4804,7 +4804,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_greedy_extDict(
         0 as std::ffi::c_int as u32,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_greedy_extDict_row)]
 pub unsafe extern "C" fn ZSTD_compressBlock_greedy_extDict_row(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4822,7 +4822,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_greedy_extDict_row(
         0 as std::ffi::c_int as u32,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_lazy_extDict)]
 pub unsafe extern "C" fn ZSTD_compressBlock_lazy_extDict(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4840,7 +4840,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_lazy_extDict(
         1 as std::ffi::c_int as u32,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_lazy_extDict_row)]
 pub unsafe extern "C" fn ZSTD_compressBlock_lazy_extDict_row(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4858,7 +4858,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_lazy_extDict_row(
         1 as std::ffi::c_int as u32,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_lazy2_extDict)]
 pub unsafe extern "C" fn ZSTD_compressBlock_lazy2_extDict(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4876,7 +4876,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_lazy2_extDict(
         2 as std::ffi::c_int as u32,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_lazy2_extDict_row)]
 pub unsafe extern "C" fn ZSTD_compressBlock_lazy2_extDict_row(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -4894,7 +4894,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_lazy2_extDict_row(
         2 as std::ffi::c_int as u32,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_btlazy2_extDict)]
 pub unsafe extern "C" fn ZSTD_compressBlock_btlazy2_extDict(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,

--- a/lib/compress/zstd_ldm.rs
+++ b/lib/compress/zstd_ldm.rs
@@ -1080,7 +1080,7 @@ unsafe extern "C" fn ZSTD_ldm_gear_feed(
     }
     n
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_ldm_adjustParameters)]
 pub unsafe extern "C" fn ZSTD_ldm_adjustParameters(
     mut params: *mut ldmParams_t,
     mut cParams: *const ZSTD_compressionParameters,
@@ -1212,7 +1212,7 @@ pub unsafe extern "C" fn ZSTD_ldm_adjustParameters(
         (*params).hashLog
     };
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_ldm_getTableSize)]
 pub unsafe extern "C" fn ZSTD_ldm_getTableSize(mut params: ldmParams_t) -> size_t {
     let ldmHSize = (1 as std::ffi::c_int as size_t) << params.hashLog;
     let ldmBucketSizeLog = (if params.bucketSizeLog < params.hashLog {
@@ -1232,7 +1232,7 @@ pub unsafe extern "C" fn ZSTD_ldm_getTableSize(mut params: ldmParams_t) -> size_
         0 as std::ffi::c_int as size_t
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_ldm_getMaxNbSeq)]
 pub unsafe extern "C" fn ZSTD_ldm_getMaxNbSeq(
     mut params: ldmParams_t,
     mut maxChunkSize: size_t,
@@ -1331,7 +1331,7 @@ unsafe extern "C" fn ZSTD_ldm_fillFastTables(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_ldm_fillHashTable)]
 pub unsafe extern "C" fn ZSTD_ldm_fillHashTable(
     mut ldmState: *mut ldmState_t,
     mut ip: *const u8,
@@ -1657,7 +1657,7 @@ unsafe extern "C" fn ZSTD_ldm_reduceTable(table: *mut ldmEntry_t, size: u32, red
         u;
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_ldm_generateSequences)]
 pub unsafe extern "C" fn ZSTD_ldm_generateSequences(
     mut ldmState: *mut ldmState_t,
     mut sequences: *mut RawSeqStore_t,
@@ -1734,7 +1734,7 @@ pub unsafe extern "C" fn ZSTD_ldm_generateSequences(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_ldm_skipSequences)]
 pub unsafe extern "C" fn ZSTD_ldm_skipSequences(
     mut rawSeqStore: *mut RawSeqStore_t,
     mut srcSize: size_t,
@@ -1791,7 +1791,7 @@ unsafe extern "C" fn maybeSplitSequence(
     ZSTD_ldm_skipSequences(rawSeqStore, remaining as size_t, minMatch);
     sequence
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_ldm_skipRawSeqStoreBytes)]
 pub unsafe extern "C" fn ZSTD_ldm_skipRawSeqStoreBytes(
     mut rawSeqStore: *mut RawSeqStore_t,
     mut nbBytes: size_t,
@@ -1812,7 +1812,7 @@ pub unsafe extern "C" fn ZSTD_ldm_skipRawSeqStoreBytes(
         (*rawSeqStore).posInSequence = 0 as std::ffi::c_int as size_t;
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_ldm_blockCompress)]
 pub unsafe extern "C" fn ZSTD_ldm_blockCompress(
     mut rawSeqStore: *mut RawSeqStore_t,
     mut ms: *mut ZSTD_MatchState_t,

--- a/lib/compress/zstd_opt.rs
+++ b/lib/compress/zstd_opt.rs
@@ -1673,7 +1673,7 @@ unsafe extern "C" fn ZSTD_updateTree_internal(
     }
     (*ms).nextToUpdate = target;
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_updateTree)]
 pub unsafe extern "C" fn ZSTD_updateTree(
     mut ms: *mut ZSTD_MatchState_t,
     mut ip: *const u8,
@@ -3276,7 +3276,7 @@ unsafe extern "C" fn ZSTD_compressBlock_opt2(
         dictMode,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_btopt)]
 pub unsafe extern "C" fn ZSTD_compressBlock_btopt(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -3306,7 +3306,7 @@ unsafe extern "C" fn ZSTD_initStats_ultra(
     (*ms).window.lowLimit = (*ms).window.dictLimit;
     (*ms).nextToUpdate = (*ms).window.dictLimit;
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_btultra)]
 pub unsafe extern "C" fn ZSTD_compressBlock_btultra(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -3316,7 +3316,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_btultra(
 ) -> size_t {
     ZSTD_compressBlock_opt2(ms, seqStore, rep, src, srcSize, ZSTD_noDict)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_btultra2)]
 pub unsafe extern "C" fn ZSTD_compressBlock_btultra2(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -3335,7 +3335,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_btultra2(
     }
     ZSTD_compressBlock_opt2(ms, seqStore, rep, src, srcSize, ZSTD_noDict)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_btopt_dictMatchState)]
 pub unsafe extern "C" fn ZSTD_compressBlock_btopt_dictMatchState(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -3345,7 +3345,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_btopt_dictMatchState(
 ) -> size_t {
     ZSTD_compressBlock_opt0(ms, seqStore, rep, src, srcSize, ZSTD_dictMatchState)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_btopt_extDict)]
 pub unsafe extern "C" fn ZSTD_compressBlock_btopt_extDict(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -3355,7 +3355,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_btopt_extDict(
 ) -> size_t {
     ZSTD_compressBlock_opt0(ms, seqStore, rep, src, srcSize, ZSTD_extDict)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_btultra_dictMatchState)]
 pub unsafe extern "C" fn ZSTD_compressBlock_btultra_dictMatchState(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,
@@ -3365,7 +3365,7 @@ pub unsafe extern "C" fn ZSTD_compressBlock_btultra_dictMatchState(
 ) -> size_t {
     ZSTD_compressBlock_opt2(ms, seqStore, rep, src, srcSize, ZSTD_dictMatchState)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_compressBlock_btultra_extDict)]
 pub unsafe extern "C" fn ZSTD_compressBlock_btultra_extDict(
     mut ms: *mut ZSTD_MatchState_t,
     mut seqStore: *mut SeqStore_t,

--- a/lib/compress/zstd_preSplit.rs
+++ b/lib/compress/zstd_preSplit.rs
@@ -369,7 +369,7 @@ unsafe extern "C" fn ZSTD_splitBlock_fromBorders(
     }) as size_t
 }
 pub const SEGMENT_SIZE: std::ffi::c_int = 512 as std::ffi::c_int;
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_splitBlock)]
 pub unsafe extern "C" fn ZSTD_splitBlock(
     mut blockStart: *const std::ffi::c_void,
     mut blockSize: size_t,

--- a/lib/compress/zstdmt_compress.rs
+++ b/lib/compress/zstdmt_compress.rs
@@ -1988,7 +1988,7 @@ unsafe extern "C" fn ZSTDMT_createCCtx_advanced_internal(
     }
     mtctx
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDMT_createCCtx_advanced)]
 pub unsafe extern "C" fn ZSTDMT_createCCtx_advanced(
     mut nbWorkers: std::ffi::c_uint,
     mut cMem: ZSTD_customMem,
@@ -2038,7 +2038,7 @@ unsafe extern "C" fn ZSTDMT_waitForAllJobsCompleted(mut mtctx: *mut ZSTDMT_CCtx)
         (*mtctx).doneJobID;
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDMT_freeCCtx)]
 pub unsafe extern "C" fn ZSTDMT_freeCCtx(mut mtctx: *mut ZSTDMT_CCtx) -> size_t {
     if mtctx.is_null() {
         return 0 as std::ffi::c_int as size_t;
@@ -2066,7 +2066,7 @@ pub unsafe extern "C" fn ZSTDMT_freeCCtx(mut mtctx: *mut ZSTDMT_CCtx) -> size_t 
     ZSTD_customFree(mtctx as *mut std::ffi::c_void, (*mtctx).cMem);
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDMT_sizeof_CCtx)]
 pub unsafe extern "C" fn ZSTDMT_sizeof_CCtx(mut mtctx: *mut ZSTDMT_CCtx) -> size_t {
     if mtctx.is_null() {
         return 0 as std::ffi::c_int as size_t;
@@ -2115,7 +2115,7 @@ unsafe extern "C" fn ZSTDMT_resize(
     ZSTDMT_CCtxParam_setNbWorkers(&mut (*mtctx).params, nbWorkers);
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDMT_updateCParams_whileCompressing)]
 pub unsafe extern "C" fn ZSTDMT_updateCParams_whileCompressing(
     mut mtctx: *mut ZSTDMT_CCtx,
     mut cctxParams: *const ZSTD_CCtx_params,
@@ -2132,7 +2132,7 @@ pub unsafe extern "C" fn ZSTDMT_updateCParams_whileCompressing(
     cParams.windowLog = saved_wlog;
     (*mtctx).params.cParams = cParams;
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDMT_getFrameProgression)]
 pub unsafe extern "C" fn ZSTDMT_getFrameProgression(
     mut mtctx: *mut ZSTDMT_CCtx,
 ) -> ZSTD_frameProgression {
@@ -2183,7 +2183,7 @@ pub unsafe extern "C" fn ZSTDMT_getFrameProgression(
     }
     fps
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDMT_toFlushNow)]
 pub unsafe extern "C" fn ZSTDMT_toFlushNow(mut mtctx: *mut ZSTDMT_CCtx) -> size_t {
     let mut toFlush: size_t = 0;
     let jobID = (*mtctx).doneJobID;
@@ -2297,7 +2297,7 @@ unsafe extern "C" fn ZSTDMT_computeOverlapSize(mut params: *const ZSTD_CCtx_para
         (1 as std::ffi::c_int as size_t) << ovLog
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDMT_initCStream_internal)]
 pub unsafe extern "C" fn ZSTDMT_initCStream_internal(
     mut mtctx: *mut ZSTDMT_CCtx,
     mut dict: *const std::ffi::c_void,
@@ -2862,7 +2862,7 @@ unsafe extern "C" fn findSynchronizationPoint(
     }
     syncPoint
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDMT_nextInputSizeHint)]
 pub unsafe extern "C" fn ZSTDMT_nextInputSizeHint(mut mtctx: *const ZSTDMT_CCtx) -> size_t {
     let mut hintInSize = ((*mtctx).targetSectionSize).wrapping_sub((*mtctx).inBuff.filled);
     if hintInSize == 0 as std::ffi::c_int as size_t {
@@ -2870,7 +2870,7 @@ pub unsafe extern "C" fn ZSTDMT_nextInputSizeHint(mut mtctx: *const ZSTDMT_CCtx)
     }
     hintInSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDMT_compressStream_generic)]
 pub unsafe extern "C" fn ZSTDMT_compressStream_generic(
     mut mtctx: *mut ZSTDMT_CCtx,
     mut output: *mut ZSTD_outBuffer,

--- a/lib/decompress/huf_decompress.rs
+++ b/lib/decompress/huf_decompress.rs
@@ -1992,7 +1992,7 @@ unsafe extern "C" fn HUF_fillDTableX2(
         w;
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUF_readDTableX2_wksp)]
 pub unsafe extern "C" fn HUF_readDTableX2_wksp(
     mut DTable: *mut HUF_DTable,
     mut src: *const std::ffi::c_void,
@@ -3202,7 +3202,7 @@ unsafe extern "C" fn HUF_decompress1X2_usingDTable_internal(
     }
     HUF_decompress1X2_usingDTable_internal_default(dst, dstSize, cSrc, cSrcSize, DTable)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUF_decompress1X2_DCtx_wksp)]
 pub unsafe extern "C" fn HUF_decompress1X2_DCtx_wksp(
     mut DCtx: *mut HUF_DTable,
     mut dst: *mut std::ffi::c_void,
@@ -3487,7 +3487,7 @@ static mut algoTime: [[algo_time_t; 2]; 16] = [
         },
     ],
 ];
-#[no_mangle]
+#[export_name = crate::prefix!(HUF_selectDecoder)]
 pub unsafe extern "C" fn HUF_selectDecoder(mut dstSize: size_t, mut cSrcSize: size_t) -> u32 {
     let Q = if cSrcSize >= dstSize {
         15 as std::ffi::c_int as u32
@@ -3520,7 +3520,7 @@ pub unsafe extern "C" fn HUF_selectDecoder(mut dstSize: size_t, mut cSrcSize: si
     DTime1 = DTime1.wrapping_add(DTime1 >> 5 as std::ffi::c_int);
     (DTime1 < DTime0) as std::ffi::c_int as u32
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUF_decompress1X_DCtx_wksp)]
 pub unsafe extern "C" fn HUF_decompress1X_DCtx_wksp(
     mut dctx: *mut HUF_DTable,
     mut dst: *mut std::ffi::c_void,
@@ -3560,7 +3560,7 @@ pub unsafe extern "C" fn HUF_decompress1X_DCtx_wksp(
         )
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUF_decompress1X_usingDTable)]
 pub unsafe extern "C" fn HUF_decompress1X_usingDTable(
     mut dst: *mut std::ffi::c_void,
     mut maxDstSize: size_t,
@@ -3576,7 +3576,7 @@ pub unsafe extern "C" fn HUF_decompress1X_usingDTable(
         HUF_decompress1X1_usingDTable_internal(dst, maxDstSize, cSrc, cSrcSize, DTable, flags)
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUF_decompress1X1_DCtx_wksp)]
 pub unsafe extern "C" fn HUF_decompress1X1_DCtx_wksp(
     mut dctx: *mut HUF_DTable,
     mut dst: *mut std::ffi::c_void,
@@ -3606,7 +3606,7 @@ pub unsafe extern "C" fn HUF_decompress1X1_DCtx_wksp(
         flags,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUF_decompress4X_usingDTable)]
 pub unsafe extern "C" fn HUF_decompress4X_usingDTable(
     mut dst: *mut std::ffi::c_void,
     mut maxDstSize: size_t,

--- a/lib/decompress/zstd_ddict.rs
+++ b/lib/decompress/zstd_ddict.rs
@@ -214,17 +214,17 @@ unsafe extern "C" fn ERR_isError(mut code: size_t) -> std::ffi::c_uint {
 #[inline]
 unsafe extern "C" fn _force_has_format_string(mut format: *const std::ffi::c_char, mut args: ...) {}
 pub const NULL: std::ffi::c_int = 0 as std::ffi::c_int;
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_DDict_dictContent)]
 pub unsafe extern "C" fn ZSTD_DDict_dictContent(
     mut ddict: *const ZSTD_DDict,
 ) -> *const std::ffi::c_void {
     (*ddict).dictContent
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_DDict_dictSize)]
 pub unsafe extern "C" fn ZSTD_DDict_dictSize(mut ddict: *const ZSTD_DDict) -> size_t {
     (*ddict).dictSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_copyDDictParameters)]
 pub unsafe extern "C" fn ZSTD_copyDDictParameters(
     mut dctx: *mut ZSTD_DCtx,
     mut ddict: *const ZSTD_DDict,
@@ -341,7 +341,7 @@ unsafe extern "C" fn ZSTD_initDDict_internal(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_createDDict_advanced)]
 pub unsafe extern "C" fn ZSTD_createDDict_advanced(
     mut dict: *const std::ffi::c_void,
     mut dictSize: size_t,
@@ -371,7 +371,7 @@ pub unsafe extern "C" fn ZSTD_createDDict_advanced(
     }
     ddict
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_createDDict)]
 pub unsafe extern "C" fn ZSTD_createDDict(
     mut dict: *const std::ffi::c_void,
     mut dictSize: size_t,
@@ -389,7 +389,7 @@ pub unsafe extern "C" fn ZSTD_createDDict(
     };
     ZSTD_createDDict_advanced(dict, dictSize, ZSTD_dlm_byCopy, ZSTD_dct_auto, allocator)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_createDDict_byReference)]
 pub unsafe extern "C" fn ZSTD_createDDict_byReference(
     mut dictBuffer: *const std::ffi::c_void,
     mut dictSize: size_t,
@@ -413,7 +413,7 @@ pub unsafe extern "C" fn ZSTD_createDDict_byReference(
         allocator,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_initStaticDDict)]
 pub unsafe extern "C" fn ZSTD_initStaticDDict(
     mut sBuffer: *mut std::ffi::c_void,
     mut sBufferSize: size_t,
@@ -459,7 +459,7 @@ pub unsafe extern "C" fn ZSTD_initStaticDDict(
     }
     ddict
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_freeDDict)]
 pub unsafe extern "C" fn ZSTD_freeDDict(mut ddict: *mut ZSTD_DDict) -> size_t {
     if ddict.is_null() {
         return 0 as std::ffi::c_int as size_t;
@@ -469,7 +469,7 @@ pub unsafe extern "C" fn ZSTD_freeDDict(mut ddict: *mut ZSTD_DDict) -> size_t {
     ZSTD_customFree(ddict as *mut std::ffi::c_void, cMem);
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_estimateDDictSize)]
 pub unsafe extern "C" fn ZSTD_estimateDDictSize(
     mut dictSize: size_t,
     mut dictLoadMethod: ZSTD_dictLoadMethod_e,
@@ -484,7 +484,7 @@ pub unsafe extern "C" fn ZSTD_estimateDDictSize(
         },
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_sizeof_DDict)]
 pub unsafe extern "C" fn ZSTD_sizeof_DDict(mut ddict: *const ZSTD_DDict) -> size_t {
     if ddict.is_null() {
         return 0 as std::ffi::c_int as size_t;
@@ -497,7 +497,7 @@ pub unsafe extern "C" fn ZSTD_sizeof_DDict(mut ddict: *const ZSTD_DDict) -> size
         },
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_getDictID_fromDDict)]
 pub unsafe extern "C" fn ZSTD_getDictID_fromDDict(
     mut ddict: *const ZSTD_DDict,
 ) -> std::ffi::c_uint {

--- a/lib/decompress/zstd_decompress.rs
+++ b/lib/decompress/zstd_decompress.rs
@@ -1200,7 +1200,7 @@ unsafe extern "C" fn ZSTD_DDictHashSet_addDDict(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_sizeof_DCtx)]
 pub unsafe extern "C" fn ZSTD_sizeof_DCtx(mut dctx: *const ZSTD_DCtx) -> size_t {
     if dctx.is_null() {
         return 0 as std::ffi::c_int as size_t;
@@ -1210,7 +1210,7 @@ pub unsafe extern "C" fn ZSTD_sizeof_DCtx(mut dctx: *const ZSTD_DCtx) -> size_t 
         .wrapping_add((*dctx).inBuffSize)
         .wrapping_add((*dctx).outBuffSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_estimateDCtxSize)]
 pub unsafe extern "C" fn ZSTD_estimateDCtxSize() -> size_t {
     ::core::mem::size_of::<ZSTD_DCtx>() as std::ffi::c_ulong
 }
@@ -1250,7 +1250,7 @@ unsafe extern "C" fn ZSTD_initDCtx_internal(mut dctx: *mut ZSTD_DCtx) {
     (*dctx).ddictSet = core::ptr::null_mut();
     ZSTD_DCtx_resetParameters(dctx);
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_initStaticDCtx)]
 pub unsafe extern "C" fn ZSTD_initStaticDCtx(
     mut workspace: *mut std::ffi::c_void,
     mut workspaceSize: size_t,
@@ -1285,11 +1285,11 @@ unsafe extern "C" fn ZSTD_createDCtx_internal(mut customMem: ZSTD_customMem) -> 
     ZSTD_initDCtx_internal(dctx);
     dctx
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_createDCtx_advanced)]
 pub unsafe extern "C" fn ZSTD_createDCtx_advanced(mut customMem: ZSTD_customMem) -> *mut ZSTD_DCtx {
     ZSTD_createDCtx_internal(customMem)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_createDCtx)]
 pub unsafe extern "C" fn ZSTD_createDCtx() -> *mut ZSTD_DCtx {
     ZSTD_createDCtx_internal(ZSTD_defaultCMem)
 }
@@ -1299,7 +1299,7 @@ unsafe extern "C" fn ZSTD_clearDict(mut dctx: *mut ZSTD_DCtx) {
     (*dctx).ddict = core::ptr::null();
     (*dctx).dictUses = ZSTD_dont_use;
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_freeDCtx)]
 pub unsafe extern "C" fn ZSTD_freeDCtx(mut dctx: *mut ZSTD_DCtx) -> size_t {
     if dctx.is_null() {
         return 0 as std::ffi::c_int as size_t;
@@ -1321,7 +1321,7 @@ pub unsafe extern "C" fn ZSTD_freeDCtx(mut dctx: *mut ZSTD_DCtx) -> size_t {
     ZSTD_customFree(dctx as *mut std::ffi::c_void, cMem);
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_copyDCtx)]
 pub unsafe extern "C" fn ZSTD_copyDCtx(mut dstDCtx: *mut ZSTD_DCtx, mut srcDCtx: *const ZSTD_DCtx) {
     let toCopy = (&mut (*dstDCtx).inBuff as *mut *mut std::ffi::c_char as *mut std::ffi::c_char)
         .offset_from(dstDCtx as *mut std::ffi::c_char) as std::ffi::c_long
@@ -1343,7 +1343,7 @@ unsafe extern "C" fn ZSTD_DCtx_selectFrameDDict(mut dctx: *mut ZSTD_DCtx) {
         }
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_isFrame)]
 pub unsafe extern "C" fn ZSTD_isFrame(
     mut buffer: *const std::ffi::c_void,
     mut size: size_t,
@@ -1363,7 +1363,7 @@ pub unsafe extern "C" fn ZSTD_isFrame(
     }
     0 as std::ffi::c_int as std::ffi::c_uint
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_isSkippableFrame)]
 pub unsafe extern "C" fn ZSTD_isSkippableFrame(
     mut buffer: *const std::ffi::c_void,
     mut size: size_t,
@@ -1398,14 +1398,14 @@ unsafe extern "C" fn ZSTD_frameHeaderSize_internal(
         .wrapping_add(*ZSTD_fcs_fieldSize.as_ptr().offset(fcsId as isize))
         .wrapping_add((singleSegment != 0 && fcsId == 0) as std::ffi::c_int as size_t)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_frameHeaderSize)]
 pub unsafe extern "C" fn ZSTD_frameHeaderSize(
     mut src: *const std::ffi::c_void,
     mut srcSize: size_t,
 ) -> size_t {
     ZSTD_frameHeaderSize_internal(src, srcSize, ZSTD_f_zstd1)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_getFrameHeader_advanced)]
 pub unsafe extern "C" fn ZSTD_getFrameHeader_advanced(
     mut zfhPtr: *mut ZSTD_FrameHeader,
     mut src: *const std::ffi::c_void,
@@ -1577,7 +1577,7 @@ pub unsafe extern "C" fn ZSTD_getFrameHeader_advanced(
     (*zfhPtr).checksumFlag = checksumFlag;
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_getFrameHeader)]
 pub unsafe extern "C" fn ZSTD_getFrameHeader(
     mut zfhPtr: *mut ZSTD_FrameHeader,
     mut src: *const std::ffi::c_void,
@@ -1585,7 +1585,7 @@ pub unsafe extern "C" fn ZSTD_getFrameHeader(
 ) -> size_t {
     ZSTD_getFrameHeader_advanced(zfhPtr, src, srcSize, ZSTD_f_zstd1)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_getFrameContentSize)]
 pub unsafe extern "C" fn ZSTD_getFrameContentSize(
     mut src: *const std::ffi::c_void,
     mut srcSize: size_t,
@@ -1641,7 +1641,7 @@ unsafe extern "C" fn readSkippableFrameSize(
     }
     skippableSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_readSkippableFrame)]
 pub unsafe extern "C" fn ZSTD_readSkippableFrame(
     mut dst: *mut std::ffi::c_void,
     mut dstCapacity: size_t,
@@ -1677,7 +1677,7 @@ pub unsafe extern "C" fn ZSTD_readSkippableFrame(
     }
     skippableContentSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_findDecompressedSize)]
 pub unsafe extern "C" fn ZSTD_findDecompressedSize(
     mut src: *const std::ffi::c_void,
     mut srcSize: size_t,
@@ -1715,7 +1715,7 @@ pub unsafe extern "C" fn ZSTD_findDecompressedSize(
     }
     totalDstSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_getDecompressedSize)]
 pub unsafe extern "C" fn ZSTD_getDecompressedSize(
     mut src: *const std::ffi::c_void,
     mut srcSize: size_t,
@@ -1881,14 +1881,14 @@ unsafe extern "C" fn ZSTD_findFrameCompressedSize_advanced(
     let frameSizeInfo = ZSTD_findFrameSizeInfo(src, srcSize, format);
     frameSizeInfo.compressedSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_findFrameCompressedSize)]
 pub unsafe extern "C" fn ZSTD_findFrameCompressedSize(
     mut src: *const std::ffi::c_void,
     mut srcSize: size_t,
 ) -> size_t {
     ZSTD_findFrameCompressedSize_advanced(src, srcSize, ZSTD_f_zstd1)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_decompressBound)]
 pub unsafe extern "C" fn ZSTD_decompressBound(
     mut src: *const std::ffi::c_void,
     mut srcSize: size_t,
@@ -1907,7 +1907,7 @@ pub unsafe extern "C" fn ZSTD_decompressBound(
     }
     bound
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_decompressionMargin)]
 pub unsafe extern "C" fn ZSTD_decompressionMargin(
     mut src: *const std::ffi::c_void,
     mut srcSize: size_t,
@@ -1960,7 +1960,7 @@ pub unsafe extern "C" fn ZSTD_decompressionMargin(
     margin = margin.wrapping_add(maxBlockSize as size_t);
     margin
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_insertBlock)]
 pub unsafe extern "C" fn ZSTD_insertBlock(
     mut dctx: *mut ZSTD_DCtx,
     mut blockStart: *const std::ffi::c_void,
@@ -2318,7 +2318,7 @@ unsafe extern "C" fn ZSTD_decompressMultiFrame(
     }
     (dst as *mut u8).offset_from(dststart as *mut u8) as std::ffi::c_long as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_decompress_usingDict)]
 pub unsafe extern "C" fn ZSTD_decompress_usingDict(
     mut dctx: *mut ZSTD_DCtx,
     mut dst: *mut std::ffi::c_void,
@@ -2352,7 +2352,7 @@ unsafe extern "C" fn ZSTD_getDDict(mut dctx: *mut ZSTD_DCtx) -> *const ZSTD_DDic
         }
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_decompressDCtx)]
 pub unsafe extern "C" fn ZSTD_decompressDCtx(
     mut dctx: *mut ZSTD_DCtx,
     mut dst: *mut std::ffi::c_void,
@@ -2362,7 +2362,7 @@ pub unsafe extern "C" fn ZSTD_decompressDCtx(
 ) -> size_t {
     ZSTD_decompress_usingDDict(dctx, dst, dstCapacity, src, srcSize, ZSTD_getDDict(dctx))
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_decompress)]
 pub unsafe extern "C" fn ZSTD_decompress(
     mut dst: *mut std::ffi::c_void,
     mut dstCapacity: size_t,
@@ -2378,7 +2378,7 @@ pub unsafe extern "C" fn ZSTD_decompress(
     ZSTD_freeDCtx(dctx);
     regenSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_nextSrcSizeToDecompress)]
 pub unsafe extern "C" fn ZSTD_nextSrcSizeToDecompress(mut dctx: *mut ZSTD_DCtx) -> size_t {
     (*dctx).expected
 }
@@ -2410,7 +2410,7 @@ unsafe extern "C" fn ZSTD_nextSrcSizeToDecompressWithInputSize(
         (*dctx).expected
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_nextInputType)]
 pub unsafe extern "C" fn ZSTD_nextInputType(mut dctx: *mut ZSTD_DCtx) -> ZSTD_nextInputType_e {
     match (*dctx).stage as std::ffi::c_uint {
         2 => ZSTDnit_blockHeader,
@@ -2425,7 +2425,7 @@ unsafe extern "C" fn ZSTD_isSkipFrame(mut dctx: *mut ZSTD_DCtx) -> std::ffi::c_i
     ((*dctx).stage as std::ffi::c_uint == ZSTDds_skipFrame as std::ffi::c_int as std::ffi::c_uint)
         as std::ffi::c_int
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_decompressContinue)]
 pub unsafe extern "C" fn ZSTD_decompressContinue(
     mut dctx: *mut ZSTD_DCtx,
     mut dst: *mut std::ffi::c_void,
@@ -2664,7 +2664,7 @@ unsafe extern "C" fn ZSTD_refDictContent(
         (dict as *const std::ffi::c_char).offset(dictSize as isize) as *const std::ffi::c_void;
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_loadDEntropy)]
 pub unsafe extern "C" fn ZSTD_loadDEntropy(
     mut entropy: *mut ZSTD_entropyDTables_t,
     dict: *const std::ffi::c_void,
@@ -2830,7 +2830,7 @@ unsafe extern "C" fn ZSTD_decompress_insertDictionary(
     (*dctx).litEntropy = (*dctx).fseEntropy;
     ZSTD_refDictContent(dctx, dict, dictSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_decompressBegin)]
 pub unsafe extern "C" fn ZSTD_decompressBegin(mut dctx: *mut ZSTD_DCtx) -> size_t {
     (*dctx).traceCtx = if (Some(
         ZSTD_trace_decompress_begin as unsafe extern "C" fn(*const ZSTD_DCtx_s) -> ZSTD_TraceCtx,
@@ -2869,7 +2869,7 @@ pub unsafe extern "C" fn ZSTD_decompressBegin(mut dctx: *mut ZSTD_DCtx) -> size_
     (*dctx).HUFptr = ((*dctx).entropy.hufTable).as_mut_ptr();
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_decompressBegin_usingDict)]
 pub unsafe extern "C" fn ZSTD_decompressBegin_usingDict(
     mut dctx: *mut ZSTD_DCtx,
     mut dict: *const std::ffi::c_void,
@@ -2887,7 +2887,7 @@ pub unsafe extern "C" fn ZSTD_decompressBegin_usingDict(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_decompressBegin_usingDDict)]
 pub unsafe extern "C" fn ZSTD_decompressBegin_usingDDict(
     mut dctx: *mut ZSTD_DCtx,
     mut ddict: *const ZSTD_DDict,
@@ -2907,7 +2907,7 @@ pub unsafe extern "C" fn ZSTD_decompressBegin_usingDDict(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_getDictID_fromDict)]
 pub unsafe extern "C" fn ZSTD_getDictID_fromDict(
     mut dict: *const std::ffi::c_void,
     mut dictSize: size_t,
@@ -2923,7 +2923,7 @@ pub unsafe extern "C" fn ZSTD_getDictID_fromDict(
             as *const std::ffi::c_void,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_getDictID_fromFrame)]
 pub unsafe extern "C" fn ZSTD_getDictID_fromFrame(
     mut src: *const std::ffi::c_void,
     mut srcSize: size_t,
@@ -2947,7 +2947,7 @@ pub unsafe extern "C" fn ZSTD_getDictID_fromFrame(
     }
     zfp.dictID
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_decompress_usingDDict)]
 pub unsafe extern "C" fn ZSTD_decompress_usingDDict(
     mut dctx: *mut ZSTD_DCtx,
     mut dst: *mut std::ffi::c_void,
@@ -2967,36 +2967,36 @@ pub unsafe extern "C" fn ZSTD_decompress_usingDDict(
         ddict,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_createDStream)]
 pub unsafe extern "C" fn ZSTD_createDStream() -> *mut ZSTD_DStream {
     ZSTD_createDCtx_internal(ZSTD_defaultCMem)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_initStaticDStream)]
 pub unsafe extern "C" fn ZSTD_initStaticDStream(
     mut workspace: *mut std::ffi::c_void,
     mut workspaceSize: size_t,
 ) -> *mut ZSTD_DStream {
     ZSTD_initStaticDCtx(workspace, workspaceSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_createDStream_advanced)]
 pub unsafe extern "C" fn ZSTD_createDStream_advanced(
     mut customMem: ZSTD_customMem,
 ) -> *mut ZSTD_DStream {
     ZSTD_createDCtx_internal(customMem)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_freeDStream)]
 pub unsafe extern "C" fn ZSTD_freeDStream(mut zds: *mut ZSTD_DStream) -> size_t {
     ZSTD_freeDCtx(zds)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_DStreamInSize)]
 pub unsafe extern "C" fn ZSTD_DStreamInSize() -> size_t {
     (ZSTD_BLOCKSIZE_MAX as size_t).wrapping_add(ZSTD_blockHeaderSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_DStreamOutSize)]
 pub unsafe extern "C" fn ZSTD_DStreamOutSize() -> size_t {
     ZSTD_BLOCKSIZE_MAX as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_DCtx_loadDictionary_advanced)]
 pub unsafe extern "C" fn ZSTD_DCtx_loadDictionary_advanced(
     mut dctx: *mut ZSTD_DCtx,
     mut dict: *const std::ffi::c_void,
@@ -3024,7 +3024,7 @@ pub unsafe extern "C" fn ZSTD_DCtx_loadDictionary_advanced(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_DCtx_loadDictionary_byReference)]
 pub unsafe extern "C" fn ZSTD_DCtx_loadDictionary_byReference(
     mut dctx: *mut ZSTD_DCtx,
     mut dict: *const std::ffi::c_void,
@@ -3032,7 +3032,7 @@ pub unsafe extern "C" fn ZSTD_DCtx_loadDictionary_byReference(
 ) -> size_t {
     ZSTD_DCtx_loadDictionary_advanced(dctx, dict, dictSize, ZSTD_dlm_byRef, ZSTD_dct_auto)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_DCtx_loadDictionary)]
 pub unsafe extern "C" fn ZSTD_DCtx_loadDictionary(
     mut dctx: *mut ZSTD_DCtx,
     mut dict: *const std::ffi::c_void,
@@ -3040,7 +3040,7 @@ pub unsafe extern "C" fn ZSTD_DCtx_loadDictionary(
 ) -> size_t {
     ZSTD_DCtx_loadDictionary_advanced(dctx, dict, dictSize, ZSTD_dlm_byCopy, ZSTD_dct_auto)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_DCtx_refPrefix_advanced)]
 pub unsafe extern "C" fn ZSTD_DCtx_refPrefix_advanced(
     mut dctx: *mut ZSTD_DCtx,
     mut prefix: *const std::ffi::c_void,
@@ -3060,7 +3060,7 @@ pub unsafe extern "C" fn ZSTD_DCtx_refPrefix_advanced(
     (*dctx).dictUses = ZSTD_use_once;
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_DCtx_refPrefix)]
 pub unsafe extern "C" fn ZSTD_DCtx_refPrefix(
     mut dctx: *mut ZSTD_DCtx,
     mut prefix: *const std::ffi::c_void,
@@ -3068,7 +3068,7 @@ pub unsafe extern "C" fn ZSTD_DCtx_refPrefix(
 ) -> size_t {
     ZSTD_DCtx_refPrefix_advanced(dctx, prefix, prefixSize, ZSTD_dct_rawContent)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_initDStream_usingDict)]
 pub unsafe extern "C" fn ZSTD_initDStream_usingDict(
     mut zds: *mut ZSTD_DStream,
     mut dict: *const std::ffi::c_void,
@@ -3084,7 +3084,7 @@ pub unsafe extern "C" fn ZSTD_initDStream_usingDict(
     }
     ZSTD_startingInputLength((*zds).format)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_initDStream)]
 pub unsafe extern "C" fn ZSTD_initDStream(mut zds: *mut ZSTD_DStream) -> size_t {
     let err_code = ZSTD_DCtx_reset(zds, ZSTD_reset_session_only);
     if ERR_isError(err_code) != 0 {
@@ -3096,7 +3096,7 @@ pub unsafe extern "C" fn ZSTD_initDStream(mut zds: *mut ZSTD_DStream) -> size_t 
     }
     ZSTD_startingInputLength((*zds).format)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_initDStream_usingDDict)]
 pub unsafe extern "C" fn ZSTD_initDStream_usingDDict(
     mut dctx: *mut ZSTD_DStream,
     mut ddict: *const ZSTD_DDict,
@@ -3111,7 +3111,7 @@ pub unsafe extern "C" fn ZSTD_initDStream_usingDDict(
     }
     ZSTD_startingInputLength((*dctx).format)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_resetDStream)]
 pub unsafe extern "C" fn ZSTD_resetDStream(mut dctx: *mut ZSTD_DStream) -> size_t {
     let err_code = ZSTD_DCtx_reset(dctx, ZSTD_reset_session_only);
     if ERR_isError(err_code) != 0 {
@@ -3119,7 +3119,7 @@ pub unsafe extern "C" fn ZSTD_resetDStream(mut dctx: *mut ZSTD_DStream) -> size_
     }
     ZSTD_startingInputLength((*dctx).format)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_DCtx_refDDict)]
 pub unsafe extern "C" fn ZSTD_DCtx_refDDict(
     mut dctx: *mut ZSTD_DCtx,
     mut ddict: *const ZSTD_DDict,
@@ -3148,7 +3148,7 @@ pub unsafe extern "C" fn ZSTD_DCtx_refDDict(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_DCtx_setMaxWindowSize)]
 pub unsafe extern "C" fn ZSTD_DCtx_setMaxWindowSize(
     mut dctx: *mut ZSTD_DCtx,
     mut maxWindowSize: size_t,
@@ -3168,7 +3168,7 @@ pub unsafe extern "C" fn ZSTD_DCtx_setMaxWindowSize(
     (*dctx).maxWindowSize = maxWindowSize;
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_DCtx_setFormat)]
 pub unsafe extern "C" fn ZSTD_DCtx_setFormat(
     mut dctx: *mut ZSTD_DCtx,
     mut format: ZSTD_format_e,
@@ -3179,7 +3179,7 @@ pub unsafe extern "C" fn ZSTD_DCtx_setFormat(
         format as std::ffi::c_int,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_dParam_getBounds)]
 pub unsafe extern "C" fn ZSTD_dParam_getBounds(mut dParam: ZSTD_dParameter) -> ZSTD_bounds {
     let mut bounds = {
         ZSTD_bounds {
@@ -3251,7 +3251,7 @@ unsafe extern "C" fn ZSTD_dParam_withinBounds(
     }
     1 as std::ffi::c_int
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_DCtx_getParameter)]
 pub unsafe extern "C" fn ZSTD_DCtx_getParameter(
     mut dctx: *mut ZSTD_DCtx,
     mut param: ZSTD_dParameter,
@@ -3290,7 +3290,7 @@ pub unsafe extern "C" fn ZSTD_DCtx_getParameter(
     }
     -(ZSTD_error_parameter_unsupported as std::ffi::c_int) as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_DCtx_setParameter)]
 pub unsafe extern "C" fn ZSTD_DCtx_setParameter(
     mut dctx: *mut ZSTD_DCtx,
     mut dParam: ZSTD_dParameter,
@@ -3361,7 +3361,7 @@ pub unsafe extern "C" fn ZSTD_DCtx_setParameter(
     }
     -(ZSTD_error_parameter_unsupported as std::ffi::c_int) as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_DCtx_reset)]
 pub unsafe extern "C" fn ZSTD_DCtx_reset(
     mut dctx: *mut ZSTD_DCtx,
     mut reset: ZSTD_ResetDirective,
@@ -3388,7 +3388,7 @@ pub unsafe extern "C" fn ZSTD_DCtx_reset(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_sizeof_DStream)]
 pub unsafe extern "C" fn ZSTD_sizeof_DStream(mut dctx: *const ZSTD_DStream) -> size_t {
     ZSTD_sizeof_DCtx(dctx)
 }
@@ -3429,14 +3429,14 @@ unsafe extern "C" fn ZSTD_decodingBufferSize_internal(
     }
     minRBSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_decodingBufferSize_min)]
 pub unsafe extern "C" fn ZSTD_decodingBufferSize_min(
     mut windowSize: std::ffi::c_ulonglong,
     mut frameContentSize: std::ffi::c_ulonglong,
 ) -> size_t {
     ZSTD_decodingBufferSize_internal(windowSize, frameContentSize, ZSTD_BLOCKSIZE_MAX as size_t)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_estimateDStreamSize)]
 pub unsafe extern "C" fn ZSTD_estimateDStreamSize(mut windowSize: size_t) -> size_t {
     let blockSize = if windowSize < ((1 as std::ffi::c_int) << 17 as std::ffi::c_int) as size_t {
         windowSize
@@ -3452,7 +3452,7 @@ pub unsafe extern "C" fn ZSTD_estimateDStreamSize(mut windowSize: size_t) -> siz
         .wrapping_add(inBuffSize)
         .wrapping_add(outBuffSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_estimateDStreamSize_fromFrame)]
 pub unsafe extern "C" fn ZSTD_estimateDStreamSize_fromFrame(
     mut src: *const std::ffi::c_void,
     mut srcSize: size_t,
@@ -3580,7 +3580,7 @@ unsafe extern "C" fn ZSTD_decompressContinueStream(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_decompressStream)]
 pub unsafe extern "C" fn ZSTD_decompressStream(
     mut zds: *mut ZSTD_DStream,
     mut output: *mut ZSTD_outBuffer,
@@ -4091,7 +4091,7 @@ pub unsafe extern "C" fn ZSTD_decompressStream(
     nextSrcSizeHint = nextSrcSizeHint.wrapping_sub((*zds).inPos);
     nextSrcSizeHint
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_decompressStream_simpleArgs)]
 pub unsafe extern "C" fn ZSTD_decompressStream_simpleArgs(
     mut dctx: *mut ZSTD_DCtx,
     mut dst: *mut std::ffi::c_void,

--- a/lib/decompress/zstd_decompress_block.rs
+++ b/lib/decompress/zstd_decompress_block.rs
@@ -705,7 +705,7 @@ unsafe extern "C" fn ZSTD_blockSizeMax(mut dctx: *const ZSTD_DCtx) -> size_t {
         ZSTD_BLOCKSIZE_MAX as std::ffi::c_uint
     }) as size_t)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_getcBlockSize)]
 pub unsafe extern "C" fn ZSTD_getcBlockSize(
     mut src: *const std::ffi::c_void,
     mut srcSize: size_t,
@@ -1342,7 +1342,7 @@ unsafe extern "C" fn ZSTD_decodeLiteralsBlock(
     }
     litCSize.wrapping_add(lhSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_decodeLiteralsBlock_wrapper)]
 pub unsafe extern "C" fn ZSTD_decodeLiteralsBlock_wrapper(
     mut dctx: *mut ZSTD_DCtx,
     mut src: *const std::ffi::c_void,
@@ -2867,7 +2867,7 @@ unsafe extern "C" fn ZSTD_buildFSETable_body_bmi2(
         wkspSize,
     );
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_buildFSETable)]
 pub unsafe extern "C" fn ZSTD_buildFSETable(
     mut dt: *mut ZSTD_seqSymbol,
     mut normalizedCounter: *const std::ffi::c_short,
@@ -2988,7 +2988,7 @@ unsafe extern "C" fn ZSTD_buildSeqTable(
         _ => -(ZSTD_error_GENERIC as std::ffi::c_int) as size_t,
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_decodeSeqHeaders)]
 pub unsafe extern "C" fn ZSTD_decodeSeqHeaders(
     mut dctx: *mut ZSTD_DCtx,
     mut nbSeqPtr: *mut std::ffi::c_int,
@@ -4787,7 +4787,7 @@ unsafe extern "C" fn ZSTD_maxShortOffset() -> size_t {
         maxOffbase.wrapping_sub(ZSTD_REP_NUM as size_t)
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_decompressBlock_internal)]
 pub unsafe extern "C" fn ZSTD_decompressBlock_internal(
     mut dctx: *mut ZSTD_DCtx,
     mut dst: *mut std::ffi::c_void,
@@ -4899,7 +4899,7 @@ pub unsafe extern "C" fn ZSTD_decompressBlock_internal(
         )
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_checkContinuity)]
 pub unsafe extern "C" fn ZSTD_checkContinuity(
     mut dctx: *mut ZSTD_DCtx,
     mut dst: *const std::ffi::c_void,
@@ -4916,7 +4916,7 @@ pub unsafe extern "C" fn ZSTD_checkContinuity(
         (*dctx).previousDstEnd = dst;
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_decompressBlock_deprecated)]
 pub unsafe extern "C" fn ZSTD_decompressBlock_deprecated(
     mut dctx: *mut ZSTD_DCtx,
     mut dst: *mut std::ffi::c_void,
@@ -4936,7 +4936,7 @@ pub unsafe extern "C" fn ZSTD_decompressBlock_deprecated(
         (dst as *mut std::ffi::c_char).offset(dSize as isize) as *const std::ffi::c_void;
     dSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTD_decompressBlock)]
 pub unsafe extern "C" fn ZSTD_decompressBlock(
     mut dctx: *mut ZSTD_DCtx,
     mut dst: *mut std::ffi::c_void,

--- a/lib/dictBuilder/cover.rs
+++ b/lib/dictBuilder/cover.rs
@@ -426,7 +426,7 @@ unsafe extern "C" fn COVER_map_destroy(mut map: *mut COVER_map_t) {
     (*map).data = NULL as *mut COVER_map_pair_t;
     (*map).size = 0 as std::ffi::c_int as u32;
 }
-#[no_mangle]
+#[export_name = crate::prefix!(COVER_sum)]
 pub unsafe extern "C" fn COVER_sum(
     mut samplesSizes: *const size_t,
     mut nbSamples: std::ffi::c_uint,
@@ -968,7 +968,7 @@ unsafe extern "C" fn COVER_ctx_init(
     (*ctx).suffix = NULL as *mut u32;
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(COVER_warnOnSmallCorpus)]
 pub unsafe extern "C" fn COVER_warnOnSmallCorpus(
     mut maxDictSize: size_t,
     mut nbDmers: size_t,
@@ -990,7 +990,7 @@ pub unsafe extern "C" fn COVER_warnOnSmallCorpus(
         fflush(stderr);
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(COVER_computeEpochs)]
 pub unsafe extern "C" fn COVER_computeEpochs(
     mut maxDictSize: u32,
     mut nbDmers: u32,
@@ -1123,7 +1123,7 @@ unsafe extern "C" fn COVER_buildDictionary(
     }
     tail
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZDICT_trainFromBuffer_cover)]
 pub unsafe extern "C" fn ZDICT_trainFromBuffer_cover(
     mut dictBuffer: *mut std::ffi::c_void,
     mut dictBufferCapacity: size_t,
@@ -1256,7 +1256,7 @@ pub unsafe extern "C" fn ZDICT_trainFromBuffer_cover(
     COVER_map_destroy(&mut activeDmers);
     dictionarySize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(COVER_checkTotalCompressedSize)]
 pub unsafe extern "C" fn COVER_checkTotalCompressedSize(
     parameters: ZDICT_cover_params_t,
     mut samplesSizes: *const size_t,
@@ -1329,7 +1329,7 @@ pub unsafe extern "C" fn COVER_checkTotalCompressedSize(
     }
     totalCompressedSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(COVER_best_init)]
 pub unsafe extern "C" fn COVER_best_init(mut best: *mut COVER_best_t) {
     if best.is_null() {
         return;
@@ -1346,7 +1346,7 @@ pub unsafe extern "C" fn COVER_best_init(mut best: *mut COVER_best_t) {
         ::core::mem::size_of::<ZDICT_cover_params_t>() as std::ffi::c_ulong,
     );
 }
-#[no_mangle]
+#[export_name = crate::prefix!(COVER_best_wait)]
 pub unsafe extern "C" fn COVER_best_wait(mut best: *mut COVER_best_t) {
     if best.is_null() {
         return;
@@ -1357,7 +1357,7 @@ pub unsafe extern "C" fn COVER_best_wait(mut best: *mut COVER_best_t) {
     }
     pthread_mutex_unlock(&mut (*best).mutex);
 }
-#[no_mangle]
+#[export_name = crate::prefix!(COVER_best_destroy)]
 pub unsafe extern "C" fn COVER_best_destroy(mut best: *mut COVER_best_t) {
     if best.is_null() {
         return;
@@ -1369,7 +1369,7 @@ pub unsafe extern "C" fn COVER_best_destroy(mut best: *mut COVER_best_t) {
     pthread_mutex_destroy(&mut (*best).mutex);
     pthread_cond_destroy(&mut (*best).cond);
 }
-#[no_mangle]
+#[export_name = crate::prefix!(COVER_best_start)]
 pub unsafe extern "C" fn COVER_best_start(mut best: *mut COVER_best_t) {
     if best.is_null() {
         return;
@@ -1379,7 +1379,7 @@ pub unsafe extern "C" fn COVER_best_start(mut best: *mut COVER_best_t) {
     (*best).liveJobs;
     pthread_mutex_unlock(&mut (*best).mutex);
 }
-#[no_mangle]
+#[export_name = crate::prefix!(COVER_best_finish)]
 pub unsafe extern "C" fn COVER_best_finish(
     mut best: *mut COVER_best_t,
     mut parameters: ZDICT_cover_params_t,
@@ -1437,22 +1437,22 @@ unsafe extern "C" fn setDictSelection(
     ds.totalCompressedSize = csz;
     ds
 }
-#[no_mangle]
+#[export_name = crate::prefix!(COVER_dictSelectionError)]
 pub unsafe extern "C" fn COVER_dictSelectionError(mut error: size_t) -> COVER_dictSelection_t {
     setDictSelection(NULL as *mut u8, 0 as std::ffi::c_int as size_t, error)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(COVER_dictSelectionIsError)]
 pub unsafe extern "C" fn COVER_dictSelectionIsError(
     mut selection: COVER_dictSelection_t,
 ) -> std::ffi::c_uint {
     (ERR_isError(selection.totalCompressedSize) != 0 || (selection.dictContent).is_null())
         as std::ffi::c_int as std::ffi::c_uint
 }
-#[no_mangle]
+#[export_name = crate::prefix!(COVER_dictSelectionFree)]
 pub unsafe extern "C" fn COVER_dictSelectionFree(mut selection: COVER_dictSelection_t) {
     free(selection.dictContent as *mut std::ffi::c_void);
 }
-#[no_mangle]
+#[export_name = crate::prefix!(COVER_selectDict)]
 pub unsafe extern "C" fn COVER_selectDict(
     mut customDictContent: *mut u8,
     mut dictBufferCapacity: size_t,
@@ -1654,7 +1654,7 @@ unsafe extern "C" fn COVER_tryParameters(mut opaque: *mut std::ffi::c_void) {
     COVER_dictSelectionFree(selection);
     free(freqs as *mut std::ffi::c_void);
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZDICT_optimizeTrainFromBuffer_cover)]
 pub unsafe extern "C" fn ZDICT_optimizeTrainFromBuffer_cover(
     mut dictBuffer: *mut std::ffi::c_void,
     mut dictBufferCapacity: size_t,

--- a/lib/dictBuilder/divsufsort.rs
+++ b/lib/dictBuilder/divsufsort.rs
@@ -7009,7 +7009,7 @@ unsafe extern "C" fn construct_BWT_indexes(
     }
     orig.offset_from(SA) as std::ffi::c_long as std::ffi::c_int
 }
-#[no_mangle]
+#[export_name = crate::prefix!(divsufsort)]
 pub unsafe extern "C" fn divsufsort(
     mut T: *const std::ffi::c_uchar,
     mut SA: *mut std::ffi::c_int,
@@ -7053,7 +7053,7 @@ pub unsafe extern "C" fn divsufsort(
     free(bucket_A as *mut std::ffi::c_void);
     err
 }
-#[no_mangle]
+#[export_name = crate::prefix!(divbwt)]
 pub unsafe extern "C" fn divbwt(
     mut T: *const std::ffi::c_uchar,
     mut U: *mut std::ffi::c_uchar,

--- a/lib/dictBuilder/fastcover.rs
+++ b/lib/dictBuilder/fastcover.rs
@@ -930,7 +930,7 @@ unsafe extern "C" fn FASTCOVER_convertToFastCoverParams(
     (*fastCoverParams).zParams = coverParams.zParams;
     (*fastCoverParams).shrinkDict = coverParams.shrinkDict;
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZDICT_trainFromBuffer_fastCover)]
 pub unsafe extern "C" fn ZDICT_trainFromBuffer_fastCover(
     mut dictBuffer: *mut std::ffi::c_void,
     mut dictBufferCapacity: size_t,
@@ -1100,7 +1100,7 @@ pub unsafe extern "C" fn ZDICT_trainFromBuffer_fastCover(
     free(segmentFreqs as *mut std::ffi::c_void);
     dictionarySize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZDICT_optimizeTrainFromBuffer_fastCover)]
 pub unsafe extern "C" fn ZDICT_optimizeTrainFromBuffer_fastCover(
     mut dictBuffer: *mut std::ffi::c_void,
     mut dictBufferCapacity: size_t,

--- a/lib/dictBuilder/zdict.rs
+++ b/lib/dictBuilder/zdict.rs
@@ -796,15 +796,15 @@ unsafe extern "C" fn ZDICT_printHex(mut ptr: *const std::ffi::c_void, mut length
         u;
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZDICT_isError)]
 pub unsafe extern "C" fn ZDICT_isError(mut errorCode: size_t) -> std::ffi::c_uint {
     ERR_isError(errorCode)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZDICT_getErrorName)]
 pub unsafe extern "C" fn ZDICT_getErrorName(mut errorCode: size_t) -> *const std::ffi::c_char {
     ERR_getErrorName(errorCode)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZDICT_getDictID)]
 pub unsafe extern "C" fn ZDICT_getDictID(
     mut dictBuffer: *const std::ffi::c_void,
     mut dictSize: size_t,
@@ -820,7 +820,7 @@ pub unsafe extern "C" fn ZDICT_getDictID(
             as *const std::ffi::c_void,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZDICT_getDictHeaderSize)]
 pub unsafe extern "C" fn ZDICT_getDictHeaderSize(
     mut dictBuffer: *const std::ffi::c_void,
     mut dictSize: size_t,
@@ -2240,7 +2240,7 @@ unsafe extern "C" fn ZDICT_maxRep(mut reps: *const u32) -> u32 {
     }
     maxRep
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZDICT_finalizeDictionary)]
 pub unsafe extern "C" fn ZDICT_finalizeDictionary(
     mut dictBuffer: *mut std::ffi::c_void,
     mut dictBufferCapacity: size_t,
@@ -2704,7 +2704,7 @@ unsafe extern "C" fn ZDICT_trainFromBuffer_unsafe_legacy(
     free(dictList as *mut std::ffi::c_void);
     dictSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZDICT_trainFromBuffer_legacy)]
 pub unsafe extern "C" fn ZDICT_trainFromBuffer_legacy(
     mut dictBuffer: *mut std::ffi::c_void,
     mut dictBufferCapacity: size_t,
@@ -2739,7 +2739,7 @@ pub unsafe extern "C" fn ZDICT_trainFromBuffer_legacy(
     free(newBuff);
     result
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZDICT_trainFromBuffer)]
 pub unsafe extern "C" fn ZDICT_trainFromBuffer(
     mut dictBuffer: *mut std::ffi::c_void,
     mut dictBufferCapacity: size_t,
@@ -2780,7 +2780,7 @@ pub unsafe extern "C" fn ZDICT_trainFromBuffer(
         &mut params,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZDICT_addEntropyTablesFromBuffer)]
 pub unsafe extern "C" fn ZDICT_addEntropyTablesFromBuffer(
     mut dictBuffer: *mut std::ffi::c_void,
     mut dictContentSize: size_t,

--- a/lib/legacy/zstd_v05.rs
+++ b/lib/legacy/zstd_v05.rs
@@ -629,7 +629,7 @@ unsafe extern "C" fn FSEv05_tableStep(mut tableSize: u32) -> u32 {
         .wrapping_add(tableSize >> 3 as std::ffi::c_int)
         .wrapping_add(3 as std::ffi::c_int as u32)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv05_createDTable)]
 pub unsafe extern "C" fn FSEv05_createDTable(mut tableLog: std::ffi::c_uint) -> *mut FSEv05_DTable {
     if tableLog > FSEv05_TABLELOG_ABSOLUTE_MAX as std::ffi::c_uint {
         tableLog = FSEv05_TABLELOG_ABSOLUTE_MAX as std::ffi::c_uint;
@@ -639,11 +639,11 @@ pub unsafe extern "C" fn FSEv05_createDTable(mut tableLog: std::ffi::c_uint) -> 
             .wrapping_mul(::core::mem::size_of::<u32>() as std::ffi::c_ulong),
     ) as *mut FSEv05_DTable
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv05_freeDTable)]
 pub unsafe extern "C" fn FSEv05_freeDTable(mut dt: *mut FSEv05_DTable) {
     free(dt as *mut std::ffi::c_void);
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv05_buildDTable)]
 pub unsafe extern "C" fn FSEv05_buildDTable(
     mut dt: *mut FSEv05_DTable,
     mut normalizedCounter: *const std::ffi::c_short,
@@ -745,11 +745,11 @@ pub unsafe extern "C" fn FSEv05_buildDTable(
     );
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv05_isError)]
 pub unsafe extern "C" fn FSEv05_isError(mut code: size_t) -> std::ffi::c_uint {
     ERR_isError(code)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv05_getErrorName)]
 pub unsafe extern "C" fn FSEv05_getErrorName(mut code: size_t) -> *const std::ffi::c_char {
     ERR_getErrorName(code)
 }
@@ -760,7 +760,7 @@ unsafe extern "C" fn FSEv05_abs(mut a: std::ffi::c_short) -> std::ffi::c_short {
         a as std::ffi::c_int
     }) as std::ffi::c_short
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv05_readNCount)]
 pub unsafe extern "C" fn FSEv05_readNCount(
     mut normalizedCounter: *mut std::ffi::c_short,
     mut maxSVPtr: *mut std::ffi::c_uint,
@@ -887,7 +887,7 @@ pub unsafe extern "C" fn FSEv05_readNCount(
     }
     ip.offset_from(istart) as std::ffi::c_long as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv05_buildDTable_rle)]
 pub unsafe extern "C" fn FSEv05_buildDTable_rle(
     mut dt: *mut FSEv05_DTable,
     mut symbolValue: u8,
@@ -903,7 +903,7 @@ pub unsafe extern "C" fn FSEv05_buildDTable_rle(
     (*cell).nbBits = 0 as std::ffi::c_int as std::ffi::c_uchar;
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv05_buildDTable_raw)]
 pub unsafe extern "C" fn FSEv05_buildDTable_raw(
     mut dt: *mut FSEv05_DTable,
     mut nbBits: std::ffi::c_uint,
@@ -1052,7 +1052,7 @@ unsafe extern "C" fn FSEv05_decompress_usingDTable_generic(
     }
     -(ZSTD_error_corruption_detected as std::ffi::c_int) as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv05_decompress_usingDTable)]
 pub unsafe extern "C" fn FSEv05_decompress_usingDTable(
     mut dst: *mut std::ffi::c_void,
     mut originalSize: size_t,
@@ -1082,7 +1082,7 @@ pub unsafe extern "C" fn FSEv05_decompress_usingDTable(
         0 as std::ffi::c_int as std::ffi::c_uint,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv05_decompress)]
 pub unsafe extern "C" fn FSEv05_decompress(
     mut dst: *mut std::ffi::c_void,
     mut maxDstSize: size_t,
@@ -1134,11 +1134,11 @@ pub unsafe extern "C" fn FSEv05_decompress(
 pub const HUFv05_ABSOLUTEMAX_TABLELOG: std::ffi::c_int = 16 as std::ffi::c_int;
 pub const HUFv05_MAX_TABLELOG: std::ffi::c_int = 12 as std::ffi::c_int;
 pub const HUFv05_MAX_SYMBOL_VALUE: std::ffi::c_int = 255 as std::ffi::c_int;
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv05_isError)]
 pub unsafe extern "C" fn HUFv05_isError(mut code: size_t) -> std::ffi::c_uint {
     ERR_isError(code)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv05_getErrorName)]
 pub unsafe extern "C" fn HUFv05_getErrorName(mut code: size_t) -> *const std::ffi::c_char {
     ERR_getErrorName(code)
 }
@@ -1276,7 +1276,7 @@ unsafe extern "C" fn HUFv05_readStats(
     *tableLogPtr = tableLog;
     iSize.wrapping_add(1 as std::ffi::c_int as size_t)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv05_readDTableX2)]
 pub unsafe extern "C" fn HUFv05_readDTableX2(
     mut DTable: *mut u16,
     mut src: *const std::ffi::c_void,
@@ -1398,7 +1398,7 @@ unsafe extern "C" fn HUFv05_decodeStreamX2(
     }
     pEnd.offset_from(pStart) as std::ffi::c_long as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv05_decompress1X2_usingDTable)]
 pub unsafe extern "C" fn HUFv05_decompress1X2_usingDTable(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -1430,7 +1430,7 @@ pub unsafe extern "C" fn HUFv05_decompress1X2_usingDTable(
     }
     dstSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv05_decompress1X2)]
 pub unsafe extern "C" fn HUFv05_decompress1X2(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -1458,7 +1458,7 @@ pub unsafe extern "C" fn HUFv05_decompress1X2(
         DTable.as_mut_ptr(),
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv05_decompress4X2_usingDTable)]
 pub unsafe extern "C" fn HUFv05_decompress4X2_usingDTable(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -1653,7 +1653,7 @@ pub unsafe extern "C" fn HUFv05_decompress4X2_usingDTable(
     }
     dstSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv05_decompress4X2)]
 pub unsafe extern "C" fn HUFv05_decompress4X2(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -1820,7 +1820,7 @@ unsafe extern "C" fn HUFv05_fillDTableX4(
         s;
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv05_readDTableX4)]
 pub unsafe extern "C" fn HUFv05_readDTableX4(
     mut DTable: *mut std::ffi::c_uint,
     mut src: *const std::ffi::c_void,
@@ -2032,7 +2032,7 @@ unsafe extern "C" fn HUFv05_decodeStreamX4(
     }
     p.offset_from(pStart) as std::ffi::c_long as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv05_decompress1X4_usingDTable)]
 pub unsafe extern "C" fn HUFv05_decompress1X4_usingDTable(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -2063,7 +2063,7 @@ pub unsafe extern "C" fn HUFv05_decompress1X4_usingDTable(
     }
     dstSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv05_decompress1X4)]
 pub unsafe extern "C" fn HUFv05_decompress1X4(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -2089,7 +2089,7 @@ pub unsafe extern "C" fn HUFv05_decompress1X4(
         DTable.as_mut_ptr(),
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv05_decompress4X4_usingDTable)]
 pub unsafe extern "C" fn HUFv05_decompress4X4_usingDTable(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -2320,7 +2320,7 @@ pub unsafe extern "C" fn HUFv05_decompress4X4_usingDTable(
     }
     dstSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv05_decompress4X4)]
 pub unsafe extern "C" fn HUFv05_decompress4X4(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -2668,7 +2668,7 @@ static mut algoTime: [[algo_time_t; 3]; 16] = [
         },
     ],
 ];
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv05_decompress)]
 pub unsafe extern "C" fn HUFv05_decompress(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -2751,19 +2751,19 @@ unsafe extern "C" fn ZSTDv05_copy4(
 ) {
     memcpy(dst, src, 4 as std::ffi::c_int as std::ffi::c_ulong);
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv05_isError)]
 pub unsafe extern "C" fn ZSTDv05_isError(mut code: size_t) -> std::ffi::c_uint {
     ERR_isError(code)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv05_getErrorName)]
 pub unsafe extern "C" fn ZSTDv05_getErrorName(mut code: size_t) -> *const std::ffi::c_char {
     ERR_getErrorName(code)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv05_sizeofDCtx)]
 pub unsafe extern "C" fn ZSTDv05_sizeofDCtx() -> size_t {
     ::core::mem::size_of::<ZSTDv05_DCtx>() as std::ffi::c_ulong
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv05_decompressBegin)]
 pub unsafe extern "C" fn ZSTDv05_decompressBegin(mut dctx: *mut ZSTDv05_DCtx) -> size_t {
     (*dctx).expected = ZSTDv05_frameHeaderSize_min;
     (*dctx).stage = ZSTDv05ds_getFrameHeaderSize;
@@ -2777,7 +2777,7 @@ pub unsafe extern "C" fn ZSTDv05_decompressBegin(mut dctx: *mut ZSTDv05_DCtx) ->
     (*dctx).flagStaticTables = 0 as std::ffi::c_int as u32;
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv05_createDCtx)]
 pub unsafe extern "C" fn ZSTDv05_createDCtx() -> *mut ZSTDv05_DCtx {
     let mut dctx =
         malloc(::core::mem::size_of::<ZSTDv05_DCtx>() as std::ffi::c_ulong) as *mut ZSTDv05_DCtx;
@@ -2787,12 +2787,12 @@ pub unsafe extern "C" fn ZSTDv05_createDCtx() -> *mut ZSTDv05_DCtx {
     ZSTDv05_decompressBegin(dctx);
     dctx
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv05_freeDCtx)]
 pub unsafe extern "C" fn ZSTDv05_freeDCtx(mut dctx: *mut ZSTDv05_DCtx) -> size_t {
     free(dctx as *mut std::ffi::c_void);
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv05_copyDCtx)]
 pub unsafe extern "C" fn ZSTDv05_copyDCtx(
     mut dstDCtx: *mut ZSTDv05_DCtx,
     mut srcDCtx: *const ZSTDv05_DCtx,
@@ -2821,7 +2821,7 @@ unsafe extern "C" fn ZSTDv05_decodeFrameHeader_Part1(
     (*zc).headerSize = ZSTDv05_frameHeaderSize_min;
     (*zc).headerSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv05_getFrameParams)]
 pub unsafe extern "C" fn ZSTDv05_getFrameParams(
     mut params: *mut ZSTDv05_parameters,
     mut src: *const std::ffi::c_void,
@@ -3799,7 +3799,7 @@ unsafe extern "C" fn ZSTDv05_decompressBlock_internal(
         srcSize,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv05_decompressBlock)]
 pub unsafe extern "C" fn ZSTDv05_decompressBlock(
     mut dctx: *mut ZSTDv05_DCtx,
     mut dst: *mut std::ffi::c_void,
@@ -3902,7 +3902,7 @@ unsafe extern "C" fn ZSTDv05_decompress_continueDCtx(
     }
     op.offset_from(ostart) as std::ffi::c_long as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv05_decompress_usingPreparedDCtx)]
 pub unsafe extern "C" fn ZSTDv05_decompress_usingPreparedDCtx(
     mut dctx: *mut ZSTDv05_DCtx,
     mut refDCtx: *const ZSTDv05_DCtx,
@@ -3915,7 +3915,7 @@ pub unsafe extern "C" fn ZSTDv05_decompress_usingPreparedDCtx(
     ZSTDv05_checkContinuity(dctx, dst);
     ZSTDv05_decompress_continueDCtx(dctx, dst, maxDstSize, src, srcSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv05_decompress_usingDict)]
 pub unsafe extern "C" fn ZSTDv05_decompress_usingDict(
     mut dctx: *mut ZSTDv05_DCtx,
     mut dst: *mut std::ffi::c_void,
@@ -3929,7 +3929,7 @@ pub unsafe extern "C" fn ZSTDv05_decompress_usingDict(
     ZSTDv05_checkContinuity(dctx, dst);
     ZSTDv05_decompress_continueDCtx(dctx, dst, maxDstSize, src, srcSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv05_decompressDCtx)]
 pub unsafe extern "C" fn ZSTDv05_decompressDCtx(
     mut dctx: *mut ZSTDv05_DCtx,
     mut dst: *mut std::ffi::c_void,
@@ -3947,7 +3947,7 @@ pub unsafe extern "C" fn ZSTDv05_decompressDCtx(
         0 as std::ffi::c_int as size_t,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv05_decompress)]
 pub unsafe extern "C" fn ZSTDv05_decompress(
     mut dst: *mut std::ffi::c_void,
     mut maxDstSize: size_t,
@@ -3971,7 +3971,7 @@ unsafe extern "C" fn ZSTD_errorFrameSizeInfoLegacy(
     *cSize = ret;
     *dBound = ZSTD_CONTENTSIZE_ERROR;
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv05_findFrameSizeInfoLegacy)]
 pub unsafe extern "C" fn ZSTDv05_findFrameSizeInfoLegacy(
     mut src: *const std::ffi::c_void,
     mut srcSize: size_t,
@@ -4034,11 +4034,11 @@ pub unsafe extern "C" fn ZSTDv05_findFrameSizeInfoLegacy(
     *cSize = ip.offset_from(src as *const u8) as std::ffi::c_long as size_t;
     *dBound = (nbBlocks * BLOCKSIZE as size_t) as std::ffi::c_ulonglong;
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv05_nextSrcSizeToDecompress)]
 pub unsafe extern "C" fn ZSTDv05_nextSrcSizeToDecompress(mut dctx: *mut ZSTDv05_DCtx) -> size_t {
     (*dctx).expected
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv05_decompressContinue)]
 pub unsafe extern "C" fn ZSTDv05_decompressContinue(
     mut dctx: *mut ZSTDv05_DCtx,
     mut dst: *mut std::ffi::c_void,
@@ -4269,7 +4269,7 @@ unsafe extern "C" fn ZSTDv05_decompress_insertDictionary(
     ZSTDv05_refDictContent(dctx, dict, dictSize);
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv05_decompressBegin_usingDict)]
 pub unsafe extern "C" fn ZSTDv05_decompressBegin_usingDict(
     mut dctx: *mut ZSTDv05_DCtx,
     mut dict: *const std::ffi::c_void,
@@ -4306,7 +4306,7 @@ unsafe extern "C" fn ZBUFFv05_limitCopy(
     length
 }
 pub const ZSTDv05_frameHeaderSize_max_0: std::ffi::c_int = 5 as std::ffi::c_int;
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv05_createDCtx)]
 pub unsafe extern "C" fn ZBUFFv05_createDCtx() -> *mut ZBUFFv05_DCtx {
     let mut zbc =
         malloc(::core::mem::size_of::<ZBUFFv05_DCtx>() as std::ffi::c_ulong) as *mut ZBUFFv05_DCtx;
@@ -4322,7 +4322,7 @@ pub unsafe extern "C" fn ZBUFFv05_createDCtx() -> *mut ZBUFFv05_DCtx {
     (*zbc).stage = ZBUFFv05ds_init;
     zbc
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv05_freeDCtx)]
 pub unsafe extern "C" fn ZBUFFv05_freeDCtx(mut zbc: *mut ZBUFFv05_DCtx) -> size_t {
     if zbc.is_null() {
         return 0 as std::ffi::c_int as size_t;
@@ -4333,7 +4333,7 @@ pub unsafe extern "C" fn ZBUFFv05_freeDCtx(mut zbc: *mut ZBUFFv05_DCtx) -> size_
     free(zbc as *mut std::ffi::c_void);
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv05_decompressInitDictionary)]
 pub unsafe extern "C" fn ZBUFFv05_decompressInitDictionary(
     mut zbc: *mut ZBUFFv05_DCtx,
     mut dict: *const std::ffi::c_void,
@@ -4346,7 +4346,7 @@ pub unsafe extern "C" fn ZBUFFv05_decompressInitDictionary(
     (*zbc).hPos = (*zbc).inPos;
     ZSTDv05_decompressBegin_usingDict((*zbc).zc, dict, dictSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv05_decompressInit)]
 pub unsafe extern "C" fn ZBUFFv05_decompressInit(mut zbc: *mut ZBUFFv05_DCtx) -> size_t {
     ZBUFFv05_decompressInitDictionary(
         zbc,
@@ -4354,7 +4354,7 @@ pub unsafe extern "C" fn ZBUFFv05_decompressInit(mut zbc: *mut ZBUFFv05_DCtx) ->
         0 as std::ffi::c_int as size_t,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv05_decompressContinue)]
 pub unsafe extern "C" fn ZBUFFv05_decompressContinue(
     mut zbc: *mut ZBUFFv05_DCtx,
     mut dst: *mut std::ffi::c_void,
@@ -4571,19 +4571,19 @@ pub unsafe extern "C" fn ZBUFFv05_decompressContinue(
     nextSrcSizeHint = nextSrcSizeHint.wrapping_sub((*zbc).inPos);
     nextSrcSizeHint
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv05_isError)]
 pub unsafe extern "C" fn ZBUFFv05_isError(mut errorCode: size_t) -> std::ffi::c_uint {
     ERR_isError(errorCode)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv05_getErrorName)]
 pub unsafe extern "C" fn ZBUFFv05_getErrorName(mut errorCode: size_t) -> *const std::ffi::c_char {
     ERR_getErrorName(errorCode)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv05_recommendedDInSize)]
 pub unsafe extern "C" fn ZBUFFv05_recommendedDInSize() -> size_t {
     (BLOCKSIZE as size_t).wrapping_add(ZBUFFv05_blockHeaderSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv05_recommendedDOutSize)]
 pub unsafe extern "C" fn ZBUFFv05_recommendedDOutSize() -> size_t {
     BLOCKSIZE as size_t
 }

--- a/lib/legacy/zstd_v06.rs
+++ b/lib/legacy/zstd_v06.rs
@@ -886,7 +886,7 @@ pub const FSEv06_TABLELOG_ABSOLUTE_MAX: std::ffi::c_int = 15 as std::ffi::c_int;
 pub unsafe extern "C" fn FSEv06_isError_1(mut code: size_t) -> std::ffi::c_uint {
     ERR_isError(code)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv06_getErrorName)]
 pub unsafe extern "C" fn FSEv06_getErrorName(mut code: size_t) -> *const std::ffi::c_char {
     ERR_getErrorName(code)
 }
@@ -900,7 +900,7 @@ unsafe extern "C" fn FSEv06_abs(mut a: std::ffi::c_short) -> std::ffi::c_short {
         a as std::ffi::c_int
     }) as std::ffi::c_short
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv06_readNCount)]
 pub unsafe extern "C" fn FSEv06_readNCount(
     mut normalizedCounter: *mut std::ffi::c_short,
     mut maxSVPtr: *mut std::ffi::c_uint,
@@ -1028,7 +1028,7 @@ pub unsafe extern "C" fn FSEv06_readNCount(
     ip.offset_from(istart) as std::ffi::c_long as size_t
 }
 pub const FSEv06_isError_0: unsafe extern "C" fn(size_t) -> std::ffi::c_uint = ERR_isError;
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv06_createDTable)]
 pub unsafe extern "C" fn FSEv06_createDTable(mut tableLog: std::ffi::c_uint) -> *mut FSEv06_DTable {
     if tableLog > FSEv06_TABLELOG_ABSOLUTE_MAX as std::ffi::c_uint {
         tableLog = FSEv06_TABLELOG_ABSOLUTE_MAX as std::ffi::c_uint;
@@ -1038,11 +1038,11 @@ pub unsafe extern "C" fn FSEv06_createDTable(mut tableLog: std::ffi::c_uint) -> 
             .wrapping_mul(::core::mem::size_of::<u32>() as std::ffi::c_ulong),
     ) as *mut FSEv06_DTable
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv06_freeDTable)]
 pub unsafe extern "C" fn FSEv06_freeDTable(mut dt: *mut FSEv06_DTable) {
     free(dt as *mut std::ffi::c_void);
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv06_buildDTable)]
 pub unsafe extern "C" fn FSEv06_buildDTable(
     mut dt: *mut FSEv06_DTable,
     mut normalizedCounter: *const std::ffi::c_short,
@@ -1139,7 +1139,7 @@ pub unsafe extern "C" fn FSEv06_buildDTable(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv06_buildDTable_rle)]
 pub unsafe extern "C" fn FSEv06_buildDTable_rle(
     mut dt: *mut FSEv06_DTable,
     mut symbolValue: u8,
@@ -1155,7 +1155,7 @@ pub unsafe extern "C" fn FSEv06_buildDTable_rle(
     (*cell).nbBits = 0 as std::ffi::c_int as std::ffi::c_uchar;
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv06_buildDTable_raw)]
 pub unsafe extern "C" fn FSEv06_buildDTable_raw(
     mut dt: *mut FSEv06_DTable,
     mut nbBits: std::ffi::c_uint,
@@ -1313,7 +1313,7 @@ unsafe extern "C" fn FSEv06_decompress_usingDTable_generic(
     }
     op.offset_from(ostart) as std::ffi::c_long as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv06_decompress_usingDTable)]
 pub unsafe extern "C" fn FSEv06_decompress_usingDTable(
     mut dst: *mut std::ffi::c_void,
     mut originalSize: size_t,
@@ -1343,7 +1343,7 @@ pub unsafe extern "C" fn FSEv06_decompress_usingDTable(
         0 as std::ffi::c_int as std::ffi::c_uint,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv06_decompress)]
 pub unsafe extern "C" fn FSEv06_decompress(
     mut dst: *mut std::ffi::c_void,
     mut maxDstSize: size_t,
@@ -1529,7 +1529,7 @@ unsafe extern "C" fn HUFv06_readStats(
     *nbSymbolsPtr = oSize.wrapping_add(1 as std::ffi::c_int as size_t) as u32;
     iSize.wrapping_add(1 as std::ffi::c_int as size_t)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv06_readDTableX2)]
 pub unsafe extern "C" fn HUFv06_readDTableX2(
     mut DTable: *mut u16,
     mut src: *const std::ffi::c_void,
@@ -1651,7 +1651,7 @@ unsafe extern "C" fn HUFv06_decodeStreamX2(
     }
     pEnd.offset_from(pStart) as std::ffi::c_long as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv06_decompress1X2_usingDTable)]
 pub unsafe extern "C" fn HUFv06_decompress1X2_usingDTable(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -1680,7 +1680,7 @@ pub unsafe extern "C" fn HUFv06_decompress1X2_usingDTable(
     }
     dstSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv06_decompress1X2)]
 pub unsafe extern "C" fn HUFv06_decompress1X2(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -1707,7 +1707,7 @@ pub unsafe extern "C" fn HUFv06_decompress1X2(
         DTable.as_mut_ptr(),
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv06_decompress4X2_usingDTable)]
 pub unsafe extern "C" fn HUFv06_decompress4X2_usingDTable(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -1902,7 +1902,7 @@ pub unsafe extern "C" fn HUFv06_decompress4X2_usingDTable(
     }
     dstSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv06_decompress4X2)]
 pub unsafe extern "C" fn HUFv06_decompress4X2(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -2068,7 +2068,7 @@ unsafe extern "C" fn HUFv06_fillDTableX4(
         s;
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv06_readDTableX4)]
 pub unsafe extern "C" fn HUFv06_readDTableX4(
     mut DTable: *mut u32,
     mut src: *const std::ffi::c_void,
@@ -2285,7 +2285,7 @@ unsafe extern "C" fn HUFv06_decodeStreamX4(
     }
     p.offset_from(pStart) as std::ffi::c_long as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv06_decompress1X4_usingDTable)]
 pub unsafe extern "C" fn HUFv06_decompress1X4_usingDTable(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -2315,7 +2315,7 @@ pub unsafe extern "C" fn HUFv06_decompress1X4_usingDTable(
     }
     dstSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv06_decompress1X4)]
 pub unsafe extern "C" fn HUFv06_decompress1X4(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -2341,7 +2341,7 @@ pub unsafe extern "C" fn HUFv06_decompress1X4(
         DTable.as_mut_ptr(),
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv06_decompress4X4_usingDTable)]
 pub unsafe extern "C" fn HUFv06_decompress4X4_usingDTable(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -2572,7 +2572,7 @@ pub unsafe extern "C" fn HUFv06_decompress4X4_usingDTable(
     }
     dstSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv06_decompress4X4)]
 pub unsafe extern "C" fn HUFv06_decompress4X4(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -2920,7 +2920,7 @@ static mut algoTime: [[algo_time_t; 3]; 16] = [
         },
     ],
 ];
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv06_decompress)]
 pub unsafe extern "C" fn HUFv06_decompress(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -3004,15 +3004,15 @@ pub unsafe extern "C" fn HUFv06_decompress(
 pub unsafe extern "C" fn ZSTDv06_isError_0(mut code: size_t) -> std::ffi::c_uint {
     ERR_isError(code)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv06_getErrorName)]
 pub unsafe extern "C" fn ZSTDv06_getErrorName(mut code: size_t) -> *const std::ffi::c_char {
     ERR_getErrorName(code)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv06_isError)]
 pub unsafe extern "C" fn ZBUFFv06_isError(mut errorCode: size_t) -> std::ffi::c_uint {
     ERR_isError(errorCode)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv06_getErrorName)]
 pub unsafe extern "C" fn ZBUFFv06_getErrorName(mut errorCode: size_t) -> *const std::ffi::c_char {
     ERR_getErrorName(errorCode)
 }
@@ -3025,11 +3025,11 @@ unsafe extern "C" fn ZSTDv06_copy4(
 ) {
     memcpy(dst, src, 4 as std::ffi::c_int as std::ffi::c_ulong);
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv06_sizeofDCtx)]
 pub unsafe extern "C" fn ZSTDv06_sizeofDCtx() -> size_t {
     ::core::mem::size_of::<ZSTDv06_DCtx>() as std::ffi::c_ulong
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv06_decompressBegin)]
 pub unsafe extern "C" fn ZSTDv06_decompressBegin(mut dctx: *mut ZSTDv06_DCtx) -> size_t {
     (*dctx).expected = ZSTDv06_frameHeaderSize_min;
     (*dctx).stage = ZSTDds_getFrameHeaderSize;
@@ -3043,7 +3043,7 @@ pub unsafe extern "C" fn ZSTDv06_decompressBegin(mut dctx: *mut ZSTDv06_DCtx) ->
     (*dctx).flagRepeatTable = 0 as std::ffi::c_int as u32;
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv06_createDCtx)]
 pub unsafe extern "C" fn ZSTDv06_createDCtx() -> *mut ZSTDv06_DCtx {
     let mut dctx =
         malloc(::core::mem::size_of::<ZSTDv06_DCtx>() as std::ffi::c_ulong) as *mut ZSTDv06_DCtx;
@@ -3053,12 +3053,12 @@ pub unsafe extern "C" fn ZSTDv06_createDCtx() -> *mut ZSTDv06_DCtx {
     ZSTDv06_decompressBegin(dctx);
     dctx
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv06_freeDCtx)]
 pub unsafe extern "C" fn ZSTDv06_freeDCtx(mut dctx: *mut ZSTDv06_DCtx) -> size_t {
     free(dctx as *mut std::ffi::c_void);
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv06_copyDCtx)]
 pub unsafe extern "C" fn ZSTDv06_copyDCtx(
     mut dstDCtx: *mut ZSTDv06_DCtx,
     mut srcDCtx: *const ZSTDv06_DCtx,
@@ -3083,7 +3083,7 @@ unsafe extern "C" fn ZSTDv06_frameHeaderSize(
         >> 6 as std::ffi::c_int) as u32;
     ZSTDv06_frameHeaderSize_min.wrapping_add(*ZSTDv06_fcs_fieldSize.as_ptr().offset(fcsId as isize))
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv06_getFrameParams)]
 pub unsafe extern "C" fn ZSTDv06_getFrameParams(
     mut fparamsPtr: *mut ZSTDv06_frameParams,
     mut src: *const std::ffi::c_void,
@@ -4131,7 +4131,7 @@ unsafe extern "C" fn ZSTDv06_decompressBlock_internal(
         srcSize,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv06_decompressBlock)]
 pub unsafe extern "C" fn ZSTDv06_decompressBlock(
     mut dctx: *mut ZSTDv06_DCtx,
     mut dst: *mut std::ffi::c_void,
@@ -4229,7 +4229,7 @@ unsafe extern "C" fn ZSTDv06_decompressFrame(
     }
     op.offset_from(ostart) as std::ffi::c_long as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv06_decompress_usingPreparedDCtx)]
 pub unsafe extern "C" fn ZSTDv06_decompress_usingPreparedDCtx(
     mut dctx: *mut ZSTDv06_DCtx,
     mut refDCtx: *const ZSTDv06_DCtx,
@@ -4242,7 +4242,7 @@ pub unsafe extern "C" fn ZSTDv06_decompress_usingPreparedDCtx(
     ZSTDv06_checkContinuity(dctx, dst);
     ZSTDv06_decompressFrame(dctx, dst, dstCapacity, src, srcSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv06_decompress_usingDict)]
 pub unsafe extern "C" fn ZSTDv06_decompress_usingDict(
     mut dctx: *mut ZSTDv06_DCtx,
     mut dst: *mut std::ffi::c_void,
@@ -4256,7 +4256,7 @@ pub unsafe extern "C" fn ZSTDv06_decompress_usingDict(
     ZSTDv06_checkContinuity(dctx, dst);
     ZSTDv06_decompressFrame(dctx, dst, dstCapacity, src, srcSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv06_decompressDCtx)]
 pub unsafe extern "C" fn ZSTDv06_decompressDCtx(
     mut dctx: *mut ZSTDv06_DCtx,
     mut dst: *mut std::ffi::c_void,
@@ -4274,7 +4274,7 @@ pub unsafe extern "C" fn ZSTDv06_decompressDCtx(
         0 as std::ffi::c_int as size_t,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv06_decompress)]
 pub unsafe extern "C" fn ZSTDv06_decompress(
     mut dst: *mut std::ffi::c_void,
     mut dstCapacity: size_t,
@@ -4298,7 +4298,7 @@ unsafe extern "C" fn ZSTD_errorFrameSizeInfoLegacy(
     *cSize = ret;
     *dBound = ZSTD_CONTENTSIZE_ERROR;
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv06_findFrameSizeInfoLegacy)]
 pub unsafe extern "C" fn ZSTDv06_findFrameSizeInfoLegacy(
     mut src: *const std::ffi::c_void,
     mut srcSize: size_t,
@@ -4368,11 +4368,11 @@ pub unsafe extern "C" fn ZSTDv06_findFrameSizeInfoLegacy(
     *cSize = ip.offset_from(src as *const u8) as std::ffi::c_long as size_t;
     *dBound = (nbBlocks * ZSTDv06_BLOCKSIZE_MAX as size_t) as std::ffi::c_ulonglong;
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv06_nextSrcSizeToDecompress)]
 pub unsafe extern "C" fn ZSTDv06_nextSrcSizeToDecompress(mut dctx: *mut ZSTDv06_DCtx) -> size_t {
     (*dctx).expected
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv06_decompressContinue)]
 pub unsafe extern "C" fn ZSTDv06_decompressContinue(
     mut dctx: *mut ZSTDv06_DCtx,
     mut dst: *mut std::ffi::c_void,
@@ -4613,7 +4613,7 @@ unsafe extern "C" fn ZSTDv06_decompress_insertDictionary(
     ZSTDv06_refDictContent(dctx, dict, dictSize);
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv06_decompressBegin_usingDict)]
 pub unsafe extern "C" fn ZSTDv06_decompressBegin_usingDict(
     mut dctx: *mut ZSTDv06_DCtx,
     mut dict: *const std::ffi::c_void,
@@ -4631,7 +4631,7 @@ pub unsafe extern "C" fn ZSTDv06_decompressBegin_usingDict(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv06_createDCtx)]
 pub unsafe extern "C" fn ZBUFFv06_createDCtx() -> *mut ZBUFFv06_DCtx {
     let mut zbd =
         malloc(::core::mem::size_of::<ZBUFFv06_DCtx>() as std::ffi::c_ulong) as *mut ZBUFFv06_DCtx;
@@ -4651,7 +4651,7 @@ pub unsafe extern "C" fn ZBUFFv06_createDCtx() -> *mut ZBUFFv06_DCtx {
     (*zbd).stage = ZBUFFds_init;
     zbd
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv06_freeDCtx)]
 pub unsafe extern "C" fn ZBUFFv06_freeDCtx(mut zbd: *mut ZBUFFv06_DCtx) -> size_t {
     if zbd.is_null() {
         return 0 as std::ffi::c_int as size_t;
@@ -4662,7 +4662,7 @@ pub unsafe extern "C" fn ZBUFFv06_freeDCtx(mut zbd: *mut ZBUFFv06_DCtx) -> size_
     free(zbd as *mut std::ffi::c_void);
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv06_decompressInitDictionary)]
 pub unsafe extern "C" fn ZBUFFv06_decompressInitDictionary(
     mut zbd: *mut ZBUFFv06_DCtx,
     mut dict: *const std::ffi::c_void,
@@ -4675,7 +4675,7 @@ pub unsafe extern "C" fn ZBUFFv06_decompressInitDictionary(
     (*zbd).lhSize = (*zbd).inPos;
     ZSTDv06_decompressBegin_usingDict((*zbd).zd, dict, dictSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv06_decompressInit)]
 pub unsafe extern "C" fn ZBUFFv06_decompressInit(mut zbd: *mut ZBUFFv06_DCtx) -> size_t {
     ZBUFFv06_decompressInitDictionary(
         zbd,
@@ -4700,7 +4700,7 @@ unsafe extern "C" fn ZBUFFv06_limitCopy(
     }
     length
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv06_decompressContinue)]
 pub unsafe extern "C" fn ZBUFFv06_decompressContinue(
     mut zbd: *mut ZBUFFv06_DCtx,
     mut dst: *mut std::ffi::c_void,
@@ -4931,11 +4931,11 @@ pub unsafe extern "C" fn ZBUFFv06_decompressContinue(
     nextSrcSizeHint = nextSrcSizeHint.wrapping_sub((*zbd).inPos);
     nextSrcSizeHint
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv06_recommendedDInSize)]
 pub unsafe extern "C" fn ZBUFFv06_recommendedDInSize() -> size_t {
     (ZSTDv06_BLOCKSIZE_MAX as size_t).wrapping_add(ZSTDv06_blockHeaderSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv06_recommendedDOutSize)]
 pub unsafe extern "C" fn ZBUFFv06_recommendedDOutSize() -> size_t {
     ZSTDv06_BLOCKSIZE_MAX as size_t
 }

--- a/lib/legacy/zstd_v07.rs
+++ b/lib/legacy/zstd_v07.rs
@@ -680,15 +680,15 @@ pub const HUFv07_SYMBOLVALUE_MAX: std::ffi::c_int = 255 as std::ffi::c_int;
 pub unsafe extern "C" fn FSEv07_isError_0(mut code: size_t) -> std::ffi::c_uint {
     ERR_isError(code)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv07_getErrorName)]
 pub unsafe extern "C" fn FSEv07_getErrorName(mut code: size_t) -> *const std::ffi::c_char {
     ERR_getErrorName(code)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv07_isError)]
 pub unsafe extern "C" fn HUFv07_isError(mut code: size_t) -> std::ffi::c_uint {
     ERR_isError(code)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv07_getErrorName)]
 pub unsafe extern "C" fn HUFv07_getErrorName(mut code: size_t) -> *const std::ffi::c_char {
     ERR_getErrorName(code)
 }
@@ -699,7 +699,7 @@ unsafe extern "C" fn FSEv07_abs(mut a: std::ffi::c_short) -> std::ffi::c_short {
         a as std::ffi::c_int
     }) as std::ffi::c_short
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv07_readNCount)]
 pub unsafe extern "C" fn FSEv07_readNCount(
     mut normalizedCounter: *mut std::ffi::c_short,
     mut maxSVPtr: *mut std::ffi::c_uint,
@@ -826,7 +826,7 @@ pub unsafe extern "C" fn FSEv07_readNCount(
     }
     ip.offset_from(istart) as std::ffi::c_long as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv07_readStats)]
 pub unsafe extern "C" fn HUFv07_readStats(
     mut huffWeight: *mut BYTE,
     mut hwSize: size_t,
@@ -962,7 +962,7 @@ pub unsafe extern "C" fn HUFv07_readStats(
     iSize.wrapping_add(1 as std::ffi::c_int as size_t)
 }
 pub const FSEv07_isError_1: unsafe extern "C" fn(size_t) -> std::ffi::c_uint = ERR_isError;
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv07_createDTable)]
 pub unsafe extern "C" fn FSEv07_createDTable(mut tableLog: std::ffi::c_uint) -> *mut FSEv07_DTable {
     if tableLog > FSEv07_TABLELOG_ABSOLUTE_MAX as std::ffi::c_uint {
         tableLog = FSEv07_TABLELOG_ABSOLUTE_MAX as std::ffi::c_uint;
@@ -972,11 +972,11 @@ pub unsafe extern "C" fn FSEv07_createDTable(mut tableLog: std::ffi::c_uint) -> 
             .wrapping_mul(::core::mem::size_of::<U32>() as std::ffi::c_ulong),
     ) as *mut FSEv07_DTable
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv07_freeDTable)]
 pub unsafe extern "C" fn FSEv07_freeDTable(mut dt: *mut FSEv07_DTable) {
     free(dt as *mut std::ffi::c_void);
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv07_buildDTable)]
 pub unsafe extern "C" fn FSEv07_buildDTable(
     mut dt: *mut FSEv07_DTable,
     mut normalizedCounter: *const std::ffi::c_short,
@@ -1073,7 +1073,7 @@ pub unsafe extern "C" fn FSEv07_buildDTable(
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv07_buildDTable_rle)]
 pub unsafe extern "C" fn FSEv07_buildDTable_rle(
     mut dt: *mut FSEv07_DTable,
     mut symbolValue: BYTE,
@@ -1089,7 +1089,7 @@ pub unsafe extern "C" fn FSEv07_buildDTable_rle(
     (*cell).nbBits = 0 as std::ffi::c_int as std::ffi::c_uchar;
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv07_buildDTable_raw)]
 pub unsafe extern "C" fn FSEv07_buildDTable_raw(
     mut dt: *mut FSEv07_DTable,
     mut nbBits: std::ffi::c_uint,
@@ -1247,7 +1247,7 @@ unsafe extern "C" fn FSEv07_decompress_usingDTable_generic(
     }
     op.offset_from(ostart) as std::ffi::c_long as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv07_decompress_usingDTable)]
 pub unsafe extern "C" fn FSEv07_decompress_usingDTable(
     mut dst: *mut std::ffi::c_void,
     mut originalSize: size_t,
@@ -1277,7 +1277,7 @@ pub unsafe extern "C" fn FSEv07_decompress_usingDTable(
         0 as std::ffi::c_int as std::ffi::c_uint,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(FSEv07_decompress)]
 pub unsafe extern "C" fn FSEv07_decompress(
     mut dst: *mut std::ffi::c_void,
     mut maxDstSize: size_t,
@@ -1339,7 +1339,7 @@ unsafe extern "C" fn HUFv07_getDTableDesc(mut table: *const HUFv07_DTable) -> DT
     );
     dtd
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv07_readDTableX2)]
 pub unsafe extern "C" fn HUFv07_readDTableX2(
     mut DTable: *mut HUFv07_DTable,
     mut src: *const std::ffi::c_void,
@@ -1497,7 +1497,7 @@ unsafe extern "C" fn HUFv07_decompress1X2_usingDTable_internal(
     }
     dstSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv07_decompress1X2_usingDTable)]
 pub unsafe extern "C" fn HUFv07_decompress1X2_usingDTable(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -1511,7 +1511,7 @@ pub unsafe extern "C" fn HUFv07_decompress1X2_usingDTable(
     }
     HUFv07_decompress1X2_usingDTable_internal(dst, dstSize, cSrc, cSrcSize, DTable)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv07_decompress1X2_DCtx)]
 pub unsafe extern "C" fn HUFv07_decompress1X2_DCtx(
     mut DCtx: *mut HUFv07_DTable,
     mut dst: *mut std::ffi::c_void,
@@ -1537,7 +1537,7 @@ pub unsafe extern "C" fn HUFv07_decompress1X2_DCtx(
         DCtx,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv07_decompress1X2)]
 pub unsafe extern "C" fn HUFv07_decompress1X2(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -1741,7 +1741,7 @@ unsafe extern "C" fn HUFv07_decompress4X2_usingDTable_internal(
     }
     dstSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv07_decompress4X2_usingDTable)]
 pub unsafe extern "C" fn HUFv07_decompress4X2_usingDTable(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -1755,7 +1755,7 @@ pub unsafe extern "C" fn HUFv07_decompress4X2_usingDTable(
     }
     HUFv07_decompress4X2_usingDTable_internal(dst, dstSize, cSrc, cSrcSize, DTable)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv07_decompress4X2_DCtx)]
 pub unsafe extern "C" fn HUFv07_decompress4X2_DCtx(
     mut dctx: *mut HUFv07_DTable,
     mut dst: *mut std::ffi::c_void,
@@ -1781,7 +1781,7 @@ pub unsafe extern "C" fn HUFv07_decompress4X2_DCtx(
         dctx,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv07_decompress4X2)]
 pub unsafe extern "C" fn HUFv07_decompress4X2(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -1931,7 +1931,7 @@ unsafe extern "C" fn HUFv07_fillDTableX4(
         s;
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv07_readDTableX4)]
 pub unsafe extern "C" fn HUFv07_readDTableX4(
     mut DTable: *mut HUFv07_DTable,
     mut src: *const std::ffi::c_void,
@@ -2184,7 +2184,7 @@ unsafe extern "C" fn HUFv07_decompress1X4_usingDTable_internal(
     }
     dstSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv07_decompress1X4_usingDTable)]
 pub unsafe extern "C" fn HUFv07_decompress1X4_usingDTable(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -2198,7 +2198,7 @@ pub unsafe extern "C" fn HUFv07_decompress1X4_usingDTable(
     }
     HUFv07_decompress1X4_usingDTable_internal(dst, dstSize, cSrc, cSrcSize, DTable)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv07_decompress1X4_DCtx)]
 pub unsafe extern "C" fn HUFv07_decompress1X4_DCtx(
     mut DCtx: *mut HUFv07_DTable,
     mut dst: *mut std::ffi::c_void,
@@ -2224,7 +2224,7 @@ pub unsafe extern "C" fn HUFv07_decompress1X4_DCtx(
         DCtx,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv07_decompress1X4)]
 pub unsafe extern "C" fn HUFv07_decompress1X4(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -2464,7 +2464,7 @@ unsafe extern "C" fn HUFv07_decompress4X4_usingDTable_internal(
     }
     dstSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv07_decompress4X4_usingDTable)]
 pub unsafe extern "C" fn HUFv07_decompress4X4_usingDTable(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -2478,7 +2478,7 @@ pub unsafe extern "C" fn HUFv07_decompress4X4_usingDTable(
     }
     HUFv07_decompress4X4_usingDTable_internal(dst, dstSize, cSrc, cSrcSize, DTable)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv07_decompress4X4_DCtx)]
 pub unsafe extern "C" fn HUFv07_decompress4X4_DCtx(
     mut dctx: *mut HUFv07_DTable,
     mut dst: *mut std::ffi::c_void,
@@ -2504,7 +2504,7 @@ pub unsafe extern "C" fn HUFv07_decompress4X4_DCtx(
         dctx,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv07_decompress4X4)]
 pub unsafe extern "C" fn HUFv07_decompress4X4(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -2515,7 +2515,7 @@ pub unsafe extern "C" fn HUFv07_decompress4X4(
         [12 as std::ffi::c_int as U32 * 0x1000001 as std::ffi::c_int as U32; 4097];
     HUFv07_decompress4X4_DCtx(DTable.as_mut_ptr(), dst, dstSize, cSrc, cSrcSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv07_decompress1X_usingDTable)]
 pub unsafe extern "C" fn HUFv07_decompress1X_usingDTable(
     mut dst: *mut std::ffi::c_void,
     mut maxDstSize: size_t,
@@ -2530,7 +2530,7 @@ pub unsafe extern "C" fn HUFv07_decompress1X_usingDTable(
         HUFv07_decompress1X2_usingDTable_internal(dst, maxDstSize, cSrc, cSrcSize, DTable)
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv07_decompress4X_usingDTable)]
 pub unsafe extern "C" fn HUFv07_decompress4X_usingDTable(
     mut dst: *mut std::ffi::c_void,
     mut maxDstSize: size_t,
@@ -2867,7 +2867,7 @@ static mut algoTime: [[algo_time_t; 3]; 16] = [
         },
     ],
 ];
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv07_selectDecoder)]
 pub unsafe extern "C" fn HUFv07_selectDecoder(mut dstSize: size_t, mut cSrcSize: size_t) -> U32 {
     let Q = (cSrcSize * 16 as std::ffi::c_int as size_t / dstSize) as U32;
     let D256 = (dstSize >> 8 as std::ffi::c_int) as U32;
@@ -2896,7 +2896,7 @@ pub unsafe extern "C" fn HUFv07_selectDecoder(mut dstSize: size_t, mut cSrcSize:
     DTime1 = DTime1.wrapping_add(DTime1 >> 3 as std::ffi::c_int);
     (DTime1 < DTime0) as std::ffi::c_int as U32
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv07_decompress)]
 pub unsafe extern "C" fn HUFv07_decompress(
     mut dst: *mut std::ffi::c_void,
     mut dstSize: size_t,
@@ -2942,7 +2942,7 @@ pub unsafe extern "C" fn HUFv07_decompress(
     let algoNb = HUFv07_selectDecoder(dstSize, cSrcSize);
     (*decompress.as_ptr().offset(algoNb as isize)).unwrap_unchecked()(dst, dstSize, cSrc, cSrcSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv07_decompress4X_DCtx)]
 pub unsafe extern "C" fn HUFv07_decompress4X_DCtx(
     mut dctx: *mut HUFv07_DTable,
     mut dst: *mut std::ffi::c_void,
@@ -2971,7 +2971,7 @@ pub unsafe extern "C" fn HUFv07_decompress4X_DCtx(
         HUFv07_decompress4X2_DCtx(dctx, dst, dstSize, cSrc, cSrcSize)
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv07_decompress4X_hufOnly)]
 pub unsafe extern "C" fn HUFv07_decompress4X_hufOnly(
     mut dctx: *mut HUFv07_DTable,
     mut dst: *mut std::ffi::c_void,
@@ -2992,7 +2992,7 @@ pub unsafe extern "C" fn HUFv07_decompress4X_hufOnly(
         HUFv07_decompress4X2_DCtx(dctx, dst, dstSize, cSrc, cSrcSize)
     }
 }
-#[no_mangle]
+#[export_name = crate::prefix!(HUFv07_decompress1X_DCtx)]
 pub unsafe extern "C" fn HUFv07_decompress1X_DCtx(
     mut dctx: *mut HUFv07_DTable,
     mut dst: *mut std::ffi::c_void,
@@ -3025,15 +3025,15 @@ pub unsafe extern "C" fn HUFv07_decompress1X_DCtx(
 pub unsafe extern "C" fn ZSTDv07_isError_0(mut code: size_t) -> std::ffi::c_uint {
     ERR_isError(code)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv07_getErrorName)]
 pub unsafe extern "C" fn ZSTDv07_getErrorName(mut code: size_t) -> *const std::ffi::c_char {
     ERR_getErrorName(code)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv07_isError)]
 pub unsafe extern "C" fn ZBUFFv07_isError(mut errorCode: size_t) -> std::ffi::c_uint {
     ERR_isError(errorCode)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv07_getErrorName)]
 pub unsafe extern "C" fn ZBUFFv07_getErrorName(mut errorCode: size_t) -> *const std::ffi::c_char {
     ERR_getErrorName(errorCode)
 }
@@ -3358,15 +3358,15 @@ unsafe extern "C" fn ZSTDv07_copy4(
 ) {
     memcpy(dst, src, 4 as std::ffi::c_int as std::ffi::c_ulong);
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv07_sizeofDCtx)]
 pub unsafe extern "C" fn ZSTDv07_sizeofDCtx(mut dctx: *const ZSTDv07_DCtx) -> size_t {
     ::core::mem::size_of::<ZSTDv07_DCtx>() as std::ffi::c_ulong
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv07_estimateDCtxSize)]
 pub unsafe extern "C" fn ZSTDv07_estimateDCtxSize() -> size_t {
     ::core::mem::size_of::<ZSTDv07_DCtx>() as std::ffi::c_ulong
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv07_decompressBegin)]
 pub unsafe extern "C" fn ZSTDv07_decompressBegin(mut dctx: *mut ZSTDv07_DCtx) -> size_t {
     (*dctx).expected = ZSTDv07_frameHeaderSize_min;
     (*dctx).stage = ZSTDds_getFrameHeaderSize;
@@ -3390,7 +3390,7 @@ pub unsafe extern "C" fn ZSTDv07_decompressBegin(mut dctx: *mut ZSTDv07_DCtx) ->
     }
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv07_createDCtx_advanced)]
 pub unsafe extern "C" fn ZSTDv07_createDCtx_advanced(
     mut customMem: ZSTDv07_customMem,
 ) -> *mut ZSTDv07_DCtx {
@@ -3416,11 +3416,11 @@ pub unsafe extern "C" fn ZSTDv07_createDCtx_advanced(
     ZSTDv07_decompressBegin(dctx);
     dctx
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv07_createDCtx)]
 pub unsafe extern "C" fn ZSTDv07_createDCtx() -> *mut ZSTDv07_DCtx {
     ZSTDv07_createDCtx_advanced(defaultCustomMem)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv07_freeDCtx)]
 pub unsafe extern "C" fn ZSTDv07_freeDCtx(mut dctx: *mut ZSTDv07_DCtx) -> size_t {
     if dctx.is_null() {
         return 0 as std::ffi::c_int as size_t;
@@ -3431,7 +3431,7 @@ pub unsafe extern "C" fn ZSTDv07_freeDCtx(mut dctx: *mut ZSTDv07_DCtx) -> size_t
     );
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv07_copyDCtx)]
 pub unsafe extern "C" fn ZSTDv07_copyDCtx(
     mut dstDCtx: *mut ZSTDv07_DCtx,
     mut srcDCtx: *const ZSTDv07_DCtx,
@@ -3465,7 +3465,7 @@ unsafe extern "C" fn ZSTDv07_frameHeaderSize(
                 as std::ffi::c_int as size_t,
         )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv07_getFrameParams)]
 pub unsafe extern "C" fn ZSTDv07_getFrameParams(
     mut fparamsPtr: *mut ZSTDv07_frameParams,
     mut src: *const std::ffi::c_void,
@@ -3586,7 +3586,7 @@ pub unsafe extern "C" fn ZSTDv07_getFrameParams(
     (*fparamsPtr).checksumFlag = checksumFlag;
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv07_getDecompressedSize)]
 pub unsafe extern "C" fn ZSTDv07_getDecompressedSize(
     mut src: *const std::ffi::c_void,
     mut srcSize: size_t,
@@ -4596,7 +4596,7 @@ unsafe extern "C" fn ZSTDv07_decompressBlock_internal(
         srcSize,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv07_decompressBlock)]
 pub unsafe extern "C" fn ZSTDv07_decompressBlock(
     mut dctx: *mut ZSTDv07_DCtx,
     mut dst: *mut std::ffi::c_void,
@@ -4611,7 +4611,7 @@ pub unsafe extern "C" fn ZSTDv07_decompressBlock(
         (dst as *mut std::ffi::c_char).offset(dSize as isize) as *const std::ffi::c_void;
     dSize
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv07_insertBlock)]
 pub unsafe extern "C" fn ZSTDv07_insertBlock(
     mut dctx: *mut ZSTDv07_DCtx,
     mut blockStart: *const std::ffi::c_void,
@@ -4750,7 +4750,7 @@ unsafe extern "C" fn ZSTDv07_decompress_usingPreparedDCtx(
     ZSTDv07_checkContinuity(dctx, dst);
     ZSTDv07_decompressFrame(dctx, dst, dstCapacity, src, srcSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv07_decompress_usingDict)]
 pub unsafe extern "C" fn ZSTDv07_decompress_usingDict(
     mut dctx: *mut ZSTDv07_DCtx,
     mut dst: *mut std::ffi::c_void,
@@ -4764,7 +4764,7 @@ pub unsafe extern "C" fn ZSTDv07_decompress_usingDict(
     ZSTDv07_checkContinuity(dctx, dst);
     ZSTDv07_decompressFrame(dctx, dst, dstCapacity, src, srcSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv07_decompressDCtx)]
 pub unsafe extern "C" fn ZSTDv07_decompressDCtx(
     mut dctx: *mut ZSTDv07_DCtx,
     mut dst: *mut std::ffi::c_void,
@@ -4782,7 +4782,7 @@ pub unsafe extern "C" fn ZSTDv07_decompressDCtx(
         0 as std::ffi::c_int as size_t,
     )
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv07_decompress)]
 pub unsafe extern "C" fn ZSTDv07_decompress(
     mut dst: *mut std::ffi::c_void,
     mut dstCapacity: size_t,
@@ -4806,7 +4806,7 @@ unsafe extern "C" fn ZSTD_errorFrameSizeInfoLegacy(
     *cSize = ret;
     *dBound = ZSTD_CONTENTSIZE_ERROR;
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv07_findFrameSizeInfoLegacy)]
 pub unsafe extern "C" fn ZSTDv07_findFrameSizeInfoLegacy(
     mut src: *const std::ffi::c_void,
     mut srcSize: size_t,
@@ -4884,16 +4884,16 @@ pub unsafe extern "C" fn ZSTDv07_findFrameSizeInfoLegacy(
     *cSize = ip.offset_from(src as *const BYTE) as std::ffi::c_long as size_t;
     *dBound = (nbBlocks * ZSTDv07_BLOCKSIZE_ABSOLUTEMAX as size_t) as std::ffi::c_ulonglong;
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv07_nextSrcSizeToDecompress)]
 pub unsafe extern "C" fn ZSTDv07_nextSrcSizeToDecompress(mut dctx: *mut ZSTDv07_DCtx) -> size_t {
     (*dctx).expected
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv07_isSkipFrame)]
 pub unsafe extern "C" fn ZSTDv07_isSkipFrame(mut dctx: *mut ZSTDv07_DCtx) -> std::ffi::c_int {
     ((*dctx).stage as std::ffi::c_uint == ZSTDds_skipFrame as std::ffi::c_int as std::ffi::c_uint)
         as std::ffi::c_int
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv07_decompressContinue)]
 pub unsafe extern "C" fn ZSTDv07_decompressContinue(
     mut dctx: *mut ZSTDv07_DCtx,
     mut dst: *mut std::ffi::c_void,
@@ -5233,7 +5233,7 @@ unsafe extern "C" fn ZSTDv07_decompress_insertDictionary(
     dictSize = dictSize.wrapping_sub(eSize);
     ZSTDv07_refDictContent(dctx, dict, dictSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv07_decompressBegin_usingDict)]
 pub unsafe extern "C" fn ZSTDv07_decompressBegin_usingDict(
     mut dctx: *mut ZSTDv07_DCtx,
     mut dict: *const std::ffi::c_void,
@@ -5287,7 +5287,7 @@ unsafe extern "C" fn ZSTDv07_createDDict_advanced(
     (*ddict).refContext = dctx;
     ddict
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv07_createDDict)]
 pub unsafe extern "C" fn ZSTDv07_createDDict(
     mut dict: *const std::ffi::c_void,
     mut dictSize: size_t,
@@ -5305,7 +5305,7 @@ pub unsafe extern "C" fn ZSTDv07_createDDict(
     };
     ZSTDv07_createDDict_advanced(dict, dictSize, allocator)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv07_freeDDict)]
 pub unsafe extern "C" fn ZSTDv07_freeDDict(mut ddict: *mut ZSTDv07_DDict) -> size_t {
     let cFree: ZSTDv07_freeFunction = (*(*ddict).refContext).customMem.customFree;
     let opaque = (*(*ddict).refContext).customMem.opaque;
@@ -5314,7 +5314,7 @@ pub unsafe extern "C" fn ZSTDv07_freeDDict(mut ddict: *mut ZSTDv07_DDict) -> siz
     cFree.unwrap_unchecked()(opaque, ddict as *mut std::ffi::c_void);
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZSTDv07_decompress_usingDDict)]
 pub unsafe extern "C" fn ZSTDv07_decompress_usingDDict(
     mut dctx: *mut ZSTDv07_DCtx,
     mut dst: *mut std::ffi::c_void,
@@ -5325,11 +5325,11 @@ pub unsafe extern "C" fn ZSTDv07_decompress_usingDDict(
 ) -> size_t {
     ZSTDv07_decompress_usingPreparedDCtx(dctx, (*ddict).refContext, dst, dstCapacity, src, srcSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv07_createDCtx)]
 pub unsafe extern "C" fn ZBUFFv07_createDCtx() -> *mut ZBUFFv07_DCtx {
     ZBUFFv07_createDCtx_advanced(defaultCustomMem)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv07_createDCtx_advanced)]
 pub unsafe extern "C" fn ZBUFFv07_createDCtx_advanced(
     mut customMem: ZSTDv07_customMem,
 ) -> *mut ZBUFFv07_DCtx {
@@ -5365,7 +5365,7 @@ pub unsafe extern "C" fn ZBUFFv07_createDCtx_advanced(
     (*zbd).stage = ZBUFFds_init;
     zbd
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv07_freeDCtx)]
 pub unsafe extern "C" fn ZBUFFv07_freeDCtx(mut zbd: *mut ZBUFFv07_DCtx) -> size_t {
     if zbd.is_null() {
         return 0 as std::ffi::c_int as size_t;
@@ -5389,7 +5389,7 @@ pub unsafe extern "C" fn ZBUFFv07_freeDCtx(mut zbd: *mut ZBUFFv07_DCtx) -> size_
     );
     0 as std::ffi::c_int as size_t
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv07_decompressInitDictionary)]
 pub unsafe extern "C" fn ZBUFFv07_decompressInitDictionary(
     mut zbd: *mut ZBUFFv07_DCtx,
     mut dict: *const std::ffi::c_void,
@@ -5402,7 +5402,7 @@ pub unsafe extern "C" fn ZBUFFv07_decompressInitDictionary(
     (*zbd).lhSize = (*zbd).inPos;
     ZSTDv07_decompressBegin_usingDict((*zbd).zd, dict, dictSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv07_decompressInit)]
 pub unsafe extern "C" fn ZBUFFv07_decompressInit(mut zbd: *mut ZBUFFv07_DCtx) -> size_t {
     ZBUFFv07_decompressInitDictionary(
         zbd,
@@ -5427,7 +5427,7 @@ unsafe extern "C" fn ZBUFFv07_limitCopy(
     }
     length
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv07_decompressContinue)]
 pub unsafe extern "C" fn ZBUFFv07_decompressContinue(
     mut zbd: *mut ZBUFFv07_DCtx,
     mut dst: *mut std::ffi::c_void,
@@ -5679,11 +5679,11 @@ pub unsafe extern "C" fn ZBUFFv07_decompressContinue(
     nextSrcSizeHint = nextSrcSizeHint.wrapping_sub((*zbd).inPos);
     nextSrcSizeHint
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv07_recommendedDInSize)]
 pub unsafe extern "C" fn ZBUFFv07_recommendedDInSize() -> size_t {
     (ZSTDv07_BLOCKSIZE_ABSOLUTEMAX as size_t).wrapping_add(ZSTDv07_blockHeaderSize)
 }
-#[no_mangle]
+#[export_name = crate::prefix!(ZBUFFv07_recommendedDOutSize)]
 pub unsafe extern "C" fn ZBUFFv07_recommendedDOutSize() -> size_t {
     ZSTDv07_BLOCKSIZE_ABSOLUTEMAX as size_t
 }


### PR DESCRIPTION
well this was interesting. I'll just include here how this was done

First, I (well, an LLM) wrote this script, that parses the rust and makes the change:

```toml
[package]
name = "rules"
version = "0.1.0"
edition = "2024"

[dependencies]
prettyplease = "0.2.36"
quote = "1.0.40"
syn = { version = "2.0.104", features = ["full", "visit-mut"] }
tempfile = "3.20.0"
walkdir = "2.5.0"
```

and 

```rust
use quote::quote;
use std::env;
use std::fs;
use std::io::Write;
use std::path::Path;
use syn::{Attribute, File, Item, ItemFn, visit_mut::VisitMut};
use tempfile::NamedTempFile;
use walkdir::WalkDir;

struct NoMangleToExportName;

impl VisitMut for NoMangleToExportName {
    fn visit_item_fn_mut(&mut self, func: &mut ItemFn) {
        let mut saw_no_mangle = false;

        func.attrs.retain(|attr| {
            if attr.path().is_ident("no_mangle") {
                saw_no_mangle = true;
                false
            } else {
                true
            }
        });

        if saw_no_mangle {
            let name = &func.sig.ident;
            let export_attr: Attribute = syn::parse_quote! {
                #[export_name = crate::prefix!(#name)]
            };
            func.attrs.insert(0, export_attr);
        }

        // Continue recursion in case you want to extend this
        syn::visit_mut::visit_item_fn_mut(self, func);
    }
}

fn process_file(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
    let content = fs::read_to_string(path)?;
    let mut syntax = syn::parse_file(&content)?;

    NoMangleToExportName.visit_file_mut(&mut syntax);

    let output = prettyplease::unparse(&syntax);

    // Write to a temp file first, then atomically replace original
    let mut tmpfile = NamedTempFile::new_in(path.parent().ok_or("File has no parent directory")?)?;
    tmpfile.write_all(output.as_bytes())?;
    tmpfile.persist(path)?;

    println!("Processed: {}", path.display());
    Ok(())
}

fn main() -> Result<(), Box<dyn std::error::Error>> {
    let dir = env::args().nth(1).expect("Usage: script <directory>");

    for entry in WalkDir::new(dir).into_iter().filter_map(Result::ok) {
        if entry.file_type().is_file()
            && entry.path().extension().and_then(|s| s.to_str()) == Some("rs")
        {
            if let Err(e) = process_file(entry.path()) {
                eprintln!("Failed to process {}: {}", entry.path().display(), e);
            }
        }
    }

    Ok(())
}
```

Unfortunately the above drops comments, and can mess with the formatting. So we can filter the hunks by whether they contain `no_mangle`:

```sh
git diff -U1 -Sno_mangle --pickaxe-regex | grepdiff -E no_mangle --output-matching=hunk > exports.diff
```

this is almost perfect: only when there is a comment in a changed hunk is that comment removed. That is unlikely enough initially that with some manual inspection this change can be made.


---

Enabling the `semver-prefix` feature does not work yet: some of our modules depend on the expected name being exported.
