### PR TITLE
Make public api of BITv05_DStream safe

### DIFF
--- a/lib/decompress/huf_decompress.rs
+++ b/lib/decompress/huf_decompress.rs
@@ -1,4 +1,5 @@
 use core::ptr::{self, NonNull};
+use std::marker::PhantomData;
 use std::ops::Bound;
 
 use libc::size_t;
@@ -239,11 +240,11 @@ impl<'a> HUF_DecompressFastArgs<'a> {
     }
 }
 
-unsafe fn init_remaining_dstream(
-    args: &HUF_DecompressFastArgs,
+unsafe fn init_remaining_dstream<'a>(
+    args: &'a HUF_DecompressFastArgs,
     stream: usize,
     segmentEnd: *mut u8,
-) -> Result<BIT_DStream_t, Error> {
+) -> Result<BIT_DStream_t<'a>, Error> {
     if args.op[stream] > segmentEnd {
         return Err(Error::corruption_detected);
     }
@@ -264,6 +265,7 @@ unsafe fn init_remaining_dstream(
         ptr,
         start,
         limitPtr,
+        _marker: PhantomData,
     })
 }
 

--- a/lib/decompress/zstd_decompress_block.rs
+++ b/lib/decompress/zstd_decompress_block.rs
@@ -60,8 +60,8 @@ enum Offset {
 }
 
 #[repr(C)]
-pub struct seqState_t {
-    DStream: BIT_DStream_t,
+pub struct seqState_t<'a> {
+    DStream: BIT_DStream_t<'a>,
     stateLL: ZSTD_fseState,
     stateOffb: ZSTD_fseState,
     stateML: ZSTD_fseState,
@@ -1612,14 +1612,12 @@ unsafe fn ZSTD_decompressSequences_bodySplitLitBuffer(
     let vBase = dctx.virtualStart as *const u8;
     let dictEnd = dctx.dictEnd as *const u8;
     if nbSeq != 0 {
+        let DStream = match BIT_DStream_t::new(seq) {
+            Ok(v) => v,
+            Err(_) => return Error::corruption_detected.to_error_code(),
+        };
         let mut seqState = seqState_t {
-            DStream: BIT_DStream_t {
-                bitContainer: 0,
-                bitsConsumed: 0,
-                ptr: core::ptr::null::<core::ffi::c_char>(),
-                start: core::ptr::null::<core::ffi::c_char>(),
-                limitPtr: core::ptr::null::<core::ffi::c_char>(),
-            },
+            DStream,
             stateLL: ZSTD_fseState {
                 state: 0,
                 table: core::ptr::null::<ZSTD_seqSymbol>(),
@@ -1638,10 +1636,6 @@ unsafe fn ZSTD_decompressSequences_bodySplitLitBuffer(
 
         seqState.prevOffset = dctx.entropy.rep.map(|v| v as size_t);
 
-        seqState.DStream = match BIT_DStream_t::new(seq) {
-            Ok(v) => v,
-            Err(_) => return Error::corruption_detected.to_error_code(),
-        };
         ZSTD_initFseState(&mut seqState.stateLL, &mut seqState.DStream, dctx.LLTptr);
         ZSTD_initFseState(&mut seqState.stateOffb, &mut seqState.DStream, dctx.OFTptr);
         ZSTD_initFseState(&mut seqState.stateML, &mut seqState.DStream, dctx.MLTptr);
@@ -1808,14 +1802,12 @@ unsafe fn ZSTD_decompressSequences_body(
     let vBase = dctx.virtualStart as *const u8;
     let dictEnd = dctx.dictEnd as *const u8;
     if nbSeq != 0 {
+        let DStream = match BIT_DStream_t::new(seq) {
+            Ok(v) => v,
+            Err(_) => return Error::corruption_detected.to_error_code(),
+        };
         let mut seqState = seqState_t {
-            DStream: BIT_DStream_t {
-                bitContainer: 0,
-                bitsConsumed: 0,
-                ptr: core::ptr::null::<core::ffi::c_char>(),
-                start: core::ptr::null::<core::ffi::c_char>(),
-                limitPtr: core::ptr::null::<core::ffi::c_char>(),
-            },
+            DStream,
             stateLL: ZSTD_fseState {
                 state: 0,
                 table: core::ptr::null::<ZSTD_seqSymbol>(),
@@ -1832,10 +1824,6 @@ unsafe fn ZSTD_decompressSequences_body(
         };
         dctx.fseEntropy = 1;
         seqState.prevOffset = dctx.entropy.rep.map(|v| v as usize);
-        seqState.DStream = match BIT_DStream_t::new(seq) {
-            Ok(v) => v,
-            Err(_) => return Error::corruption_detected.to_error_code(),
-        };
 
         ZSTD_initFseState(&mut seqState.stateLL, &mut seqState.DStream, dctx.LLTptr);
         ZSTD_initFseState(&mut seqState.stateOffb, &mut seqState.DStream, dctx.OFTptr);
@@ -1973,14 +1961,12 @@ unsafe fn ZSTD_decompressSequencesLong_body(
     let dictEnd = dctx.dictEnd as *const u8;
     if nbSeq != 0 {
         let seqAdvance = if nbSeq < 8 { nbSeq } else { 8 };
+        let DStream = match BIT_DStream_t::new(seq) {
+            Ok(v) => v,
+            Err(_) => return Error::corruption_detected.to_error_code(),
+        };
         let mut seqState = seqState_t {
-            DStream: BIT_DStream_t {
-                bitContainer: 0,
-                bitsConsumed: 0,
-                ptr: core::ptr::null::<core::ffi::c_char>(),
-                start: core::ptr::null::<core::ffi::c_char>(),
-                limitPtr: core::ptr::null::<core::ffi::c_char>(),
-            },
+            DStream,
             stateLL: ZSTD_fseState {
                 state: 0,
                 table: core::ptr::null::<ZSTD_seqSymbol>(),
@@ -1997,10 +1983,6 @@ unsafe fn ZSTD_decompressSequencesLong_body(
         };
         dctx.fseEntropy = 1;
         seqState.prevOffset = dctx.entropy.rep.map(|v| v as usize);
-        seqState.DStream = match BIT_DStream_t::new(seq) {
-            Ok(v) => v,
-            Err(_) => return Error::corruption_detected.to_error_code(),
-        };
 
         ZSTD_initFseState(&mut seqState.stateLL, &mut seqState.DStream, dctx.LLTptr);
         ZSTD_initFseState(&mut seqState.stateOffb, &mut seqState.DStream, dctx.OFTptr);

--- a/programs/benchfn.rs
+++ b/programs/benchfn.rs
@@ -62,11 +62,6 @@ pub struct tfs_align {
     pub tfs: BMK_timedFnState_t,
 }
 pub type check_size = [core::ffi::c_char; 1];
-pub const __ASSERT_FUNCTION: [core::ffi::c_char; 75] = unsafe {
-    *::core::mem::transmute::<&[u8; 75], &[core::ffi::c_char; 75]>(
-        b"BMK_runOutcome_t BMK_benchTimedFn(BMK_timedFnState_t *, BMK_benchParams_t)\0",
-    )
-};
 pub const TIMELOOP_NANOSEC: core::ffi::c_ulonglong =
     (1 as core::ffi::c_ulonglong).wrapping_mul(1000000000);
 pub unsafe fn BMK_isSuccessful_runOutcome(outcome: BMK_runOutcome_t) -> core::ffi::c_int {

--- a/programs/fileio.rs
+++ b/programs/fileio.rs
@@ -365,12 +365,9 @@ const ZSTD_FRAMEHEADERSIZE_MAX: core::ffi::c_int = 18;
 const ZSTD_WINDOWLOG_MAX_32: core::ffi::c_int = 30;
 const ZSTD_WINDOWLOG_MAX_64: core::ffi::c_int = 31;
 const ZSTD_WINDOWLOG_LIMIT_DEFAULT: core::ffi::c_int = 27;
-const stdinmark: [core::ffi::c_char; 10] =
-    unsafe { *::core::mem::transmute::<&[u8; 10], &[core::ffi::c_char; 10]>(b"/*stdin*\\\0") };
-const stdoutmark: [core::ffi::c_char; 11] =
-    unsafe { *::core::mem::transmute::<&[u8; 11], &[core::ffi::c_char; 11]>(b"/*stdout*\\\0") };
-const nulmark: [core::ffi::c_char; 10] =
-    unsafe { *::core::mem::transmute::<&[u8; 10], &[core::ffi::c_char; 10]>(b"/dev/null\0") };
+const stdinmark: &CStr = c"/*stdin*\\";
+const stdoutmark: &CStr = c"/*stdout*\\";
+const nulmark: &CStr = c"/dev/null";
 const LZMA_EXTENSION: &CStr = c".lzma";
 const XZ_EXTENSION: &CStr = c".xz";
 const TXZ_EXTENSION: &CStr = c".txz";
@@ -388,8 +385,7 @@ pub static mut g_display_prefs: FIO_display_prefs_t = {
     }
 };
 static mut g_displayClock: UTIL_time_t = UTIL_time_t { t: 0 };
-const ZLIB_VERSION: [core::ffi::c_char; 4] =
-    unsafe { *::core::mem::transmute::<&[u8; 4], &[core::ffi::c_char; 4]>(b"1.3\0") };
+const ZLIB_VERSION: &CStr = c"1.3";
 const Z_NO_FLUSH: core::ffi::c_int = 0;
 const Z_FINISH: core::ffi::c_int = 4;
 const Z_OK: core::ffi::c_int = 0;

--- a/programs/zstdcli.rs
+++ b/programs/zstdcli.rs
@@ -194,50 +194,29 @@ pub const ZSTD_TARGETLENGTH_MAX: core::ffi::c_int = (1) << ZSTD_BLOCKSIZELOG_MAX
 pub const ZSTD_STRATEGY_MAX: core::ffi::c_int = ZSTD_btultra2 as core::ffi::c_int;
 pub const ZSTD_OVERLAPLOG_MAX: core::ffi::c_int = 9;
 pub const ZSTD_LDM_BUCKETSIZELOG_MAX: core::ffi::c_int = 8;
-pub const stdinmark: [core::ffi::c_char; 10] =
-    unsafe { *::core::mem::transmute::<&[u8; 10], &[core::ffi::c_char; 10]>(b"/*stdin*\\\0") };
-pub const stdoutmark: [core::ffi::c_char; 11] =
-    unsafe { *::core::mem::transmute::<&[u8; 11], &[core::ffi::c_char; 11]>(b"/*stdout*\\\0") };
-pub const nulmark: [core::ffi::c_char; 10] =
-    unsafe { *::core::mem::transmute::<&[u8; 10], &[core::ffi::c_char; 10]>(b"/dev/null\0") };
-pub const LZMA_EXTENSION: [core::ffi::c_char; 6] =
-    unsafe { *::core::mem::transmute::<&[u8; 6], &[core::ffi::c_char; 6]>(b".lzma\0") };
-pub const XZ_EXTENSION: [core::ffi::c_char; 4] =
-    unsafe { *::core::mem::transmute::<&[u8; 4], &[core::ffi::c_char; 4]>(b".xz\0") };
-pub const GZ_EXTENSION: [core::ffi::c_char; 4] =
-    unsafe { *::core::mem::transmute::<&[u8; 4], &[core::ffi::c_char; 4]>(b".gz\0") };
-pub const ZSTD_EXTENSION: [core::ffi::c_char; 5] =
-    unsafe { *::core::mem::transmute::<&[u8; 5], &[core::ffi::c_char; 5]>(b".zst\0") };
-pub const LZ4_EXTENSION: [core::ffi::c_char; 5] =
-    unsafe { *::core::mem::transmute::<&[u8; 5], &[core::ffi::c_char; 5]>(b".lz4\0") };
+const stdinmark: &CStr = c"/*stdin*\\";
+const stdoutmark: &CStr = c"/*stdout*\\";
+const nulmark: &CStr = c"/dev/null";
+const LZMA_EXTENSION: &CStr = c".lzma";
+const XZ_EXTENSION: &CStr = c".xz";
+const GZ_EXTENSION: &CStr = c".gz";
+const ZSTD_EXTENSION: &CStr = c".zst";
+const LZ4_EXTENSION: &CStr = c".lz4";
 pub const ZSTDCLI_CLEVEL_DEFAULT: core::ffi::c_int = 3;
 pub const ZSTDCLI_CLEVEL_MAX: core::ffi::c_int = 19;
-pub const ZSTD_ZSTDMT: [core::ffi::c_char; 7] =
-    unsafe { *::core::mem::transmute::<&[u8; 7], &[core::ffi::c_char; 7]>(b"zstdmt\0") };
-pub const ZSTD_UNZSTD: [core::ffi::c_char; 7] =
-    unsafe { *::core::mem::transmute::<&[u8; 7], &[core::ffi::c_char; 7]>(b"unzstd\0") };
-pub const ZSTD_CAT: [core::ffi::c_char; 8] =
-    unsafe { *::core::mem::transmute::<&[u8; 8], &[core::ffi::c_char; 8]>(b"zstdcat\0") };
-pub const ZSTD_ZCAT: [core::ffi::c_char; 5] =
-    unsafe { *::core::mem::transmute::<&[u8; 5], &[core::ffi::c_char; 5]>(b"zcat\0") };
-pub const ZSTD_GZ: [core::ffi::c_char; 5] =
-    unsafe { *::core::mem::transmute::<&[u8; 5], &[core::ffi::c_char; 5]>(b"gzip\0") };
-pub const ZSTD_GUNZIP: [core::ffi::c_char; 7] =
-    unsafe { *::core::mem::transmute::<&[u8; 7], &[core::ffi::c_char; 7]>(b"gunzip\0") };
-pub const ZSTD_GZCAT: [core::ffi::c_char; 6] =
-    unsafe { *::core::mem::transmute::<&[u8; 6], &[core::ffi::c_char; 6]>(b"gzcat\0") };
-pub const ZSTD_LZMA: [core::ffi::c_char; 5] =
-    unsafe { *::core::mem::transmute::<&[u8; 5], &[core::ffi::c_char; 5]>(b"lzma\0") };
-pub const ZSTD_UNLZMA: [core::ffi::c_char; 7] =
-    unsafe { *::core::mem::transmute::<&[u8; 7], &[core::ffi::c_char; 7]>(b"unlzma\0") };
-pub const ZSTD_XZ: [core::ffi::c_char; 3] =
-    unsafe { *::core::mem::transmute::<&[u8; 3], &[core::ffi::c_char; 3]>(b"xz\0") };
-pub const ZSTD_UNXZ: [core::ffi::c_char; 5] =
-    unsafe { *::core::mem::transmute::<&[u8; 5], &[core::ffi::c_char; 5]>(b"unxz\0") };
-pub const ZSTD_LZ4: [core::ffi::c_char; 4] =
-    unsafe { *::core::mem::transmute::<&[u8; 4], &[core::ffi::c_char; 4]>(b"lz4\0") };
-pub const ZSTD_UNLZ4: [core::ffi::c_char; 6] =
-    unsafe { *::core::mem::transmute::<&[u8; 6], &[core::ffi::c_char; 6]>(b"unlz4\0") };
+const ZSTD_ZSTDMT: &CStr = c"zstdmt";
+const ZSTD_UNZSTD: &CStr = c"unzstd";
+const ZSTD_CAT: &CStr = c"zstdcat";
+const ZSTD_ZCAT: &CStr = c"zcat";
+const ZSTD_GZ: &CStr = c"gzip";
+const ZSTD_GUNZIP: &CStr = c"gunzip";
+const ZSTD_GZCAT: &CStr = c"gzcat";
+const ZSTD_LZMA: &CStr = c"lzma";
+const ZSTD_UNLZMA: &CStr = c"unlzma";
+const ZSTD_XZ: &CStr = c"xz";
+const ZSTD_UNXZ: &CStr = c"unxz";
+const ZSTD_LZ4: &CStr = c"lz4";
+const ZSTD_UNLZ4: &CStr = c"unlz4";
 pub const DISPLAY_LEVEL_DEFAULT: core::ffi::c_int = 2;
 static mut g_defaultDictName: *const core::ffi::c_char =
     b"dictionary\0" as *const u8 as *const core::ffi::c_char;
@@ -1718,10 +1697,8 @@ unsafe fn printActualCParams(
         actualCParams.strategy as core::ffi::c_uint,
     );
 }
-pub const ENV_CLEVEL: [core::ffi::c_char; 12] =
-    unsafe { *::core::mem::transmute::<&[u8; 12], &[core::ffi::c_char; 12]>(b"ZSTD_CLEVEL\0") };
-pub const ENV_NBWORKERS: [core::ffi::c_char; 15] =
-    unsafe { *::core::mem::transmute::<&[u8; 15], &[core::ffi::c_char; 15]>(b"ZSTD_NBTHREADS\0") };
+const ENV_CLEVEL: &CStr = c"ZSTD_CLEVEL";
+const ENV_NBWORKERS: &CStr = c"ZSTD_NBTHREADS";
 unsafe fn init_cLevel() -> core::ffi::c_int {
     let env: *const core::ffi::c_char = getenv(ENV_CLEVEL.as_ptr());
     if !env.is_null() {


### PR DESCRIPTION
And improve soundness of `BIT_DStream`. It is currently not yet fully sound as `BIT_DStream` publicly exposes its internal pointer fields.