### PR TITLE
fix missing return in `ZSTD_nextSrcSizeToDecompressWithInputSize`

### DIFF
--- a/lib/decompress/zstd_decompress.rs
+++ b/lib/decompress/zstd_decompress.rs
@@ -1873,6 +1873,10 @@ unsafe fn ZSTD_nextSrcSizeToDecompressWithInputSize(
 ) -> size_t {
     match (*dctx).stage {
         DecompressStage::DecompressBlock | DecompressStage::DecompressLastBlock => {
+            if (*dctx).bType != BlockType::Raw {
+                return (*dctx).expected;
+            }
+
             // Apparently it's possible for min > max here, so Ord::clamp would panic.
             Ord::max(1, Ord::min(inputSize, (*dctx).expected))
         }


### PR DESCRIPTION
first introduced in 'enum `DecompressStage`: cleanup'