### PR TITLE
Replace more __errno_location with io::Error::last_os_error

### DIFF
--- a/programs/benchzstd.rs
+++ b/programs/benchzstd.rs
@@ -1,8 +1,10 @@
 use core::ptr;
+use std::ffi::CStr;
+use std::io;
 
 use libc::{
-    __errno_location, abort, calloc, exit, fclose, fflush, fopen, fprintf, fread, free, malloc,
-    memcpy, setpriority, size_t, strerror, strlen, strrchr, FILE, PRIO_PROCESS,
+    abort, calloc, exit, fclose, fflush, fopen, fprintf, fread, free, malloc, memcpy, setpriority,
+    size_t, strlen, strrchr, FILE, PRIO_PROCESS,
 };
 use libzstd_rs_sys::internal::ZSTD_XXH64;
 use libzstd_rs_sys::lib::common::zstd_common::{ZSTD_getErrorName, ZSTD_isError};
@@ -2149,11 +2151,10 @@ pub unsafe fn BMK_benchFilesAdvanced(
         let dictFileSize = UTIL_getFileSize(dictFileName);
         if dictFileSize == UTIL_FILESIZE_UNKNOWN as u64 {
             if displayLevel >= 1 {
-                fprintf(
-                    stderr,
-                    b"error loading %s : %s \n\0" as *const u8 as *const core::ffi::c_char,
-                    dictFileName,
-                    strerror(*__errno_location()),
+                eprintln!(
+                    "error loading {} : {}",
+                    CStr::from_ptr(dictFileName).to_string_lossy(),
+                    io::Error::last_os_error(),
                 );
                 fflush(core::ptr::null_mut());
             }

--- a/programs/dibio.rs
+++ b/programs/dibio.rs
@@ -1,9 +1,8 @@
 use core::ptr;
+use std::ffi::CStr;
+use std::io;
 
-use libc::{
-    __errno_location, exit, fclose, fflush, fopen, fprintf, fread, free, fwrite, malloc, size_t,
-    strerror, FILE,
-};
+use libc::{exit, fclose, fflush, fopen, fprintf, fread, free, fwrite, malloc, size_t, FILE};
 use libzstd_rs_sys::lib::zdict::experimental::{
     ZDICT_cover_params_t, ZDICT_fastCover_params_t, ZDICT_legacy_params_t,
     ZDICT_optimizeTrainFromBuffer_cover, ZDICT_optimizeTrainFromBuffer_fastCover,
@@ -79,11 +78,10 @@ unsafe fn DiB_loadFiles(
                     b"Error %i : \0" as *const u8 as *const core::ffi::c_char,
                     10,
                 );
-                fprintf(
-                    stderr,
-                    b"zstd: dictBuilder: %s %s \0" as *const u8 as *const core::ffi::c_char,
-                    *fileNamesTable.offset(fileIndex as isize),
-                    strerror(*__errno_location()),
+                eprintln!(
+                    "zstd: dictBuilder: {} {}",
+                    CStr::from_ptr(*fileNamesTable.offset(fileIndex as isize)).to_string_lossy(),
+                    io::Error::last_os_error()
                 );
                 fprintf(stderr, b"\n\0" as *const u8 as *const core::ffi::c_char);
                 exit(10);

--- a/programs/fileio_asyncio.rs
+++ b/programs/fileio_asyncio.rs
@@ -1,9 +1,10 @@
+use std::io;
+
 use libc::{
-    __errno_location, exit, fclose, feof, ferror, fprintf, fread, free, fseek, fwrite, malloc,
-    memcpy, pthread_cond_destroy, pthread_cond_init, pthread_cond_signal, pthread_cond_t,
+    exit, fclose, feof, ferror, fprintf, fread, free, fseek, fwrite, malloc, memcpy,
+    pthread_cond_destroy, pthread_cond_init, pthread_cond_signal, pthread_cond_t,
     pthread_cond_wait, pthread_condattr_t, pthread_mutex_destroy, pthread_mutex_init,
-    pthread_mutex_lock, pthread_mutex_t, pthread_mutex_unlock, pthread_mutexattr_t, size_t,
-    strerror, FILE,
+    pthread_mutex_lock, pthread_mutex_t, pthread_mutex_unlock, pthread_mutexattr_t, size_t, FILE,
 };
 use libzstd_rs_sys::internal::{
     POOL_add, POOL_create, POOL_ctx, POOL_free, POOL_function, POOL_joinJobs,
@@ -157,15 +158,10 @@ unsafe fn AIO_fwriteSparse(
                 );
             }
             if g_display_prefs.displayLevel >= 1 {
-                fprintf(
-                    stderr,
-                    b"Write error : cannot write block : %s\0" as *const u8
-                        as *const core::ffi::c_char,
-                    strerror(*__errno_location()),
+                eprintln!(
+                    "Write error : cannot write block : {}",
+                    io::Error::last_os_error(),
                 );
-            }
-            if g_display_prefs.displayLevel >= 1 {
-                fprintf(stderr, b" \n\0" as *const u8 as *const core::ffi::c_char);
             }
             exit(70);
         }
@@ -287,15 +283,10 @@ unsafe fn AIO_fwriteSparse(
                     );
                 }
                 if g_display_prefs.displayLevel >= 1 {
-                    fprintf(
-                        stderr,
-                        b"Write error : cannot write block : %s\0" as *const u8
-                            as *const core::ffi::c_char,
-                        strerror(*__errno_location()),
+                    eprintln!(
+                        "Write error : cannot write block : {}",
+                        io::Error::last_os_error(),
                     );
-                }
-                if g_display_prefs.displayLevel >= 1 {
-                    fprintf(stderr, b" \n\0" as *const u8 as *const core::ffi::c_char);
                 }
                 exit(93);
             }
@@ -367,15 +358,10 @@ unsafe fn AIO_fwriteSparse(
                     );
                 }
                 if g_display_prefs.displayLevel >= 1 {
-                    fprintf(
-                        stderr,
-                        b"Write error : cannot write end of decoded block : %s\0" as *const u8
-                            as *const core::ffi::c_char,
-                        strerror(*__errno_location()),
+                    eprintln!(
+                        "Write error : cannot write end of decoded block : {}",
+                        io::Error::last_os_error(),
                     );
-                }
-                if g_display_prefs.displayLevel >= 1 {
-                    fprintf(stderr, b" \n\0" as *const u8 as *const core::ffi::c_char);
                 }
                 exit(95);
             }
@@ -457,15 +443,10 @@ unsafe fn AIO_fwriteSparseEnd(
                 );
             }
             if g_display_prefs.displayLevel >= 1 {
-                fprintf(
-                    stderr,
-                    b"Write error : cannot write last zero : %s\0" as *const u8
-                        as *const core::ffi::c_char,
-                    strerror(*__errno_location()),
+                eprintln!(
+                    "Write error : cannot write last zero : {}",
+                    io::Error::last_os_error(),
                 );
-            }
-            if g_display_prefs.displayLevel >= 1 {
-                fprintf(stderr, b" \n\0" as *const u8 as *const core::ffi::c_char);
             }
             exit(69);
         }


### PR DESCRIPTION
Only the couple of writes to __errno_location can't be replaced easily.