### PR TITLE
Remove handling of the legacy formats from the public API

### DIFF
--- a/c2rust-lib.rs
+++ b/c2rust-lib.rs
@@ -43,10 +43,10 @@ pub mod lib {
         pub(crate) mod fastcover;
         pub(crate) mod zdict;
     } // mod dictBuilder
-    pub mod legacy {
-        pub mod zstd_v05;
-        pub mod zstd_v06;
-        pub mod zstd_v07;
+    pub(crate) mod legacy {
+        pub(crate) mod zstd_v05;
+        pub(crate) mod zstd_v06;
+        pub(crate) mod zstd_v07;
     } // mod legacy
     pub mod zdict;
     pub mod zstd;


### PR DESCRIPTION
Debian doesn't ship these headers and only allows decompressing the legacy formats through the standard API.