### PR TITLE
convert `.offset` into `.add` when possible

### DIFF
--- a/lib/common/pool.rs
+++ b/lib/common/pool.rs
@@ -92,7 +92,7 @@ unsafe fn POOL_thread(mut opaque: *mut core::ffi::c_void) -> *mut core::ffi::c_v
             }
             pthread_cond_wait(&mut (*ctx).queuePopCond, &mut (*ctx).queueMutex);
         }
-        let job = *((*ctx).queue).offset((*ctx).queueHead as isize);
+        let job = *((*ctx).queue).add((*ctx).queueHead);
         (*ctx).queueHead = ((*ctx).queueHead).wrapping_add(1) % (*ctx).queueSize;
         (*ctx).numThreadsBusy = ((*ctx).numThreadsBusy).wrapping_add(1);
         (*ctx).numThreadsBusy;
@@ -169,7 +169,7 @@ pub unsafe fn POOL_create_advanced(
     i = 0;
     while i < numThreads {
         if pthread_create(
-            &mut *((*ctx).threads).offset(i as isize),
+            &mut *((*ctx).threads).add(i),
             core::ptr::null::<pthread_attr_t>(),
             core::mem::transmute(
                 POOL_thread as unsafe fn(*mut core::ffi::c_void) -> *mut core::ffi::c_void,
@@ -197,7 +197,7 @@ unsafe fn POOL_join(mut ctx: *mut POOL_ctx) {
     i = 0;
     while i < (*ctx).threadCapacity {
         pthread_join(
-            *((*ctx).threads).offset(i as isize),
+            *((*ctx).threads).add(i),
             NULL_0 as *mut *mut core::ffi::c_void,
         );
         i = i.wrapping_add(1);
@@ -263,7 +263,7 @@ unsafe fn POOL_resize_internal(mut ctx: *mut POOL_ctx, mut numThreads: size_t) -
     threadId = (*ctx).threadCapacity;
     while threadId < numThreads {
         if pthread_create(
-            &mut *threadPool.offset(threadId as isize),
+            &mut *threadPool.add(threadId),
             core::ptr::null::<pthread_attr_t>(),
             core::mem::transmute(
                 POOL_thread as unsafe fn(*mut core::ffi::c_void) -> *mut core::ffi::c_void,
@@ -314,7 +314,7 @@ unsafe fn POOL_add_internal(
         return;
     }
     (*ctx).queueEmpty = 0;
-    *((*ctx).queue).offset((*ctx).queueTail as isize) = job;
+    *((*ctx).queue).add((*ctx).queueTail) = job;
     (*ctx).queueTail = ((*ctx).queueTail).wrapping_add(1) % (*ctx).queueSize;
     pthread_cond_signal(&mut (*ctx).queuePopCond);
 }

--- a/lib/compress/hist.rs
+++ b/lib/compress/hist.rs
@@ -21,7 +21,7 @@ pub unsafe fn HIST_add(
     mut srcSize: size_t,
 ) {
     let mut ip = src as *const u8;
-    let end = ip.offset(srcSize as isize);
+    let end = ip.add(srcSize);
     while ip < end {
         let fresh0 = ip;
         ip = ip.offset(1);
@@ -36,7 +36,7 @@ pub unsafe fn HIST_count_simple(
     mut srcSize: size_t,
 ) -> core::ffi::c_uint {
     let mut ip = src as *const u8;
-    let end = ip.offset(srcSize as isize);
+    let end = ip.add(srcSize);
     let mut maxSymbolValue = *maxSymbolValuePtr;
     let mut largestCount = 0;
     ptr::write_bytes(
@@ -79,7 +79,7 @@ unsafe fn HIST_count_parallel_wksp(
     workSpace: *mut u32,
 ) -> size_t {
     let mut ip = source as *const u8;
-    let iend = ip.offset(sourceSize as isize);
+    let iend = ip.add(sourceSize);
     let countSize = ((*maxSymbolValuePtr).wrapping_add(1) as core::ffi::c_ulong)
         .wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>() as core::ffi::c_ulong);
     let mut max = 0;

--- a/lib/compress/zstd_compress_literals.rs
+++ b/lib/compress/zstd_compress_literals.rs
@@ -99,7 +99,7 @@ unsafe fn allBytesIdentical(
     let mut p: size_t = 0;
     p = 1;
     while p < srcSize {
-        if *(src as *const u8).offset(p as isize) as core::ffi::c_int != b as core::ffi::c_int {
+        if *(src as *const u8).add(p) as core::ffi::c_int != b as core::ffi::c_int {
             return 0;
         }
         p = p.wrapping_add(1);
@@ -255,7 +255,7 @@ pub unsafe fn ZSTD_compressLiterals(
         )
     };
     cLitSize = huf_compress.unwrap_unchecked()(
-        ostart.offset(lhSize as isize) as *mut core::ffi::c_void,
+        ostart.add(lhSize) as *mut core::ffi::c_void,
         dstCapacity.wrapping_sub(lhSize),
         src,
         srcSize,

--- a/lib/compress/zstd_ldm.rs
+++ b/lib/compress/zstd_ldm.rs
@@ -216,7 +216,7 @@ unsafe fn ZSTD_storeSeq(
     mut matchLength: size_t,
 ) {
     let litLimit_w = litLimit.offset(-(WILDCOPY_OVERLENGTH as isize));
-    let litEnd = literals.offset(litLength as isize);
+    let litEnd = literals.add(litLength);
     if litEnd <= litLimit_w {
         ZSTD_copy16(
             (*seqStorePtr).lit as *mut core::ffi::c_void,
@@ -233,7 +233,7 @@ unsafe fn ZSTD_storeSeq(
     } else {
         ZSTD_safecopyLiterals((*seqStorePtr).lit, literals, litEnd, litLimit_w);
     }
-    (*seqStorePtr).lit = ((*seqStorePtr).lit).offset(litLength as isize);
+    (*seqStorePtr).lit = ((*seqStorePtr).lit).add(litLength);
     ZSTD_storeSeqOnly(seqStorePtr, litLength, offBase, matchLength);
 }
 #[inline]
@@ -297,10 +297,10 @@ unsafe fn ZSTD_count_2segments(
         iEnd
     };
     let matchLength = ZSTD_count(ip, match_0, vEnd);
-    if match_0.offset(matchLength as isize) != mEnd {
+    if match_0.add(matchLength) != mEnd {
         return matchLength;
     }
-    matchLength.wrapping_add(ZSTD_count(ip.offset(matchLength as isize), iStart, iEnd))
+    matchLength.wrapping_add(ZSTD_count(ip.add(matchLength), iStart, iEnd))
 }
 #[inline]
 unsafe fn ZSTD_window_hasExtDict(window: ZSTD_window_t) -> u32 {
@@ -465,7 +465,7 @@ unsafe fn ZSTD_wildcopy(
     let mut diff = (dst as *mut u8).offset_from(src as *const u8) as core::ffi::c_long;
     let mut ip = src as *const u8;
     let mut op = dst as *mut u8;
-    let oend = op.offset(length as isize);
+    let oend = op.add(length);
     if ovtype as core::ffi::c_uint
         == ZSTD_overlap_src_before_dst as core::ffi::c_int as core::ffi::c_uint
         && diff < WILDCOPY_VECLEN as ptrdiff_t
@@ -822,25 +822,25 @@ unsafe fn ZSTD_ldm_gear_reset(
     let mut n = 0 as size_t;
     while n.wrapping_add(3) < minMatchLength {
         hash = (hash << 1).wrapping_add(*ZSTD_ldm_gearTab.as_ptr().offset(
-            (*data.offset(n as isize) as core::ffi::c_int & 0xff as core::ffi::c_int) as isize,
+            (*data.add(n) as core::ffi::c_int & 0xff as core::ffi::c_int) as isize,
         ));
         n = n.wrapping_add(1);
         hash = (hash << 1).wrapping_add(*ZSTD_ldm_gearTab.as_ptr().offset(
-            (*data.offset(n as isize) as core::ffi::c_int & 0xff as core::ffi::c_int) as isize,
+            (*data.add(n) as core::ffi::c_int & 0xff as core::ffi::c_int) as isize,
         ));
         n = n.wrapping_add(1);
         hash = (hash << 1).wrapping_add(*ZSTD_ldm_gearTab.as_ptr().offset(
-            (*data.offset(n as isize) as core::ffi::c_int & 0xff as core::ffi::c_int) as isize,
+            (*data.add(n) as core::ffi::c_int & 0xff as core::ffi::c_int) as isize,
         ));
         n = n.wrapping_add(1);
         hash = (hash << 1).wrapping_add(*ZSTD_ldm_gearTab.as_ptr().offset(
-            (*data.offset(n as isize) as core::ffi::c_int & 0xff as core::ffi::c_int) as isize,
+            (*data.add(n) as core::ffi::c_int & 0xff as core::ffi::c_int) as isize,
         ));
         n = n.wrapping_add(1);
     }
     while n < minMatchLength {
         hash = (hash << 1).wrapping_add(*ZSTD_ldm_gearTab.as_ptr().offset(
-            (*data.offset(n as isize) as core::ffi::c_int & 0xff as core::ffi::c_int) as isize,
+            (*data.add(n) as core::ffi::c_int & 0xff as core::ffi::c_int) as isize,
         ));
         n = n.wrapping_add(1);
     }
@@ -865,7 +865,7 @@ unsafe fn ZSTD_ldm_gear_feed(
             break;
         }
         hash = (hash << 1).wrapping_add(*ZSTD_ldm_gearTab.as_ptr().offset(
-            (*data.offset(n as isize) as core::ffi::c_int & 0xff as core::ffi::c_int) as isize,
+            (*data.add(n) as core::ffi::c_int & 0xff as core::ffi::c_int) as isize,
         ));
         n = n.wrapping_add(1);
         if (hash & mask == 0) as core::ffi::c_int as core::ffi::c_long != 0 {
@@ -877,7 +877,7 @@ unsafe fn ZSTD_ldm_gear_feed(
             }
         }
         hash = (hash << 1).wrapping_add(*ZSTD_ldm_gearTab.as_ptr().offset(
-            (*data.offset(n as isize) as core::ffi::c_int & 0xff as core::ffi::c_int) as isize,
+            (*data.add(n) as core::ffi::c_int & 0xff as core::ffi::c_int) as isize,
         ));
         n = n.wrapping_add(1);
         if (hash & mask == 0) as core::ffi::c_int as core::ffi::c_long != 0 {
@@ -889,7 +889,7 @@ unsafe fn ZSTD_ldm_gear_feed(
             }
         }
         hash = (hash << 1).wrapping_add(*ZSTD_ldm_gearTab.as_ptr().offset(
-            (*data.offset(n as isize) as core::ffi::c_int & 0xff as core::ffi::c_int) as isize,
+            (*data.add(n) as core::ffi::c_int & 0xff as core::ffi::c_int) as isize,
         ));
         n = n.wrapping_add(1);
         if (hash & mask == 0) as core::ffi::c_int as core::ffi::c_long != 0 {
@@ -901,7 +901,7 @@ unsafe fn ZSTD_ldm_gear_feed(
             }
         }
         hash = (hash << 1).wrapping_add(*ZSTD_ldm_gearTab.as_ptr().offset(
-            (*data.offset(n as isize) as core::ffi::c_int & 0xff as core::ffi::c_int) as isize,
+            (*data.add(n) as core::ffi::c_int & 0xff as core::ffi::c_int) as isize,
         ));
         n = n.wrapping_add(1);
         if (hash & mask == 0) as core::ffi::c_int as core::ffi::c_long == 0 {
@@ -926,7 +926,7 @@ unsafe fn ZSTD_ldm_gear_feed(
                     continue;
                 }
                 hash = (hash << 1).wrapping_add(*ZSTD_ldm_gearTab.as_ptr().offset(
-                    (*data.offset(n as isize) as core::ffi::c_int & 0xff as core::ffi::c_int)
+                    (*data.add(n) as core::ffi::c_int & 0xff as core::ffi::c_int)
                         as isize,
                 ));
                 n = n.wrapping_add(1);
@@ -1092,7 +1092,7 @@ unsafe fn ZSTD_ldm_getBucket(
     mut hash: size_t,
     bucketSizeLog: u32,
 ) -> *mut ldmEntry_t {
-    ((*ldmState).hashTable).offset((hash << bucketSizeLog) as isize)
+    ((*ldmState).hashTable).add(hash << bucketSizeLog)
 }
 unsafe fn ZSTD_ldm_insertEntry(
     mut ldmState: *mut ldmState_t,
@@ -1100,7 +1100,7 @@ unsafe fn ZSTD_ldm_insertEntry(
     entry: ldmEntry_t,
     bucketSizeLog: u32,
 ) {
-    let pOffset = ((*ldmState).bucketOffsets).offset(hash as isize);
+    let pOffset = ((*ldmState).bucketOffsets).add(hash);
     let offset = *pOffset as core::ffi::c_uint;
     *(ZSTD_ldm_getBucket(ldmState, hash, bucketSizeLog)).offset(offset as isize) = entry;
     *pOffset = (offset.wrapping_add(1)
@@ -1201,11 +1201,10 @@ pub unsafe fn ZSTD_ldm_fillHashTable(
         );
         n = 0;
         while n < numSplits {
-            if ip.offset(*splits.offset(n as isize) as isize)
+            if ip.add(*splits.offset(n as isize))
                 >= istart.offset(minMatchLength as isize)
             {
-                let split = ip
-                    .offset(*splits.offset(n as isize) as isize)
+                let split = ip.add(*splits.offset(n as isize))
                     .offset(-(minMatchLength as isize));
                 let xxhash = ZSTD_XXH64(
                     split as *const core::ffi::c_void,
@@ -1223,7 +1222,7 @@ pub unsafe fn ZSTD_ldm_fillHashTable(
             }
             n = n.wrapping_add(1);
         }
-        ip = ip.offset(hashed as isize);
+        ip = ip.add(hashed);
     }
 }
 unsafe fn ZSTD_ldm_limitTableUpdate(mut ms: *mut ZSTD_MatchState_t, mut anchor: *const u8) {
@@ -1273,7 +1272,7 @@ unsafe fn ZSTD_ldm_generateSequences_internal(
     };
     let lowPrefixPtr = base.offset(dictLimit as isize);
     let istart = src as *const u8;
-    let iend = istart.offset(srcSize as isize);
+    let iend = istart.add(srcSize);
     let ilimit = iend.offset(-(HASH_READ_SIZE as isize));
     let mut anchor = istart;
     let mut ip = istart;
@@ -1303,8 +1302,7 @@ unsafe fn ZSTD_ldm_generateSequences_internal(
         );
         n = 0;
         while n < numSplits {
-            let split = ip
-                .offset(*splits.offset(n as isize) as isize)
+            let split = ip.add(*splits.offset(n as isize))
                 .offset(-(minMatchLength as isize));
             let xxhash = ZSTD_XXH64(
                 split as *const core::ffi::c_void,
@@ -1428,7 +1426,7 @@ unsafe fn ZSTD_ldm_generateSequences_internal(
                     offset = (split_0.offset_from(base) as core::ffi::c_long as u32)
                         .wrapping_sub((*bestEntry).offset);
                     mLength = forwardMatchLength.wrapping_add(backwardMatchLength);
-                    let seq = ((*rawSeqStore).seq).offset((*rawSeqStore).size as isize);
+                    let seq = ((*rawSeqStore).seq).add((*rawSeqStore).size);
                     if (*rawSeqStore).size == (*rawSeqStore).capacity {
                         return -(ZSTD_error_dstSize_tooSmall as core::ffi::c_int) as size_t;
                     }
@@ -1446,8 +1444,8 @@ unsafe fn ZSTD_ldm_generateSequences_internal(
                         newEntry,
                         (*params).bucketSizeLog,
                     );
-                    anchor = split_0.offset(forwardMatchLength as isize);
-                    if anchor > ip.offset(hashed as isize) {
+                    anchor = split_0.add(forwardMatchLength);
+                    if anchor > ip.add(hashed) {
                         ZSTD_ldm_gear_reset(
                             &mut hashState,
                             anchor.offset(-(minMatchLength as isize)),
@@ -1460,7 +1458,7 @@ unsafe fn ZSTD_ldm_generateSequences_internal(
             }
             n = n.wrapping_add(1);
         }
-        ip = ip.offset(hashed as isize);
+        ip = ip.add(hashed);
     }
     iend.offset_from(anchor) as core::ffi::c_long as size_t
 }
@@ -1486,7 +1484,7 @@ pub unsafe fn ZSTD_ldm_generateSequences(
 ) -> size_t {
     let maxDist = (1) << (*params).windowLog;
     let istart = src as *const u8;
-    let iend = istart.offset(srcSize as isize);
+    let iend = istart.add(srcSize);
     let kMaxChunkSize = ((1) << 20) as size_t;
     let nbChunks = (srcSize / kMaxChunkSize)
         .wrapping_add((srcSize % kMaxChunkSize != 0) as core::ffi::c_int as size_t);
@@ -1494,12 +1492,12 @@ pub unsafe fn ZSTD_ldm_generateSequences(
     let mut leftoverSize = 0;
     chunk = 0;
     while chunk < nbChunks && (*sequences).size < (*sequences).capacity {
-        let chunkStart = istart.offset((chunk * kMaxChunkSize) as isize);
+        let chunkStart = istart.add(chunk * kMaxChunkSize);
         let remaining = iend.offset_from(chunkStart) as core::ffi::c_long as size_t;
         let chunkEnd = if remaining < kMaxChunkSize {
             iend
         } else {
-            chunkStart.offset(kMaxChunkSize as isize)
+            chunkStart.add(kMaxChunkSize)
         };
         let chunkSize = chunkEnd.offset_from(chunkStart) as core::ffi::c_long as size_t;
         let mut newLeftoverSize: size_t = 0;
@@ -1541,7 +1539,7 @@ pub unsafe fn ZSTD_ldm_generateSequences(
             return newLeftoverSize;
         }
         if prevSize < (*sequences).size {
-            let fresh5 = &mut (*((*sequences).seq).offset(prevSize as isize)).litLength;
+            let fresh5 = &mut (*((*sequences).seq).add(prevSize)).litLength;
             *fresh5 = (*fresh5).wrapping_add(leftoverSize as u32);
             leftoverSize = newLeftoverSize;
         } else {
@@ -1557,7 +1555,7 @@ pub unsafe fn ZSTD_ldm_skipSequences(
     minMatch: u32,
 ) {
     while srcSize > 0 && (*rawSeqStore).pos < (*rawSeqStore).size {
-        let mut seq = ((*rawSeqStore).seq).offset((*rawSeqStore).pos as isize);
+        let mut seq = ((*rawSeqStore).seq).add((*rawSeqStore).pos);
         if srcSize <= (*seq).litLength as size_t {
             (*seq).litLength = ((*seq).litLength).wrapping_sub(srcSize as u32);
             return;
@@ -1587,7 +1585,7 @@ unsafe fn maybeSplitSequence(
     remaining: u32,
     minMatch: u32,
 ) -> rawSeq {
-    let mut sequence = *((*rawSeqStore).seq).offset((*rawSeqStore).pos as isize);
+    let mut sequence = *((*rawSeqStore).seq).add((*rawSeqStore).pos);
     if remaining >= (sequence.litLength).wrapping_add(sequence.matchLength) {
         (*rawSeqStore).pos = ((*rawSeqStore).pos).wrapping_add(1);
         (*rawSeqStore).pos;
@@ -1610,7 +1608,7 @@ pub unsafe fn ZSTD_ldm_skipRawSeqStoreBytes(
 ) {
     let mut currPos = ((*rawSeqStore).posInSequence).wrapping_add(nbBytes) as u32;
     while currPos != 0 && (*rawSeqStore).pos < (*rawSeqStore).size {
-        let mut currSeq = *((*rawSeqStore).seq).offset((*rawSeqStore).pos as isize);
+        let mut currSeq = *((*rawSeqStore).seq).add((*rawSeqStore).pos);
         if currPos >= (currSeq.litLength).wrapping_add(currSeq.matchLength) {
             currPos = currPos.wrapping_sub((currSeq.litLength).wrapping_add(currSeq.matchLength));
             (*rawSeqStore).pos = ((*rawSeqStore).pos).wrapping_add(1);
@@ -1641,7 +1639,7 @@ pub unsafe fn ZSTD_ldm_blockCompress(
         ZSTD_matchState_dictMode(ms),
     );
     let istart = src as *const u8;
-    let iend = istart.offset(srcSize as isize);
+    let iend = istart.add(srcSize);
     let mut ip = istart;
     if (*cParams).strategy as core::ffi::c_uint
         >= ZSTD_btopt as core::ffi::c_int as core::ffi::c_uint

--- a/lib/decompress/zstd_ddict.rs
+++ b/lib/decompress/zstd_ddict.rs
@@ -75,7 +75,7 @@ pub unsafe fn ZSTD_copyDDictParameters(mut dctx: *mut ZSTD_DCtx, mut ddict: *con
     (*dctx).dictID = (*ddict).dictID;
     (*dctx).prefixStart = (*ddict).dictContent;
     (*dctx).virtualStart = (*ddict).dictContent;
-    (*dctx).dictEnd = ((*ddict).dictContent as *const u8).offset((*ddict).dictSize as isize)
+    (*dctx).dictEnd = ((*ddict).dictContent as *const u8).add((*ddict).dictSize)
         as *const core::ffi::c_void;
     (*dctx).previousDstEnd = (*dctx).dictEnd;
     if (*ddict).entropyPresent != 0 {

--- a/lib/decompress/zstd_decompress.rs
+++ b/lib/decompress/zstd_decompress.rs
@@ -541,10 +541,10 @@ unsafe fn ZSTD_decompressLegacyStream(
     match version {
         5 => {
             let mut dctx = legacyContext as *mut ZBUFFv05_DCtx;
-            let mut src = ((*input).src as *const core::ffi::c_char).offset((*input).pos as isize)
+            let mut src = ((*input).src as *const core::ffi::c_char).add((*input).pos)
                 as *const core::ffi::c_void;
             let mut readSize = ((*input).size).wrapping_sub((*input).pos);
-            let mut dst = ((*output).dst as *mut core::ffi::c_char).offset((*output).pos as isize)
+            let mut dst = ((*output).dst as *mut core::ffi::c_char).add((*output).pos)
                 as *mut core::ffi::c_void;
             let mut decodedSize = ((*output).size).wrapping_sub((*output).pos);
             let hintSize =
@@ -555,10 +555,10 @@ unsafe fn ZSTD_decompressLegacyStream(
         }
         6 => {
             let mut dctx_0 = legacyContext as *mut ZBUFFv06_DCtx;
-            let mut src_0 = ((*input).src as *const core::ffi::c_char).offset((*input).pos as isize)
+            let mut src_0 = ((*input).src as *const core::ffi::c_char).add((*input).pos)
                 as *const core::ffi::c_void;
             let mut readSize_0 = ((*input).size).wrapping_sub((*input).pos);
-            let mut dst_0 = ((*output).dst as *mut core::ffi::c_char).offset((*output).pos as isize)
+            let mut dst_0 = ((*output).dst as *mut core::ffi::c_char).add((*output).pos)
                 as *mut core::ffi::c_void;
             let mut decodedSize_0 = ((*output).size).wrapping_sub((*output).pos);
             let hintSize_0 = ZBUFFv06_decompressContinue(
@@ -574,10 +574,10 @@ unsafe fn ZSTD_decompressLegacyStream(
         }
         7 => {
             let mut dctx_1 = legacyContext as *mut ZBUFFv07_DCtx;
-            let mut src_1 = ((*input).src as *const core::ffi::c_char).offset((*input).pos as isize)
+            let mut src_1 = ((*input).src as *const core::ffi::c_char).add((*input).pos)
                 as *const core::ffi::c_void;
             let mut readSize_1 = ((*input).size).wrapping_sub((*input).pos);
-            let mut dst_1 = ((*output).dst as *mut core::ffi::c_char).offset((*output).pos as isize)
+            let mut dst_1 = ((*output).dst as *mut core::ffi::c_char).add((*output).pos)
                 as *mut core::ffi::c_void;
             let mut decodedSize_1 = ((*output).size).wrapping_sub((*output).pos);
             let hintSize_1 = ZBUFFv07_decompressContinue(
@@ -619,16 +619,16 @@ unsafe fn ZSTD_DDictHashSet_emplaceDDict(
     if (*hashSet).ddictPtrCount == (*hashSet).ddictPtrTableSize {
         return -(ZSTD_error_GENERIC as core::ffi::c_int) as size_t;
     }
-    while !(*((*hashSet).ddictPtrTable).offset(idx as isize)).is_null() {
-        if ZSTD_getDictID_fromDDict(*((*hashSet).ddictPtrTable).offset(idx as isize)) == dictID {
-            let fresh0 = &mut (*((*hashSet).ddictPtrTable).offset(idx as isize));
+    while !(*((*hashSet).ddictPtrTable).add(idx)).is_null() {
+        if ZSTD_getDictID_fromDDict(*((*hashSet).ddictPtrTable).add(idx)) == dictID {
+            let fresh0 = &mut (*((*hashSet).ddictPtrTable).add(idx));
             *fresh0 = ddict;
             return 0;
         }
         idx &= idxRangeMask;
         idx = idx.wrapping_add(1);
     }
-    let fresh1 = &mut (*((*hashSet).ddictPtrTable).offset(idx as isize));
+    let fresh1 = &mut (*((*hashSet).ddictPtrTable).add(idx));
     *fresh1 = ddict;
     (*hashSet).ddictPtrCount = ((*hashSet).ddictPtrCount).wrapping_add(1);
     (*hashSet).ddictPtrCount;
@@ -654,8 +654,8 @@ unsafe fn ZSTD_DDictHashSet_expand(
     (*hashSet).ddictPtrCount = 0;
     i = 0;
     while i < oldTableSize {
-        if !(*oldTable.offset(i as isize)).is_null() {
-            let err_code = ZSTD_DDictHashSet_emplaceDDict(hashSet, *oldTable.offset(i as isize));
+        if !(*oldTable.add(i)).is_null() {
+            let err_code = ZSTD_DDictHashSet_emplaceDDict(hashSet, *oldTable.add(i));
             if ERR_isError(err_code) != 0 {
                 return err_code;
             }
@@ -673,14 +673,14 @@ unsafe fn ZSTD_DDictHashSet_getDDict(
     let idxRangeMask = ((*hashSet).ddictPtrTableSize).wrapping_sub(1);
     loop {
         let mut currDictID =
-            ZSTD_getDictID_fromDDict(*((*hashSet).ddictPtrTable).offset(idx as isize)) as size_t;
+            ZSTD_getDictID_fromDDict(*((*hashSet).ddictPtrTable).add(idx)) as size_t;
         if currDictID == dictID as size_t || currDictID == 0 {
             break;
         }
         idx &= idxRangeMask;
         idx = idx.wrapping_add(1);
     }
-    *((*hashSet).ddictPtrTable).offset(idx as isize)
+    *((*hashSet).ddictPtrTable).add(idx)
 }
 unsafe fn ZSTD_createDDictHashSet(mut customMem: ZSTD_customMem) -> *mut ZSTD_DDictHashSet {
     let mut ret = ZSTD_customMalloc(
@@ -952,7 +952,7 @@ unsafe fn ZSTD_frameHeaderSize_internal(
     if srcSize < minInputSize {
         return -(ZSTD_error_srcSize_wrong as core::ffi::c_int) as size_t;
     }
-    let fhd = *(src as *const u8).offset(minInputSize.wrapping_sub(1) as isize);
+    let fhd = *(src as *const u8).add(minInputSize.wrapping_sub(1));
     let dictID = (fhd as core::ffi::c_int & 3) as u32;
     let singleSegment = (fhd as core::ffi::c_int >> 5 & 1) as u32;
     let fcsId = (fhd as core::ffi::c_int >> 6) as u32;
@@ -1264,7 +1264,7 @@ pub unsafe extern "C" fn ZSTD_findDecompressedSize(
             if ERR_isError(skippableSize) != 0 {
                 return ZSTD_CONTENTSIZE_ERROR;
             }
-            src = (src as *const u8).offset(skippableSize as isize) as *const core::ffi::c_void;
+            src = (src as *const u8).add(skippableSize) as *const core::ffi::c_void;
             srcSize = srcSize.wrapping_sub(skippableSize);
         } else {
             let fcs = ZSTD_getFrameContentSize(src, srcSize);
@@ -1279,7 +1279,7 @@ pub unsafe extern "C" fn ZSTD_findDecompressedSize(
             if ERR_isError(frameSrcSize) != 0 {
                 return ZSTD_CONTENTSIZE_ERROR;
             }
-            src = (src as *const u8).offset(frameSrcSize as isize) as *const core::ffi::c_void;
+            src = (src as *const u8).add(frameSrcSize) as *const core::ffi::c_void;
             srcSize = srcSize.wrapping_sub(frameSrcSize);
         }
     }
@@ -1544,7 +1544,7 @@ pub unsafe extern "C" fn ZSTD_insertBlock(
     mut blockSize: size_t,
 ) -> size_t {
     ZSTD_checkContinuity(dctx, blockStart, blockSize);
-    (*dctx).previousDstEnd = (blockStart as *const core::ffi::c_char).offset(blockSize as isize)
+    (*dctx).previousDstEnd = (blockStart as *const core::ffi::c_char).add(blockSize)
         as *const core::ffi::c_void;
     blockSize
 }
@@ -1632,7 +1632,7 @@ unsafe fn ZSTD_decompressFrame(
     let mut ip = istart;
     let ostart = dst as *mut u8;
     let oend = if dstCapacity != 0 {
-        ostart.offset(dstCapacity as isize)
+        ostart.add(dstCapacity)
     } else {
         ostart
     };
@@ -1667,7 +1667,7 @@ unsafe fn ZSTD_decompressFrame(
     if ERR_isError(err_code) != 0 {
         return err_code;
     }
-    ip = ip.offset(frameHeaderSize as isize);
+    ip = ip.add(frameHeaderSize);
     remainingSrcSize = remainingSrcSize.wrapping_sub(frameHeaderSize);
     if (*dctx).maxBlockSizeParam != 0 {
         (*dctx).fParams.blockSizeMax =
@@ -1693,7 +1693,7 @@ unsafe fn ZSTD_decompressFrame(
         if ERR_isError(cBlockSize) != 0 {
             return cBlockSize;
         }
-        ip = ip.offset(ZSTD_blockHeaderSize as isize);
+        ip = ip.add(ZSTD_blockHeaderSize);
         remainingSrcSize = remainingSrcSize.wrapping_sub(ZSTD_blockHeaderSize);
         if cBlockSize > remainingSrcSize {
             return -(ZSTD_error_srcSize_wrong as core::ffi::c_int) as size_t;
@@ -1744,9 +1744,9 @@ unsafe fn ZSTD_decompressFrame(
             );
         }
         if decodedSize != 0 {
-            op = op.offset(decodedSize as isize);
+            op = op.add(decodedSize);
         }
-        ip = ip.offset(cBlockSize as isize);
+        ip = ip.add(cBlockSize);
         remainingSrcSize = remainingSrcSize.wrapping_sub(cBlockSize);
         if blockProperties.lastBlock != 0 {
             break;
@@ -1822,9 +1822,9 @@ unsafe fn ZSTD_decompressMultiFrame(
             {
                 return -(ZSTD_error_corruption_detected as core::ffi::c_int) as size_t;
             }
-            dst = (dst as *mut u8).offset(decodedSize as isize) as *mut core::ffi::c_void;
+            dst = (dst as *mut u8).add(decodedSize) as *mut core::ffi::c_void;
             dstCapacity = dstCapacity.wrapping_sub(decodedSize);
-            src = (src as *const u8).offset(frameSize as isize) as *const core::ffi::c_void;
+            src = (src as *const u8).add(frameSize) as *const core::ffi::c_void;
             srcSize = srcSize.wrapping_sub(frameSize);
         } else {
             if (*dctx).format == Format::ZSTD_f_zstd1 && srcSize >= 4 {
@@ -1837,7 +1837,7 @@ unsafe fn ZSTD_decompressMultiFrame(
                     if ERR_isError(err_code) != 0 {
                         return err_code;
                     }
-                    src = (src as *const u8).offset(skippableSize as isize)
+                    src = (src as *const u8).add(skippableSize)
                         as *const core::ffi::c_void;
                     srcSize = srcSize.wrapping_sub(skippableSize);
                     continue;
@@ -1866,7 +1866,7 @@ unsafe fn ZSTD_decompressMultiFrame(
                 return res;
             }
             if res != 0 {
-                dst = (dst as *mut u8).offset(res as isize) as *mut core::ffi::c_void;
+                dst = (dst as *mut u8).add(res) as *mut core::ffi::c_void;
             }
             dstCapacity = dstCapacity.wrapping_sub(res);
             moreThan1Frame = 1;
@@ -2026,8 +2026,7 @@ pub unsafe extern "C" fn ZSTD_decompressContinue(
         1 => {
             libc::memcpy(
                 ((*dctx).headerBuffer)
-                    .as_mut_ptr()
-                    .offset(((*dctx).headerSize).wrapping_sub(srcSize) as isize)
+                    .as_mut_ptr().add(((*dctx).headerSize).wrapping_sub(srcSize))
                     as *mut core::ffi::c_void,
                 src,
                 srcSize as libc::size_t,
@@ -2125,7 +2124,7 @@ pub unsafe extern "C" fn ZSTD_decompressContinue(
                 ZSTD_XXH64_update(&mut (*dctx).xxhState, dst, rSize as usize);
             }
             (*dctx).previousDstEnd =
-                (dst as *mut core::ffi::c_char).offset(rSize as isize) as *const core::ffi::c_void;
+                (dst as *mut core::ffi::c_char).add(rSize) as *const core::ffi::c_void;
             if (*dctx).expected > 0 {
                 return rSize;
             }
@@ -2168,8 +2167,7 @@ pub unsafe extern "C" fn ZSTD_decompressContinue(
         6 => {
             libc::memcpy(
                 ((*dctx).headerBuffer)
-                    .as_mut_ptr()
-                    .offset((8 as size_t).wrapping_sub(srcSize) as isize)
+                    .as_mut_ptr().add((8 as size_t).wrapping_sub(srcSize))
                     as *mut core::ffi::c_void,
                 src,
                 srcSize as libc::size_t,
@@ -2203,7 +2201,7 @@ unsafe fn ZSTD_refDictContent(
     ) as *const core::ffi::c_void;
     (*dctx).prefixStart = dict;
     (*dctx).previousDstEnd =
-        (dict as *const core::ffi::c_char).offset(dictSize as isize) as *const core::ffi::c_void;
+        (dict as *const core::ffi::c_char).add(dictSize) as *const core::ffi::c_void;
     0
 }
 
@@ -2213,7 +2211,7 @@ pub unsafe fn ZSTD_loadDEntropy(
     dictSize: size_t,
 ) -> size_t {
     let mut dictPtr = dict as *const u8;
-    let dictEnd = dictPtr.offset(dictSize as isize);
+    let dictEnd = dictPtr.add(dictSize);
     if dictSize <= 8 {
         return -(ZSTD_error_dictionary_corrupted as core::ffi::c_int) as size_t;
     }
@@ -2239,7 +2237,7 @@ pub unsafe fn ZSTD_loadDEntropy(
     if ERR_isError(hSize) != 0 {
         return -(ZSTD_error_dictionary_corrupted as core::ffi::c_int) as size_t;
     }
-    dictPtr = dictPtr.offset(hSize as isize);
+    dictPtr = dictPtr.add(hSize);
     let mut offcodeNCount: [core::ffi::c_short; 32] = [0; 32];
     let mut offcodeMaxValue = MaxOff as core::ffi::c_uint;
     let mut offcodeLog: core::ffi::c_uint = 0;
@@ -2268,7 +2266,7 @@ pub unsafe fn ZSTD_loadDEntropy(
         &mut (*entropy).workspace,
         false,
     );
-    dictPtr = dictPtr.offset(offcodeHeaderSize as isize);
+    dictPtr = dictPtr.add(offcodeHeaderSize);
     let mut matchlengthNCount: [core::ffi::c_short; 53] = [0; 53];
     let mut matchlengthMaxValue = MaxML as core::ffi::c_uint;
     let mut matchlengthLog: core::ffi::c_uint = 0;
@@ -2297,7 +2295,7 @@ pub unsafe fn ZSTD_loadDEntropy(
         &mut (*entropy).workspace,
         false,
     );
-    dictPtr = dictPtr.offset(matchlengthHeaderSize as isize);
+    dictPtr = dictPtr.add(matchlengthHeaderSize);
     let mut litlengthNCount: [core::ffi::c_short; 36] = [0; 36];
     let mut litlengthMaxValue = MaxLL as core::ffi::c_uint;
     let mut litlengthLog: core::ffi::c_uint = 0;
@@ -2326,7 +2324,7 @@ pub unsafe fn ZSTD_loadDEntropy(
         &mut (*entropy).workspace,
         false,
     );
-    dictPtr = dictPtr.offset(litlengthHeaderSize as isize);
+    dictPtr = dictPtr.add(litlengthHeaderSize);
     if dictPtr.offset(12) > dictEnd {
         return -(ZSTD_error_dictionary_corrupted as core::ffi::c_int) as size_t;
     }
@@ -2365,7 +2363,7 @@ unsafe fn ZSTD_decompress_insertDictionary(
     if ERR_isError(eSize) != 0 {
         return -(ZSTD_error_dictionary_corrupted as core::ffi::c_int) as size_t;
     }
-    dict = (dict as *const core::ffi::c_char).offset(eSize as isize) as *const core::ffi::c_void;
+    dict = (dict as *const core::ffi::c_char).add(eSize) as *const core::ffi::c_void;
     dictSize = dictSize.wrapping_sub(eSize);
     (*dctx).fseEntropy = 1;
     (*dctx).litEntropy = (*dctx).fseEntropy;
@@ -2425,7 +2423,7 @@ pub unsafe extern "C" fn ZSTD_decompressBegin_usingDDict(
     if !ddict.is_null() {
         let dictStart = ZSTD_DDict_dictContent(ddict) as *const core::ffi::c_char;
         let dictSize = ZSTD_DDict_dictSize(ddict);
-        let dictEnd = dictStart.offset(dictSize as isize) as *const core::ffi::c_void;
+        let dictEnd = dictStart.add(dictSize) as *const core::ffi::c_void;
         (*dctx).ddictIsCold = ((*dctx).dictEnd != dictEnd) as core::ffi::c_int;
     }
     let err_code = ZSTD_decompressBegin(dctx);
@@ -3082,7 +3080,7 @@ unsafe fn ZSTD_decompressContinueStream(
         };
         let decodedSize = ZSTD_decompressContinue(
             zds,
-            ((*zds).outBuff).offset((*zds).outStart as isize) as *mut core::ffi::c_void,
+            ((*zds).outBuff).add((*zds).outStart) as *mut core::ffi::c_void,
             dstSize,
             src,
             srcSize,
@@ -3109,7 +3107,7 @@ unsafe fn ZSTD_decompressContinueStream(
         if ERR_isError(err_code_0) != 0 {
             return err_code_0;
         }
-        *op = (*op).offset(decodedSize_0 as isize);
+        *op = (*op).add(decodedSize_0);
         (*zds).streamStage = zdss_read;
     }
     0
@@ -3122,24 +3120,24 @@ pub unsafe extern "C" fn ZSTD_decompressStream(
 ) -> size_t {
     let src = (*input).src as *const core::ffi::c_char;
     let istart = if (*input).pos != 0 {
-        src.offset((*input).pos as isize)
+        src.add((*input).pos)
     } else {
         src
     };
     let iend = if (*input).size != 0 {
-        src.offset((*input).size as isize)
+        src.add((*input).size)
     } else {
         src
     };
     let mut ip = istart;
     let dst = (*output).dst as *mut core::ffi::c_char;
     let ostart = if (*output).pos != 0 {
-        dst.offset((*output).pos as isize)
+        dst.add((*output).pos)
     } else {
         dst
     };
     let oend = if (*output).size != 0 {
-        dst.offset((*output).size as isize)
+        dst.add((*output).size)
     } else {
         dst
     };
@@ -3183,11 +3181,11 @@ pub unsafe extern "C" fn ZSTD_decompressStream(
                 let flushedSize = ZSTD_limitCopy(
                     op as *mut core::ffi::c_void,
                     oend.offset_from(op) as core::ffi::c_long as size_t,
-                    ((*zds).outBuff).offset((*zds).outStart as isize) as *const core::ffi::c_void,
+                    ((*zds).outBuff).add((*zds).outStart) as *const core::ffi::c_void,
                     toFlushSize,
                 );
                 op = if !op.is_null() {
-                    op.offset(flushedSize as isize)
+                    op.add(flushedSize)
                 } else {
                     op
                 };
@@ -3286,8 +3284,7 @@ pub unsafe extern "C" fn ZSTD_decompressStream(
                     if remainingInput > 0 {
                         libc::memcpy(
                             ((*zds).headerBuffer)
-                                .as_mut_ptr()
-                                .offset((*zds).lhSize as isize)
+                                .as_mut_ptr().add((*zds).lhSize)
                                 as *mut core::ffi::c_void,
                             ip as *const core::ffi::c_void,
                             remainingInput as libc::size_t,
@@ -3324,14 +3321,13 @@ pub unsafe extern "C" fn ZSTD_decompressStream(
                 }
                 libc::memcpy(
                     ((*zds).headerBuffer)
-                        .as_mut_ptr()
-                        .offset((*zds).lhSize as isize)
+                        .as_mut_ptr().add((*zds).lhSize)
                         as *mut core::ffi::c_void,
                     ip as *const core::ffi::c_void,
                     toLoad as libc::size_t,
                 );
                 (*zds).lhSize = hSize;
-                ip = ip.offset(toLoad as isize);
+                ip = ip.add(toLoad);
                 current_block_402 = 7792909578691485565;
             } else {
                 if (*zds).fParams.frameContentSize != ZSTD_CONTENTSIZE_UNKNOWN
@@ -3359,9 +3355,9 @@ pub unsafe extern "C" fn ZSTD_decompressStream(
                         if ERR_isError(decompressedSize) != 0 {
                             return decompressedSize;
                         }
-                        ip = istart.offset(cSize as isize);
+                        ip = istart.add(cSize);
                         op = if !op.is_null() {
-                            op.offset(decompressedSize as isize)
+                            op.add(decompressedSize)
                         } else {
                             op
                         };
@@ -3488,7 +3484,7 @@ pub unsafe extern "C" fn ZSTD_decompressStream(
                                 }
                             }
                             (*zds).inBuffSize = neededInBuffSize;
-                            (*zds).outBuff = ((*zds).inBuff).offset((*zds).inBuffSize as isize);
+                            (*zds).outBuff = ((*zds).inBuff).add((*zds).inBuffSize);
                             (*zds).outBuffSize = neededOutBuffSize;
                         }
                         (*zds).streamStage = zdss_read;
@@ -3517,7 +3513,7 @@ pub unsafe extern "C" fn ZSTD_decompressStream(
                 if ERR_isError(err_code_4) != 0 {
                     return err_code_4;
                 }
-                ip = ip.offset(neededInSize as isize);
+                ip = ip.add(neededInSize);
                 current_block_402 = 7792909578691485565;
             } else if ip == iend {
                 someMoreWork = 0;
@@ -3543,14 +3539,14 @@ pub unsafe extern "C" fn ZSTD_decompressStream(
                     return -(ZSTD_error_corruption_detected as core::ffi::c_int) as size_t;
                 }
                 loadedSize = ZSTD_limitCopy(
-                    ((*zds).inBuff).offset((*zds).inPos as isize) as *mut core::ffi::c_void,
+                    ((*zds).inBuff).add((*zds).inPos) as *mut core::ffi::c_void,
                     toLoad_0,
                     ip as *const core::ffi::c_void,
                     iend.offset_from(ip) as core::ffi::c_long as size_t,
                 );
             }
             if loadedSize != 0 {
-                ip = ip.offset(loadedSize as isize);
+                ip = ip.add(loadedSize);
                 (*zds).inPos = ((*zds).inPos).wrapping_add(loadedSize);
             }
             if loadedSize < toLoad_0 {

--- a/lib/dictBuilder/cover.rs
+++ b/lib/dictBuilder/cover.rs
@@ -329,7 +329,7 @@ unsafe fn COVER_lower_bound(
     while count != 0 {
         let mut step = count / 2;
         let mut ptr = first;
-        ptr = ptr.offset(step as isize);
+        ptr = ptr.add(step);
         if *ptr < value {
             ptr = ptr.offset(1);
             first = ptr;
@@ -359,7 +359,7 @@ unsafe fn COVER_groupBy(
     let mut ptr = data as *const u8;
     let mut num = 0;
     while num < count {
-        let mut grpEnd = ptr.offset(size as isize);
+        let mut grpEnd = ptr.add(size);
         num = num.wrapping_add(1);
         while num < count
             && cmp.unwrap_unchecked()(
@@ -368,7 +368,7 @@ unsafe fn COVER_groupBy(
                 grpEnd as *const core::ffi::c_void,
             ) == 0
         {
-            grpEnd = grpEnd.offset(size as isize);
+            grpEnd = grpEnd.add(size);
             num = num.wrapping_add(1);
         }
         grp.unwrap_unchecked()(
@@ -389,7 +389,7 @@ unsafe fn COVER_group(
     let dmerId = grpPtr.offset_from((*ctx).suffix) as core::ffi::c_long as u32;
     let mut freq = 0u32;
     let mut curOffsetPtr: *const size_t = (*ctx).offsets;
-    let mut offsetsEnd: *const size_t = ((*ctx).offsets).offset((*ctx).nbSamples as isize);
+    let mut offsetsEnd: *const size_t = ((*ctx).offsets).add((*ctx).nbSamples);
     let mut curSampleEnd = *((*ctx).offsets).offset(0);
     while grpPtr != grpEnd {
         *((*ctx).dmerAt).offset(*grpPtr as isize) = dmerId;
@@ -844,7 +844,7 @@ unsafe fn COVER_buildDictionary(
             }
             tail = tail.wrapping_sub(segmentSize);
             memcpy(
-                dict.offset(tail as isize) as *mut core::ffi::c_void,
+                dict.add(tail) as *mut core::ffi::c_void,
                 ((*ctx).samples).offset(segment.begin as isize) as *const core::ffi::c_void,
                 segmentSize,
             );
@@ -986,7 +986,7 @@ pub unsafe extern "C" fn ZDICT_trainFromBuffer_cover(
     let dictionarySize = ZDICT_finalizeDictionary(
         dict as *mut core::ffi::c_void,
         dictBufferCapacity,
-        dict.offset(tail as isize) as *const core::ffi::c_void,
+        dict.add(tail) as *const core::ffi::c_void,
         dictBufferCapacity.wrapping_sub(tail),
         samplesBuffer,
         samplesSizes,
@@ -1028,8 +1028,8 @@ pub unsafe fn COVER_checkTotalCompressedSize(
         0
     };
     while i < nbSamples {
-        maxSampleSize = if *samplesSizes.offset(i as isize) > maxSampleSize {
-            *samplesSizes.offset(i as isize)
+        maxSampleSize = if *samplesSizes.add(i) > maxSampleSize {
+            *samplesSizes.add(i)
         } else {
             maxSampleSize
         };
@@ -1055,8 +1055,8 @@ pub unsafe fn COVER_checkTotalCompressedSize(
                 cctx,
                 dst,
                 dstCapacity,
-                samples.offset(*offsets.offset(i as isize) as isize) as *const core::ffi::c_void,
-                *samplesSizes.offset(i as isize),
+                samples.add(*offsets.add(i)) as *const core::ffi::c_void,
+                *samplesSizes.add(i),
                 cdict,
             );
             if ERR_isError(size) != 0 {
@@ -1205,7 +1205,7 @@ pub unsafe fn COVER_selectDict(
 ) -> COVER_dictSelection_t {
     let mut largestDict = 0;
     let mut largestCompressed = 0;
-    let mut customDictContentEnd = customDictContent.offset(dictContentSize as isize);
+    let mut customDictContentEnd = customDictContent.add(dictContentSize);
     let mut largestDictbuffer = malloc(dictBufferCapacity) as *mut u8;
     let mut candidateDictBuffer = malloc(dictBufferCapacity) as *mut u8;
     let mut regressionTolerance =
@@ -1361,7 +1361,7 @@ unsafe extern "C" fn COVER_tryParameters(mut opaque: *mut core::ffi::c_void) {
             parameters,
         );
         selection = COVER_selectDict(
-            dict.offset(tail as isize),
+            dict.add(tail),
             dictBufferCapacity,
             dictBufferCapacity.wrapping_sub(tail),
             (*ctx).samples,

--- a/lib/dictBuilder/fastcover.rs
+++ b/lib/dictBuilder/fastcover.rs
@@ -224,11 +224,11 @@ unsafe fn FASTCOVER_selectSegment(
             f,
             d,
         );
-        if *segmentFreqs.offset(idx as isize) as core::ffi::c_int == 0 {
-            activeSegment.score = (activeSegment.score).wrapping_add(*freqs.offset(idx as isize));
+        if *segmentFreqs.add(idx) as core::ffi::c_int == 0 {
+            activeSegment.score = (activeSegment.score).wrapping_add(*freqs.add(idx));
         }
         activeSegment.end = (activeSegment.end).wrapping_add(1);
-        let fresh0 = &mut (*segmentFreqs.offset(idx as isize));
+        let fresh0 = &mut (*segmentFreqs.add(idx));
         *fresh0 = (*fresh0 as core::ffi::c_int + 1) as u16;
         if (activeSegment.end).wrapping_sub(activeSegment.begin) == dmersInK.wrapping_add(1) {
             let delIndex = FASTCOVER_hashPtrToIndex(
@@ -236,11 +236,11 @@ unsafe fn FASTCOVER_selectSegment(
                 f,
                 d,
             );
-            let fresh1 = &mut (*segmentFreqs.offset(delIndex as isize));
+            let fresh1 = &mut (*segmentFreqs.add(delIndex));
             *fresh1 = (*fresh1 as core::ffi::c_int - 1) as u16;
-            if *segmentFreqs.offset(delIndex as isize) as core::ffi::c_int == 0 {
+            if *segmentFreqs.add(delIndex) as core::ffi::c_int == 0 {
                 activeSegment.score =
-                    (activeSegment.score).wrapping_sub(*freqs.offset(delIndex as isize));
+                    (activeSegment.score).wrapping_sub(*freqs.add(delIndex));
             }
             activeSegment.begin = (activeSegment.begin).wrapping_add(1);
         }
@@ -254,7 +254,7 @@ unsafe fn FASTCOVER_selectSegment(
             f,
             d,
         );
-        let fresh2 = &mut (*segmentFreqs.offset(delIndex_0 as isize));
+        let fresh2 = &mut (*segmentFreqs.add(delIndex_0));
         *fresh2 = (*fresh2 as core::ffi::c_int - 1) as u16;
         activeSegment.begin = (activeSegment.begin).wrapping_add(1);
     }
@@ -266,7 +266,7 @@ unsafe fn FASTCOVER_selectSegment(
             f,
             d,
         );
-        *freqs.offset(i as isize) = 0;
+        *freqs.add(i) = 0;
         pos = pos.wrapping_add(1);
     }
     bestSegment
@@ -317,15 +317,15 @@ unsafe fn FASTCOVER_computeFrequency(mut freqs: *mut u32, mut ctx: *const FASTCO
     let mut i: size_t = 0;
     i = 0;
     while i < (*ctx).nbTrainSamples {
-        let mut start = *((*ctx).offsets).offset(i as isize);
-        let currSampleEnd = *((*ctx).offsets).offset(i.wrapping_add(1) as isize);
+        let mut start = *((*ctx).offsets).add(i);
+        let currSampleEnd = *((*ctx).offsets).add(i.wrapping_add(1));
         while start.wrapping_add(readLength as size_t) <= currSampleEnd {
             let dmerIndex = FASTCOVER_hashPtrToIndex(
-                ((*ctx).samples).offset(start as isize) as *const core::ffi::c_void,
+                ((*ctx).samples).add(start) as *const core::ffi::c_void,
                 f,
                 d,
             );
-            let fresh3 = &mut (*freqs.offset(dmerIndex as isize));
+            let fresh3 = &mut (*freqs.add(dmerIndex));
             *fresh3 = (*fresh3).wrapping_add(1);
             start = start.wrapping_add(skip as size_t).wrapping_add(1);
         }
@@ -562,7 +562,7 @@ unsafe fn FASTCOVER_buildDictionary(
             }
             tail = tail.wrapping_sub(segmentSize);
             memcpy(
-                dict.offset(tail as isize) as *mut core::ffi::c_void,
+                dict.add(tail) as *mut core::ffi::c_void,
                 ((*ctx).samples).offset(segment.begin as isize) as *const core::ffi::c_void,
                 segmentSize,
             );
@@ -633,7 +633,7 @@ unsafe extern "C" fn FASTCOVER_tryParameters(mut opaque: *mut core::ffi::c_void)
         let nbFinalizeSamples = ((*ctx).nbTrainSamples * (*ctx).accelParams.finalize as size_t
             / 100) as core::ffi::c_uint;
         selection = COVER_selectDict(
-            dict.offset(tail as isize),
+            dict.add(tail),
             dictBufferCapacity,
             dictBufferCapacity.wrapping_sub(tail),
             (*ctx).samples,
@@ -837,7 +837,7 @@ pub unsafe extern "C" fn ZDICT_trainFromBuffer_fastCover(
     let dictionarySize = ZDICT_finalizeDictionary(
         dict as *mut core::ffi::c_void,
         dictBufferCapacity,
-        dict.offset(tail as isize) as *const core::ffi::c_void,
+        dict.add(tail) as *const core::ffi::c_void,
         dictBufferCapacity.wrapping_sub(tail),
         samplesBuffer,
         samplesSizes,

--- a/lib/dictBuilder/zdict.rs
+++ b/lib/dictBuilder/zdict.rs
@@ -475,7 +475,7 @@ unsafe fn ZDICT_printHex(mut ptr: *const core::ffi::c_void, mut length: size_t) 
     let mut u: size_t = 0;
     u = 0;
     while u < length {
-        let mut c = *b.offset(u as isize);
+        let mut c = *b.add(u);
         if (c as core::ffi::c_int) < 32 || c as core::ffi::c_int > 126 {
             c = '.' as i32 as u8;
         }
@@ -539,11 +539,9 @@ unsafe fn ZDICT_count(
     loop {
         let diff = MEM_readST(pMatch) ^ MEM_readST(pIn);
         if diff == 0 {
-            pIn = (pIn as *const core::ffi::c_char)
-                .offset(::core::mem::size_of::<size_t>() as isize)
+            pIn = (pIn as *const core::ffi::c_char).add(::core::mem::size_of::<size_t>())
                 as *const core::ffi::c_void;
-            pMatch = (pMatch as *const core::ffi::c_char)
-                .offset(::core::mem::size_of::<size_t>() as isize)
+            pMatch = (pMatch as *const core::ffi::c_char).add(::core::mem::size_of::<size_t>())
                 as *const core::ffi::c_void;
         } else {
             pIn = (pIn as *const core::ffi::c_char).offset(ZSTD_NbCommonBytes(diff) as isize)
@@ -585,38 +583,38 @@ unsafe fn ZDICT_analyzePos(
         0,
         ::core::mem::size_of::<dictItem>(),
     );
-    *doneMarks.offset(pos as isize) = 1;
-    if MEM_read16(b.offset(pos as isize).offset(0) as *const core::ffi::c_void) as core::ffi::c_int
-        == MEM_read16(b.offset(pos as isize).offset(2) as *const core::ffi::c_void)
+    *doneMarks.add(pos) = 1;
+    if MEM_read16(b.add(pos).offset(0) as *const core::ffi::c_void) as core::ffi::c_int
+        == MEM_read16(b.add(pos).offset(2) as *const core::ffi::c_void)
             as core::ffi::c_int
-        || MEM_read16(b.offset(pos as isize).offset(1) as *const core::ffi::c_void)
+        || MEM_read16(b.add(pos).offset(1) as *const core::ffi::c_void)
             as core::ffi::c_int
-            == MEM_read16(b.offset(pos as isize).offset(3) as *const core::ffi::c_void)
+            == MEM_read16(b.add(pos).offset(3) as *const core::ffi::c_void)
                 as core::ffi::c_int
-        || MEM_read16(b.offset(pos as isize).offset(2) as *const core::ffi::c_void)
+        || MEM_read16(b.add(pos).offset(2) as *const core::ffi::c_void)
             as core::ffi::c_int
-            == MEM_read16(b.offset(pos as isize).offset(4) as *const core::ffi::c_void)
+            == MEM_read16(b.add(pos).offset(4) as *const core::ffi::c_void)
                 as core::ffi::c_int
     {
-        let pattern16 = MEM_read16(b.offset(pos as isize).offset(4) as *const core::ffi::c_void);
+        let pattern16 = MEM_read16(b.add(pos).offset(4) as *const core::ffi::c_void);
         let mut u: u32 = 0;
         let mut patternEnd = 6u32;
         while MEM_read16(
-            b.offset(pos as isize).offset(patternEnd as isize) as *const core::ffi::c_void
+            b.add(pos).offset(patternEnd as isize) as *const core::ffi::c_void
         ) as core::ffi::c_int
             == pattern16 as core::ffi::c_int
         {
             patternEnd = patternEnd.wrapping_add(2);
         }
-        if *b.offset(pos.wrapping_add(patternEnd as size_t) as isize) as core::ffi::c_int
-            == *b.offset(pos.wrapping_add(patternEnd as size_t).wrapping_sub(1) as isize)
+        if *b.add(pos.wrapping_add(patternEnd as size_t)) as core::ffi::c_int
+            == *b.add(pos.wrapping_add(patternEnd as size_t).wrapping_sub(1))
                 as core::ffi::c_int
         {
             patternEnd = patternEnd.wrapping_add(1);
         }
         u = 1;
         while u < patternEnd {
-            *doneMarks.offset(pos.wrapping_add(u as size_t) as isize) = 1;
+            *doneMarks.add(pos.wrapping_add(u as size_t)) = 1;
             u = u.wrapping_add(1);
         }
         return solution;
@@ -625,7 +623,7 @@ unsafe fn ZDICT_analyzePos(
     loop {
         end = end.wrapping_add(1);
         length = ZDICT_count(
-            b.offset(pos as isize) as *const core::ffi::c_void,
+            b.add(pos) as *const core::ffi::c_void,
             b.offset(*suffix.offset(end as isize) as isize) as *const core::ffi::c_void,
         );
         if length < MINMATCHLENGTH as size_t {
@@ -635,7 +633,7 @@ unsafe fn ZDICT_analyzePos(
     let mut length_0: size_t = 0;
     loop {
         length_0 = ZDICT_count(
-            b.offset(pos as isize) as *const core::ffi::c_void,
+            b.add(pos) as *const core::ffi::c_void,
             b.offset(*suffix.offset(start as isize).offset(-(1)) as isize)
                 as *const core::ffi::c_void,
         );
@@ -726,13 +724,13 @@ unsafe fn ZDICT_analyzePos(
     loop {
         end = end.wrapping_add(1);
         length_1 = ZDICT_count(
-            b.offset(pos as isize) as *const core::ffi::c_void,
+            b.add(pos) as *const core::ffi::c_void,
             b.offset(*suffix.offset(end as isize) as isize) as *const core::ffi::c_void,
         );
         if length_1 >= LLIMIT as size_t {
             length_1 = (LLIMIT - 1) as size_t;
         }
-        let fresh0 = &mut (*lengthList.as_mut_ptr().offset(length_1 as isize));
+        let fresh0 = &mut (*lengthList.as_mut_ptr().add(length_1));
         *fresh0 = (*fresh0).wrapping_add(1);
         if length_1 < MINMATCHLENGTH as size_t {
             break;
@@ -744,14 +742,14 @@ unsafe fn ZDICT_analyzePos(
         != 0
     {
         length_2 = ZDICT_count(
-            b.offset(pos as isize) as *const core::ffi::c_void,
+            b.add(pos) as *const core::ffi::c_void,
             b.offset(*suffix.offset(start.wrapping_sub(1) as isize) as isize)
                 as *const core::ffi::c_void,
         );
         if length_2 >= LLIMIT as size_t {
             length_2 = (LLIMIT - 1) as size_t;
         }
-        let fresh1 = &mut (*lengthList.as_mut_ptr().offset(length_2 as isize));
+        let fresh1 = &mut (*lengthList.as_mut_ptr().add(length_2));
         *fresh1 = (*fresh1).wrapping_add(1);
         if length_2 >= MINMATCHLENGTH as size_t {
             start = start.wrapping_sub(1);
@@ -763,10 +761,8 @@ unsafe fn ZDICT_analyzePos(
         ::core::mem::size_of::<[u32; 64]>(),
     );
     *cumulLength
-        .as_mut_ptr()
-        .offset(maxLength.wrapping_sub(1) as isize) = *lengthList
-        .as_mut_ptr()
-        .offset(maxLength.wrapping_sub(1) as isize);
+        .as_mut_ptr().add(maxLength.wrapping_sub(1)) = *lengthList
+        .as_mut_ptr().add(maxLength.wrapping_sub(1));
     i = maxLength.wrapping_sub(2) as core::ffi::c_int;
     while i >= 0 {
         *cumulLength.as_mut_ptr().offset(i as isize) =
@@ -784,8 +780,8 @@ unsafe fn ZDICT_analyzePos(
     }
     maxLength = u_0 as size_t;
     let mut l = maxLength as u32;
-    let c = *b.offset(pos.wrapping_add(maxLength).wrapping_sub(1) as isize);
-    while *b.offset(pos.wrapping_add(l as size_t).wrapping_sub(2) as isize) as core::ffi::c_int
+    let c = *b.add(pos.wrapping_add(maxLength).wrapping_sub(1));
+    while *b.add(pos.wrapping_add(l as size_t).wrapping_sub(2)) as core::ffi::c_int
         == c as core::ffi::c_int
     {
         l = l.wrapping_sub(1);
@@ -811,15 +807,15 @@ unsafe fn ZDICT_analyzePos(
                 as *const u8 as *const core::ffi::c_char,
             pos as core::ffi::c_uint,
             maxLength as core::ffi::c_uint,
-            *savings.as_mut_ptr().offset(maxLength as isize),
-            *savings.as_mut_ptr().offset(maxLength as isize) as core::ffi::c_double
+            *savings.as_mut_ptr().add(maxLength),
+            *savings.as_mut_ptr().add(maxLength) as core::ffi::c_double
                 / maxLength as core::ffi::c_double,
         );
         fflush(stderr);
     }
     solution.pos = pos as u32;
     solution.length = maxLength as u32;
-    solution.savings = *savings.as_mut_ptr().offset(maxLength as isize);
+    solution.savings = *savings.as_mut_ptr().add(maxLength);
     let mut id_0: u32 = 0;
     id_0 = start;
     while id_0 < end {
@@ -831,7 +827,7 @@ unsafe fn ZDICT_analyzePos(
             length_3 = solution.length;
         } else {
             length_3 = ZDICT_count(
-                b.offset(pos as isize) as *const core::ffi::c_void,
+                b.add(pos) as *const core::ffi::c_void,
                 b.offset(testedPos as isize) as *const core::ffi::c_void,
             ) as u32;
             if length_3 > solution.length {
@@ -858,8 +854,8 @@ unsafe fn isIncluded(
     let mut u: size_t = 0;
     u = 0;
     while u < length {
-        if *ip.offset(u as isize) as core::ffi::c_int
-            != *into.offset(u as isize) as core::ffi::c_int
+        if *ip.add(u) as core::ffi::c_int
+            != *into.add(u) as core::ffi::c_int
         {
             break;
         }
@@ -1103,20 +1099,20 @@ unsafe fn ZDICT_trainBuffer_legacy(
         if divSuftSortResult != 0 {
             result = -(ZSTD_error_GENERIC as core::ffi::c_int) as size_t;
         } else {
-            *suffix.offset(bufferSize as isize) = bufferSize as core::ffi::c_uint;
+            *suffix.add(bufferSize) = bufferSize as core::ffi::c_uint;
             *suffix0.offset(0) = bufferSize as core::ffi::c_uint;
             let mut pos: size_t = 0;
             pos = 0;
             while pos < bufferSize {
-                *reverseSuffix.offset(*suffix.offset(pos as isize) as isize) = pos as u32;
+                *reverseSuffix.offset(*suffix.add(pos) as isize) = pos as u32;
                 pos = pos.wrapping_add(1);
             }
             *filePos.offset(0) = 0;
             pos = 1;
             while pos < nbFiles as size_t {
-                *filePos.offset(pos as isize) = (*filePos.offset(pos.wrapping_sub(1) as isize)
+                *filePos.add(pos) = (*filePos.add(pos.wrapping_sub(1))
                     as size_t)
-                    .wrapping_add(*fileSizes.offset(pos.wrapping_sub(1) as isize))
+                    .wrapping_add(*fileSizes.add(pos.wrapping_sub(1)))
                     as u32;
                 pos = pos.wrapping_add(1);
             }
@@ -1194,7 +1190,7 @@ unsafe fn ZDICT_fillNoise(mut buffer: *mut core::ffi::c_void, mut length: size_t
     p = 0;
     while p < length {
         acc = acc.wrapping_mul(prime2);
-        *(buffer as *mut core::ffi::c_uchar).offset(p as isize) = (acc >> 21) as core::ffi::c_uchar;
+        *(buffer as *mut core::ffi::c_uchar).add(p) = (acc >> 21) as core::ffi::c_uchar;
         p = p.wrapping_add(1);
     }
 }
@@ -1487,7 +1483,7 @@ unsafe fn ZDICT_analyzeEntropy(
                     matchLengthCount.as_mut_ptr(),
                     litLengthCount.as_mut_ptr(),
                     repOffset.as_mut_ptr(),
-                    (srcBuffer as *const core::ffi::c_char).offset(pos as isize)
+                    (srcBuffer as *const core::ffi::c_char).add(pos)
                         as *const core::ffi::c_void,
                     *fileSizes.offset(u as isize),
                     notificationLevel,
@@ -1670,7 +1666,7 @@ unsafe fn ZDICT_analyzeEntropy(
                                     fflush(stderr);
                                 }
                             } else {
-                                dstPtr = dstPtr.offset(hhSize as isize);
+                                dstPtr = dstPtr.add(hhSize);
                                 maxDstSize = maxDstSize.wrapping_sub(hhSize);
                                 eSize = eSize.wrapping_add(hhSize);
                                 let ohSize = FSE_writeNCount(
@@ -1692,7 +1688,7 @@ unsafe fn ZDICT_analyzeEntropy(
                                         fflush(stderr);
                                     }
                                 } else {
-                                    dstPtr = dstPtr.offset(ohSize as isize);
+                                    dstPtr = dstPtr.add(ohSize);
                                     maxDstSize = maxDstSize.wrapping_sub(ohSize);
                                     eSize = eSize.wrapping_add(ohSize);
                                     let mhSize = FSE_writeNCount(
@@ -1714,7 +1710,7 @@ unsafe fn ZDICT_analyzeEntropy(
                                             fflush(stderr);
                                         }
                                     } else {
-                                        dstPtr = dstPtr.offset(mhSize as isize);
+                                        dstPtr = dstPtr.add(mhSize);
                                         maxDstSize = maxDstSize.wrapping_sub(mhSize);
                                         eSize = eSize.wrapping_add(mhSize);
                                         let lhSize = FSE_writeNCount(
@@ -1735,7 +1731,7 @@ unsafe fn ZDICT_analyzeEntropy(
                                                 fflush(stderr);
                                             }
                                         } else {
-                                            dstPtr = dstPtr.offset(lhSize as isize);
+                                            dstPtr = dstPtr.add(lhSize);
                                             maxDstSize = maxDstSize.wrapping_sub(lhSize);
                                             eSize = eSize.wrapping_add(lhSize);
                                             if maxDstSize < 12 {
@@ -1855,7 +1851,7 @@ pub unsafe extern "C" fn ZDICT_finalizeDictionary(
         fflush(stderr);
     }
     let eSize = ZDICT_analyzeEntropy(
-        header.as_mut_ptr().offset(hSize as isize) as *mut core::ffi::c_void,
+        header.as_mut_ptr().add(hSize) as *mut core::ffi::c_void,
         (HBUFFSIZE as size_t).wrapping_sub(hSize),
         compressionLevel,
         samplesBuffer,
@@ -1884,8 +1880,8 @@ pub unsafe extern "C" fn ZDICT_finalizeDictionary(
         .wrapping_add(paddingSize)
         .wrapping_add(dictContentSize);
     let outDictHeader = dictBuffer as *mut u8;
-    let outDictPadding = outDictHeader.offset(hSize as isize);
-    let outDictContent = outDictPadding.offset(paddingSize as isize);
+    let outDictPadding = outDictHeader.add(hSize);
+    let outDictContent = outDictPadding.add(paddingSize);
     memmove(
         outDictContent as *mut core::ffi::c_void,
         customDictContent,
@@ -1932,14 +1928,13 @@ unsafe fn ZDICT_addEntropyTablesFromBuffer_advanced(
         fflush(stderr);
     }
     let eSize = ZDICT_analyzeEntropy(
-        (dictBuffer as *mut core::ffi::c_char).offset(hSize as isize) as *mut core::ffi::c_void,
+        (dictBuffer as *mut core::ffi::c_char).add(hSize) as *mut core::ffi::c_void,
         dictBufferCapacity.wrapping_sub(hSize),
         compressionLevel,
         samplesBuffer,
         samplesSizes,
         nbSamples,
-        (dictBuffer as *mut core::ffi::c_char)
-            .offset(dictBufferCapacity as isize)
+        (dictBuffer as *mut core::ffi::c_char).add(dictBufferCapacity)
             .offset(-(dictContentSize as isize)) as *const core::ffi::c_void,
         dictContentSize,
         notificationLevel,
@@ -1950,8 +1945,7 @@ unsafe fn ZDICT_addEntropyTablesFromBuffer_advanced(
     hSize = hSize.wrapping_add(eSize);
     MEM_writeLE32(dictBuffer, ZSTD_MAGIC_DICTIONARY);
     let randomID = ZSTD_XXH64(
-        (dictBuffer as *mut core::ffi::c_char)
-            .offset(dictBufferCapacity as isize)
+        (dictBuffer as *mut core::ffi::c_char).add(dictBufferCapacity)
             .offset(-(dictContentSize as isize)) as *const core::ffi::c_void,
         dictContentSize as usize,
         0,
@@ -1969,9 +1963,8 @@ unsafe fn ZDICT_addEntropyTablesFromBuffer_advanced(
     );
     if hSize.wrapping_add(dictContentSize) < dictBufferCapacity {
         memmove(
-            (dictBuffer as *mut core::ffi::c_char).offset(hSize as isize) as *mut core::ffi::c_void,
-            (dictBuffer as *mut core::ffi::c_char)
-                .offset(dictBufferCapacity as isize)
+            (dictBuffer as *mut core::ffi::c_char).add(hSize) as *mut core::ffi::c_void,
+            (dictBuffer as *mut core::ffi::c_char).add(dictBufferCapacity)
                 .offset(-(dictContentSize as isize)) as *const core::ffi::c_void,
             dictContentSize,
         );
@@ -2197,7 +2190,7 @@ unsafe fn ZDICT_trainFromBuffer_unsafe_legacy(
     (*dictList).pos = n;
     dictContentSize_0 = currentSize;
     let mut u_0: u32 = 0;
-    let mut ptr = (dictBuffer as *mut u8).offset(maxDictSize as isize);
+    let mut ptr = (dictBuffer as *mut u8).add(maxDictSize);
     u_0 = 1;
     while u_0 < (*dictList).pos {
         let mut l = (*dictList.offset(u_0 as isize)).length;
@@ -2248,7 +2241,7 @@ pub unsafe extern "C" fn ZDICT_trainFromBuffer_legacy(
     }
     memcpy(newBuff, samplesBuffer, sBuffSize);
     ZDICT_fillNoise(
-        (newBuff as *mut core::ffi::c_char).offset(sBuffSize as isize) as *mut core::ffi::c_void,
+        (newBuff as *mut core::ffi::c_char).add(sBuffSize) as *mut core::ffi::c_void,
         NOISELENGTH as size_t,
     );
     result = ZDICT_trainFromBuffer_unsafe_legacy(

--- a/programs/benchfn.rs
+++ b/programs/benchfn.rs
@@ -125,9 +125,9 @@ pub unsafe fn BMK_benchFunction(
     i = 0;
     while i < p.blockCount {
         memset(
-            *(p.dstBuffers).offset(i as isize),
+            *(p.dstBuffers).add(i),
             0xe5,
-            *(p.dstCapacities).offset(i as isize),
+            *(p.dstCapacities).add(i),
         );
         i = i.wrapping_add(1);
     }

--- a/programs/benchzstd.rs
+++ b/programs/benchzstd.rs
@@ -298,7 +298,7 @@ unsafe fn XXH64_endian_align(
         ::core::hint::assert_unchecked(len == 0);
     }
     if len >= 32 {
-        let bEnd = input.offset(len as isize);
+        let bEnd = input.add(len);
         let limit = bEnd.offset(-(31));
         let mut v1 = (seed as core::ffi::c_ulonglong)
             .wrapping_add(XXH_PRIME64_1)
@@ -405,7 +405,7 @@ unsafe fn formatString_u(
         if *formatString.offset(i as isize) as core::ffi::c_int != '%' as i32 {
             let fresh2 = written;
             written = written.wrapping_add(1);
-            *buffer.offset(fresh2 as isize) = *formatString.offset(i as isize);
+            *buffer.add(fresh2) = *formatString.offset(i as isize);
         } else {
             i += 1;
             if *formatString.offset(i as isize) as core::ffi::c_int == 'u' as i32 {
@@ -413,7 +413,7 @@ unsafe fn formatString_u(
                     abort();
                 }
                 writeUint_varLen(
-                    buffer.offset(written as isize),
+                    buffer.add(written),
                     buffer_size.wrapping_sub(written),
                     value,
                 );
@@ -421,7 +421,7 @@ unsafe fn formatString_u(
             } else if *formatString.offset(i as isize) as core::ffi::c_int == '%' as i32 {
                 let fresh3 = written;
                 written = written.wrapping_add(1);
-                *buffer.offset(fresh3 as isize) = '%' as i32 as core::ffi::c_char;
+                *buffer.add(fresh3) = '%' as i32 as core::ffi::c_char;
             } else {
                 abort();
             }
@@ -429,7 +429,7 @@ unsafe fn formatString_u(
         i += 1;
     }
     if written < buffer_size {
-        *buffer.offset(written as isize) = '\0' as i32 as core::ffi::c_char;
+        *buffer.add(written) = '\0' as i32 as core::ffi::c_char;
     } else {
         abort();
     }
@@ -1065,7 +1065,7 @@ unsafe fn BMK_benchMemAdvancedNoAlloc(
         ::core::mem::size_of::<BMK_benchResult_t>(),
     );
     if strlen(displayName) > 17 {
-        displayName = displayName.offset((strlen(displayName)).wrapping_sub(17) as isize);
+        displayName = displayName.add((strlen(displayName)).wrapping_sub(17));
     }
     if (*adv).mode as core::ffi::c_uint == BMK_decodeOnly as core::ffi::c_int as core::ffi::c_uint {
         let mut srcPtr = srcBuffer as *const core::ffi::c_char;
@@ -1154,7 +1154,7 @@ unsafe fn BMK_benchMemAdvancedNoAlloc(
                 return r_0;
             }
             totalDSize64 = totalDSize64.wrapping_add(fSize64);
-            srcPtr = srcPtr.offset(*fileSizes.offset(fileNb as isize) as isize);
+            srcPtr = srcPtr.add(*fileSizes.offset(fileNb as isize));
             fileNb = fileNb.wrapping_add(1);
         }
         let decodedSize = totalDSize64 as size_t;
@@ -1285,9 +1285,9 @@ unsafe fn BMK_benchMemAdvancedNoAlloc(
             } else {
                 chunkSize
             };
-            srcPtr_0 = srcPtr_0.offset(chunkSize as isize);
-            cPtr = cPtr.offset(*cCapacities.offset(chunkID as isize) as isize);
-            resPtr = resPtr.offset(chunkSize as isize);
+            srcPtr_0 = srcPtr_0.add(chunkSize);
+            cPtr = cPtr.add(*cCapacities.offset(chunkID as isize));
+            resPtr = resPtr.add(chunkSize);
             reing = reing.wrapping_sub(chunkSize);
             if (*adv).mode as core::ffi::c_uint
                 == BMK_decodeOnly as core::ffi::c_int as core::ffi::c_uint
@@ -1611,8 +1611,8 @@ unsafe fn BMK_benchMemAdvancedNoAlloc(
         fflush(NULL as *mut FILE);
         u = 0;
         while u < srcSize {
-            if *(srcBuffer as *const u8).offset(u as isize) as core::ffi::c_int
-                != *resultBuffer.offset(u as isize) as core::ffi::c_int
+            if *(srcBuffer as *const u8).add(u) as core::ffi::c_int
+                != *resultBuffer.add(u) as core::ffi::c_int
             {
                 let mut segNb: core::ffi::c_uint = 0;
                 let mut bNb: core::ffi::c_uint = 0;
@@ -1654,7 +1654,7 @@ unsafe fn BMK_benchMemAdvancedNoAlloc(
                     fprintf(
                         stderr,
                         b"%02X \0" as *const u8 as *const core::ffi::c_char,
-                        *(srcBuffer as *const u8).offset(u.wrapping_sub(n) as isize)
+                        *(srcBuffer as *const u8).add(u.wrapping_sub(n))
                             as core::ffi::c_int,
                     );
                     fflush(NULL as *mut FILE);
@@ -1663,7 +1663,7 @@ unsafe fn BMK_benchMemAdvancedNoAlloc(
                 fprintf(
                     stderr,
                     b" :%02X:  \0" as *const u8 as *const core::ffi::c_char,
-                    *(srcBuffer as *const u8).offset(u as isize) as core::ffi::c_int,
+                    *(srcBuffer as *const u8).add(u) as core::ffi::c_int,
                 );
                 fflush(NULL as *mut FILE);
                 n = 1;
@@ -1671,7 +1671,7 @@ unsafe fn BMK_benchMemAdvancedNoAlloc(
                     fprintf(
                         stderr,
                         b"%02X \0" as *const u8 as *const core::ffi::c_char,
-                        *(srcBuffer as *const u8).offset(u.wrapping_add(n) as isize)
+                        *(srcBuffer as *const u8).add(u.wrapping_add(n))
                             as core::ffi::c_int,
                     );
                     fflush(NULL as *mut FILE);
@@ -1689,7 +1689,7 @@ unsafe fn BMK_benchMemAdvancedNoAlloc(
                     fprintf(
                         stderr,
                         b"%02X \0" as *const u8 as *const core::ffi::c_char,
-                        *resultBuffer.offset(u.wrapping_sub(n) as isize) as core::ffi::c_int,
+                        *resultBuffer.add(u.wrapping_sub(n)) as core::ffi::c_int,
                     );
                     fflush(NULL as *mut FILE);
                     n = n.wrapping_sub(1);
@@ -1697,7 +1697,7 @@ unsafe fn BMK_benchMemAdvancedNoAlloc(
                 fprintf(
                     stderr,
                     b" :%02X:  \0" as *const u8 as *const core::ffi::c_char,
-                    *resultBuffer.offset(u as isize) as core::ffi::c_int,
+                    *resultBuffer.add(u) as core::ffi::c_int,
                 );
                 fflush(NULL as *mut FILE);
                 n = 1;
@@ -1705,7 +1705,7 @@ unsafe fn BMK_benchMemAdvancedNoAlloc(
                     fprintf(
                         stderr,
                         b"%02X \0" as *const u8 as *const core::ffi::c_char,
-                        *resultBuffer.offset(u.wrapping_add(n) as isize) as core::ffi::c_int,
+                        *resultBuffer.add(u.wrapping_add(n)) as core::ffi::c_int,
                     );
                     fflush(NULL as *mut FILE);
                     n = n.wrapping_add(1);
@@ -2252,7 +2252,7 @@ unsafe fn BMK_loadFiles(
                 fflush(NULL as *mut FILE);
             }
             let readSize = fread(
-                (buffer as *mut core::ffi::c_char).offset(pos as isize) as *mut core::ffi::c_void,
+                (buffer as *mut core::ffi::c_char).add(pos) as *mut core::ffi::c_void,
                 1,
                 fileSize as size_t,
                 f,

--- a/programs/datagen.rs
+++ b/programs/datagen.rs
@@ -91,19 +91,19 @@ unsafe fn RDG_genBlock(
         size0 = size0.wrapping_add(RDG_rand(seedPtr) as size_t & size0.wrapping_sub(1));
         if buffSize < pos.wrapping_add(size0) {
             memset(
-                buffPtr.offset(pos as isize) as *mut core::ffi::c_void,
+                buffPtr.add(pos) as *mut core::ffi::c_void,
                 0,
                 buffSize.wrapping_sub(pos),
             );
             return;
         }
         memset(
-            buffPtr.offset(pos as isize) as *mut core::ffi::c_void,
+            buffPtr.add(pos) as *mut core::ffi::c_void,
             0,
             size0,
         );
         pos = pos.wrapping_add(size0);
-        *buffPtr.offset(pos.wrapping_sub(1) as isize) = RDG_genChar(seedPtr, ldt);
+        *buffPtr.add(pos.wrapping_sub(1)) = RDG_genChar(seedPtr, ldt);
     }
     if pos == 0 {
         *buffPtr.offset(0) = RDG_genChar(seedPtr, ldt);
@@ -134,7 +134,7 @@ unsafe fn RDG_genBlock(
                 match_0 = match_0.wrapping_add(1);
                 let fresh2 = pos;
                 pos = pos.wrapping_add(1);
-                *buffPtr.offset(fresh2 as isize) = *buffPtr.offset(fresh1 as isize);
+                *buffPtr.add(fresh2) = *buffPtr.add(fresh1);
             }
             prevOffset = offset;
         } else {
@@ -147,7 +147,7 @@ unsafe fn RDG_genBlock(
             while pos < d_0 as size_t {
                 let fresh3 = pos;
                 pos = pos.wrapping_add(1);
-                *buffPtr.offset(fresh3 as isize) = RDG_genChar(seedPtr, ldt);
+                *buffPtr.add(fresh3) = RDG_genChar(seedPtr, ldt);
             }
         }
     }
@@ -231,7 +231,7 @@ pub unsafe fn RDG_genStdout(
         let _ = fwrite(buff as *const core::ffi::c_void, 1, genBlockSize, stdout);
         memcpy(
             buff as *mut core::ffi::c_void,
-            buff.offset(stdBlockSize as isize) as *const core::ffi::c_void,
+            buff.add(stdBlockSize) as *const core::ffi::c_void,
             stdDictSize,
         );
     }

--- a/programs/dibio.rs
+++ b/programs/dibio.rs
@@ -123,7 +123,7 @@ unsafe fn DiB_loadFiles(
                 break;
             }
             if fread(
-                buff.offset(totalDataLoaded as isize) as *mut core::ffi::c_void,
+                buff.add(totalDataLoaded) as *mut core::ffi::c_void,
                 1,
                 fileDataLoaded,
                 f,
@@ -158,7 +158,7 @@ unsafe fn DiB_loadFiles(
                         break;
                     }
                     if fread(
-                        buff.offset(totalDataLoaded as isize) as *mut core::ffi::c_void,
+                        buff.add(totalDataLoaded) as *mut core::ffi::c_void,
                         1,
                         chunkSize,
                         f,
@@ -264,7 +264,7 @@ unsafe fn DiB_fillNoise(mut buffer: *mut core::ffi::c_void, mut length: size_t) 
     p = 0;
     while p < length {
         acc = acc.wrapping_mul(prime2);
-        *(buffer as *mut core::ffi::c_uchar).offset(p as isize) = (acc >> 21) as core::ffi::c_uchar;
+        *(buffer as *mut core::ffi::c_uchar).add(p) = (acc >> 21) as core::ffi::c_uchar;
         p = p.wrapping_add(1);
     }
 }
@@ -587,7 +587,7 @@ pub unsafe fn DiB_trainFromFiles(
     let mut dictSize = ZSTD_error_GENERIC as core::ffi::c_int as size_t;
     if !params.is_null() {
         DiB_fillNoise(
-            (srcBuffer as *mut core::ffi::c_char).offset(loadedSize as isize)
+            (srcBuffer as *mut core::ffi::c_char).add(loadedSize)
                 as *mut core::ffi::c_void,
             NOISELENGTH as size_t,
         );

--- a/programs/fileio.rs
+++ b/programs/fileio.rs
@@ -836,7 +836,7 @@ pub unsafe fn FIO_determineHasStdinInput(fCtx: *mut FIO_ctx_t, filenames: *const
     while i < (*filenames).tableSize {
         if strcmp(
             stdinmark.as_ptr(),
-            *((*filenames).fileNames).offset(i as isize),
+            *((*filenames).fileNames).add(i),
         ) == 0
         {
             (*fCtx).hasStdinInput = 1;
@@ -1656,22 +1656,22 @@ unsafe fn FIO_createFilename_fromOutDir(
         outDirName as *const core::ffi::c_void,
         strlen(outDirName),
     );
-    if *outDirName.offset((strlen(outDirName)).wrapping_sub(1) as isize) as core::ffi::c_int
+    if *outDirName.add((strlen(outDirName)).wrapping_sub(1)) as core::ffi::c_int
         == separator as core::ffi::c_int
     {
         memcpy(
-            result.offset(strlen(outDirName) as isize) as *mut core::ffi::c_void,
+            result.add(strlen(outDirName)) as *mut core::ffi::c_void,
             filenameStart as *const core::ffi::c_void,
             strlen(filenameStart),
         );
     } else {
         memcpy(
-            result.offset(strlen(outDirName) as isize) as *mut core::ffi::c_void,
+            result.add(strlen(outDirName)) as *mut core::ffi::c_void,
             &mut separator as *mut core::ffi::c_char as *const core::ffi::c_void,
             1,
         );
         memcpy(
-            result.offset(strlen(outDirName) as isize).offset(1) as *mut core::ffi::c_void,
+            result.add(strlen(outDirName)).offset(1) as *mut core::ffi::c_void,
             filenameStart as *const core::ffi::c_void,
             strlen(filenameStart),
         );
@@ -4521,7 +4521,7 @@ unsafe fn FIO_compressZstdFrame(
                         let mut srcFileNameSize = strlen(srcFileName);
                         if srcFileNameSize > 18 {
                             let mut truncatedSrcFileName =
-                                srcFileName.offset(srcFileNameSize as isize).offset(-(15));
+                                srcFileName.add(srcFileNameSize).offset(-(15));
                             if g_display_prefs.progressSetting as core::ffi::c_uint
                                 != FIO_ps_never as core::ffi::c_int as core::ffi::c_uint
                                 && (g_display_prefs.displayLevel >= 2
@@ -5384,7 +5384,7 @@ unsafe fn FIO_determineCompressedName(
         );
     }
     memcpy(
-        dstFileNameBuffer.offset(sfnSize as isize) as *mut core::ffi::c_void,
+        dstFileNameBuffer.add(sfnSize) as *mut core::ffi::c_void,
         suffix as *const core::ffi::c_void,
         srcSuffixLen.wrapping_add(1),
     );
@@ -5399,7 +5399,7 @@ unsafe fn FIO_getLargestFileSize(
     let mut maxFileSize = 0;
     i = 0;
     while i < nbFiles as size_t {
-        fileSize = UTIL_getFileSize(*inFileNames.offset(i as isize)) as core::ffi::c_ulonglong;
+        fileSize = UTIL_getFileSize(*inFileNames.add(i)) as core::ffi::c_ulonglong;
         maxFileSize = if fileSize > maxFileSize {
             fileSize
         } else {
@@ -6132,7 +6132,7 @@ unsafe fn FIO_decompressZstdFrame(
     assert!(!writeJob.is_null());
     let srcFileLength = strlen(srcFileName);
     if srcFileLength > 20 && g_display_prefs.displayLevel < 3 {
-        srcFName20 = srcFName20.offset(srcFileLength.wrapping_sub(20) as isize);
+        srcFName20 = srcFName20.add(srcFileLength.wrapping_sub(20));
     }
     ZSTD_DCtx_reset((*ress).dctx, ZSTD_reset_session_only);
     AIO_ReadPool_fillBuffer((*ress).readCtx, ZSTD_FRAMEHEADERSIZE_MAX as size_t);
@@ -6897,7 +6897,7 @@ unsafe fn FIO_determineDstName(
         );
     }
     strcpy(
-        dstFileNameBuffer.offset(dstFileNameEndPos as isize),
+        dstFileNameBuffer.add(dstFileNameEndPos),
         dstSuffix,
     );
     dstFileNameBuffer

--- a/programs/lorem.rs
+++ b/programs/lorem.rs
@@ -285,12 +285,12 @@ unsafe fn countFreqs(
     let mut w: size_t = 0;
     w = 0;
     while w < nbWords {
-        let mut len = strlen((*words.offset(w as isize)).as_ptr());
+        let mut len = strlen((*words.add(w)).as_ptr());
         let mut lmax: core::ffi::c_int = 0;
         if len >= nbWeights {
             len = nbWeights.wrapping_sub(1);
         }
-        lmax = *weights.offset(len as isize);
+        lmax = *weights.add(len);
         total = total.wrapping_add(lmax as core::ffi::c_uint);
         w = w.wrapping_add(1);
     }
@@ -308,18 +308,18 @@ unsafe fn init_word_distrib(
     countFreqs(words, nbWords, weights, nbWeights);
     w = 0;
     while w < nbWords {
-        let mut len = strlen((*words.offset(w as isize)).as_ptr());
+        let mut len = strlen((*words.add(w)).as_ptr());
         let mut l: core::ffi::c_int = 0;
         let mut lmax: core::ffi::c_int = 0;
         if len >= nbWeights {
             len = nbWeights.wrapping_sub(1);
         }
-        lmax = *weights.offset(len as isize);
+        lmax = *weights.add(len);
         l = 0;
         while l < lmax {
             let fresh0 = d;
             d = d.wrapping_add(1);
-            *g_distrib.as_mut_ptr().offset(fresh0 as isize) = w as core::ffi::c_int;
+            *g_distrib.as_mut_ptr().add(fresh0) = w as core::ffi::c_int;
             l += 1;
         }
         w = w.wrapping_add(1);
@@ -348,16 +348,16 @@ unsafe fn writeLastCharacters() {
     }
     let fresh1 = g_nbChars;
     g_nbChars = g_nbChars.wrapping_add(1);
-    *g_ptr.offset(fresh1 as isize) = '.' as i32 as core::ffi::c_char;
+    *g_ptr.add(fresh1) = '.' as i32 as core::ffi::c_char;
     if lastChars > 2 {
         memset(
-            g_ptr.offset(g_nbChars as isize) as *mut core::ffi::c_void,
+            g_ptr.add(g_nbChars) as *mut core::ffi::c_void,
             ' ' as i32,
             lastChars.wrapping_sub(2),
         );
     }
     if lastChars > 1 {
-        *g_ptr.offset(g_maxChars.wrapping_sub(1) as isize) = '\n' as i32 as core::ffi::c_char;
+        *g_ptr.add(g_maxChars.wrapping_sub(1)) = '\n' as i32 as core::ffi::c_char;
     }
     g_nbChars = g_maxChars;
 }
@@ -372,19 +372,19 @@ unsafe fn generateWord(
         return;
     }
     memcpy(
-        g_ptr.offset(g_nbChars as isize) as *mut core::ffi::c_void,
+        g_ptr.add(g_nbChars) as *mut core::ffi::c_void,
         word as *const core::ffi::c_void,
         strlen(word),
     );
     if upCase != 0 {
         static toUp: core::ffi::c_char = ('A' as i32 - 'a' as i32) as core::ffi::c_char;
-        *g_ptr.offset(g_nbChars as isize) = (*g_ptr.offset(g_nbChars as isize) as core::ffi::c_int
+        *g_ptr.add(g_nbChars) = (*g_ptr.add(g_nbChars) as core::ffi::c_int
             + toUp as core::ffi::c_int)
             as core::ffi::c_char;
     }
     g_nbChars = g_nbChars.wrapping_add(strlen(word)) as size_t as size_t;
     memcpy(
-        g_ptr.offset(g_nbChars as isize) as *mut core::ffi::c_void,
+        g_ptr.add(g_nbChars) as *mut core::ffi::c_void,
         separator as *const core::ffi::c_void,
         strlen(separator),
     );
@@ -434,12 +434,12 @@ unsafe fn generateParagraph(mut nbSentences: core::ffi::c_int) {
     if g_nbChars < g_maxChars {
         let fresh2 = g_nbChars;
         g_nbChars = g_nbChars.wrapping_add(1);
-        *g_ptr.offset(fresh2 as isize) = '\n' as i32 as core::ffi::c_char;
+        *g_ptr.add(fresh2) = '\n' as i32 as core::ffi::c_char;
     }
     if g_nbChars < g_maxChars {
         let fresh3 = g_nbChars;
         g_nbChars = g_nbChars.wrapping_add(1);
-        *g_ptr.offset(fresh3 as isize) = '\n' as i32 as core::ffi::c_char;
+        *g_ptr.add(fresh3) = '\n' as i32 as core::ffi::c_char;
     }
 }
 unsafe fn generateFirstSentence() {

--- a/programs/zstdcli.rs
+++ b/programs/zstdcli.rs
@@ -292,8 +292,8 @@ unsafe fn exeNameMatch(
     mut test: *const core::ffi::c_char,
 ) -> core::ffi::c_int {
     (strncmp(exeName, test, strlen(test)) == 0
-        && (*exeName.offset(strlen(test) as isize) as core::ffi::c_int == '\0' as i32
-            || *exeName.offset(strlen(test) as isize) as core::ffi::c_int == '.' as i32))
+        && (*exeName.add(strlen(test)) as core::ffi::c_int == '\0' as i32
+            || *exeName.add(strlen(test)) as core::ffi::c_int == '.' as i32))
         as core::ffi::c_int
 }
 unsafe fn usage(mut f: *mut FILE, mut programName: *const core::ffi::c_char) {
@@ -931,7 +931,7 @@ unsafe fn longCommandWArg(
     let comSize = strlen(longCommand);
     let result = (strncmp(*stringPtr, longCommand, comSize) == 0) as core::ffi::c_int;
     if result != 0 {
-        *stringPtr = (*stringPtr).offset(comSize as isize);
+        *stringPtr = (*stringPtr).add(comSize);
     }
     result
 }
@@ -2491,7 +2491,7 @@ unsafe fn main_0(
                                     if *argument as core::ffi::c_int == '=' as i32 {
                                         argument = argument.offset(1);
                                         __nb = argument;
-                                        argument = argument.offset(strlen(__nb) as isize);
+                                        argument = argument.add(strlen(__nb));
                                     } else {
                                         argNb += 1;
                                         if argNb >= argCount {
@@ -2556,7 +2556,7 @@ unsafe fn main_0(
                                     if *argument as core::ffi::c_int == '=' as i32 {
                                         argument = argument.offset(1);
                                         __nb_0 = argument;
-                                        argument = argument.offset(strlen(__nb_0) as isize);
+                                        argument = argument.add(strlen(__nb_0));
                                     } else {
                                         argNb += 1;
                                         if argNb >= argCount {
@@ -2620,7 +2620,7 @@ unsafe fn main_0(
                                     if *argument as core::ffi::c_int == '=' as i32 {
                                         argument = argument.offset(1);
                                         __nb_1 = argument;
-                                        argument = argument.offset(strlen(__nb_1) as isize);
+                                        argument = argument.add(strlen(__nb_1));
                                     } else {
                                         argNb += 1;
                                         if argNb >= argCount {
@@ -2685,7 +2685,7 @@ unsafe fn main_0(
                                     if *argument as core::ffi::c_int == '=' as i32 {
                                         argument = argument.offset(1);
                                         __nb_2 = argument;
-                                        argument = argument.offset(strlen(__nb_2) as isize);
+                                        argument = argument.add(strlen(__nb_2));
                                     } else {
                                         argNb += 1;
                                         if argNb >= argCount {
@@ -2749,7 +2749,7 @@ unsafe fn main_0(
                                     if *argument as core::ffi::c_int == '=' as i32 {
                                         argument = argument.offset(1);
                                         __nb_3 = argument;
-                                        argument = argument.offset(strlen(__nb_3) as isize);
+                                        argument = argument.add(strlen(__nb_3));
                                     } else {
                                         argNb += 1;
                                         if argNb >= argCount {
@@ -2813,7 +2813,7 @@ unsafe fn main_0(
                                     if *argument as core::ffi::c_int == '=' as i32 {
                                         argument = argument.offset(1);
                                         __nb_4 = argument;
-                                        argument = argument.offset(strlen(__nb_4) as isize);
+                                        argument = argument.add(strlen(__nb_4));
                                     } else {
                                         argNb += 1;
                                         if argNb >= argCount {
@@ -2877,7 +2877,7 @@ unsafe fn main_0(
                                     if *argument as core::ffi::c_int == '=' as i32 {
                                         argument = argument.offset(1);
                                         __nb_5 = argument;
-                                        argument = argument.offset(strlen(__nb_5) as isize);
+                                        argument = argument.add(strlen(__nb_5));
                                     } else {
                                         argNb += 1;
                                         if argNb >= argCount {
@@ -2941,7 +2941,7 @@ unsafe fn main_0(
                                     if *argument as core::ffi::c_int == '=' as i32 {
                                         argument = argument.offset(1);
                                         __nb_6 = argument;
-                                        argument = argument.offset(strlen(__nb_6) as isize);
+                                        argument = argument.add(strlen(__nb_6));
                                     } else {
                                         argNb += 1;
                                         if argNb >= argCount {
@@ -3005,7 +3005,7 @@ unsafe fn main_0(
                                     if *argument as core::ffi::c_int == '=' as i32 {
                                         argument = argument.offset(1);
                                         __nb_7 = argument;
-                                        argument = argument.offset(strlen(__nb_7) as isize);
+                                        argument = argument.add(strlen(__nb_7));
                                     } else {
                                         argNb += 1;
                                         if argNb >= argCount {
@@ -3084,7 +3084,7 @@ unsafe fn main_0(
                                     if *argument as core::ffi::c_int == '=' as i32 {
                                         argument = argument.offset(1);
                                         __nb_8 = argument;
-                                        argument = argument.offset(strlen(__nb_8) as isize);
+                                        argument = argument.add(strlen(__nb_8));
                                     } else {
                                         argNb += 1;
                                         if argNb >= argCount {
@@ -3149,7 +3149,7 @@ unsafe fn main_0(
                                     if *argument as core::ffi::c_int == '=' as i32 {
                                         argument = argument.offset(1);
                                         __nb_9 = argument;
-                                        argument = argument.offset(strlen(__nb_9) as isize);
+                                        argument = argument.add(strlen(__nb_9));
                                     } else {
                                         argNb += 1;
                                         if argNb >= argCount {
@@ -3213,7 +3213,7 @@ unsafe fn main_0(
                                     if *argument as core::ffi::c_int == '=' as i32 {
                                         argument = argument.offset(1);
                                         __nb_10 = argument;
-                                        argument = argument.offset(strlen(__nb_10) as isize);
+                                        argument = argument.add(strlen(__nb_10));
                                     } else {
                                         argNb += 1;
                                         if argNb >= argCount {
@@ -3277,7 +3277,7 @@ unsafe fn main_0(
                                     if *argument as core::ffi::c_int == '=' as i32 {
                                         argument = argument.offset(1);
                                         outDirName = argument;
-                                        argument = argument.offset(strlen(outDirName) as isize);
+                                        argument = argument.add(strlen(outDirName));
                                     } else {
                                         argNb += 1;
                                         if argNb >= argCount {
@@ -3348,7 +3348,7 @@ unsafe fn main_0(
                                     if *argument as core::ffi::c_int == '=' as i32 {
                                         argument = argument.offset(1);
                                         threadDefault = argument;
-                                        argument = argument.offset(strlen(threadDefault) as isize);
+                                        argument = argument.add(strlen(threadDefault));
                                     } else {
                                         argNb += 1;
                                         if argNb >= argCount {
@@ -3415,7 +3415,7 @@ unsafe fn main_0(
                                         argument = argument.offset(1);
                                         outMirroredDirName = argument;
                                         argument =
-                                            argument.offset(strlen(outMirroredDirName) as isize);
+                                            argument.add(strlen(outMirroredDirName));
                                     } else {
                                         argNb += 1;
                                         if argNb >= argCount {
@@ -3486,7 +3486,7 @@ unsafe fn main_0(
                                     if *argument as core::ffi::c_int == '=' as i32 {
                                         argument = argument.offset(1);
                                         traceFile = argument;
-                                        argument = argument.offset(strlen(traceFile) as isize);
+                                        argument = argument.add(strlen(traceFile));
                                     } else {
                                         argNb += 1;
                                         if argNb >= argCount {
@@ -3546,7 +3546,7 @@ unsafe fn main_0(
                                         argument = argument.offset(1);
                                         patchFromDictFileName = argument;
                                         argument =
-                                            argument.offset(strlen(patchFromDictFileName) as isize);
+                                            argument.add(strlen(patchFromDictFileName));
                                     } else {
                                         argNb += 1;
                                         if argNb >= argCount {
@@ -3607,7 +3607,7 @@ unsafe fn main_0(
                                         argument = argument.offset(1);
                                         patchFromDictFileName = argument;
                                         argument =
-                                            argument.offset(strlen(patchFromDictFileName) as isize);
+                                            argument.add(strlen(patchFromDictFileName));
                                     } else {
                                         argNb += 1;
                                         if argNb >= argCount {
@@ -3724,7 +3724,7 @@ unsafe fn main_0(
                                     if *argument as core::ffi::c_int == '=' as i32 {
                                         argument = argument.offset(1);
                                         listName = argument;
-                                        argument = argument.offset(strlen(listName) as isize);
+                                        argument = argument.add(strlen(listName));
                                     } else {
                                         argNb += 1;
                                         if argNb >= argCount {
@@ -3836,7 +3836,7 @@ unsafe fn main_0(
                                     if *argument as core::ffi::c_int == '=' as i32 {
                                         argument = argument.offset(1);
                                         outFileName = argument;
-                                        argument = argument.offset(strlen(outFileName) as isize);
+                                        argument = argument.add(strlen(outFileName));
                                     } else {
                                         argNb += 1;
                                         if argNb >= argCount {
@@ -3896,7 +3896,7 @@ unsafe fn main_0(
                                     if *argument as core::ffi::c_int == '=' as i32 {
                                         argument = argument.offset(1);
                                         dictFileName = argument;
-                                        argument = argument.offset(strlen(dictFileName) as isize);
+                                        argument = argument.add(strlen(dictFileName));
                                     } else {
                                         argNb += 1;
                                         if argNb >= argCount {
@@ -4156,7 +4156,7 @@ unsafe fn main_0(
                             break;
                         }
                         let fnt = UTIL_createFileNamesTable_fromFileList(
-                            *((*file_of_names).fileNames).offset(flNb as isize),
+                            *((*file_of_names).fileNames).add(flNb),
                         );
                         if fnt.is_null() {
                             if g_displayLevel >= 1 {
@@ -4164,7 +4164,7 @@ unsafe fn main_0(
                                     stderr,
                                     b"zstd: error reading %s \n\0" as *const u8
                                         as *const core::ffi::c_char,
-                                    *((*file_of_names).fileNames).offset(flNb as isize),
+                                    *((*file_of_names).fileNames).add(flNb),
                                 );
                             }
                             operationResult = 1;
@@ -4683,20 +4683,14 @@ unsafe fn main_0(
                                                             while fileNb < (*filenames).tableSize {
                                                                 if showDefaultCParams != 0 {
                                                                     printDefaultCParams(
-                                                                        *((*filenames).fileNames)
-                                                                            .offset(
-                                                                                fileNb as isize,
-                                                                            ),
+                                                                        *((*filenames).fileNames).add(fileNb),
                                                                         dictFileName,
                                                                         cLevel,
                                                                     );
                                                                 }
                                                                 if g_displayLevel >= 4 {
                                                                     printActualCParams(
-                                                                        *((*filenames).fileNames)
-                                                                            .offset(
-                                                                                fileNb as isize,
-                                                                            ),
+                                                                        *((*filenames).fileNames).add(fileNb),
                                                                         dictFileName,
                                                                         cLevel,
                                                                         &mut compressionParams,


### PR DESCRIPTION
I think this is uncontroversial, and the vast majority of the changes. I'll rebase the other branch on top of this.

```
RUSTFLAGS="-Aclippy::all -D clippy::ptr_offset_with_cast" cargo clippy --fix --allow-dirty
```