### PR TITLE
apply `clippy::ptr_offset_by_literal`

### DIFF
--- a/lib/common/fse.rs
+++ b/lib/common/fse.rs
@@ -55,8 +55,8 @@ pub(crate) unsafe fn FSE_initCState(statePtr: *mut FSE_CState_t, ct: *const FSE_
     let u16ptr = ptr as *const u16;
     let tableLog = MEM_read16(ptr) as u32;
     (*statePtr).value = (1) << tableLog;
-    (*statePtr).stateTable = u16ptr.offset(2) as *const core::ffi::c_void;
-    (*statePtr).symbolTT = ct.offset(1).offset(
+    (*statePtr).stateTable = u16ptr.add(2) as *const core::ffi::c_void;
+    (*statePtr).symbolTT = ct.add(1).offset(
         (if tableLog != 0 {
             (1) << tableLog.wrapping_sub(1)
         } else {

--- a/lib/common/mem.rs
+++ b/lib/common/mem.rs
@@ -66,7 +66,7 @@ pub(crate) unsafe fn MEM_readLE16(memPtr: *const c_void) -> u16 {
         MEM_read16(memPtr)
     } else {
         let p = memPtr as *const u8;
-        (*p.offset(0) as core::ffi::c_int + ((*p.offset(1) as core::ffi::c_int) << 8)) as u16
+        (*p as core::ffi::c_int + ((*p.add(1) as core::ffi::c_int) << 8)) as u16
     }
 }
 
@@ -81,13 +81,13 @@ pub(crate) unsafe fn MEM_writeLE16(memPtr: *mut c_void, val32: u16) {
 
 #[inline]
 pub unsafe fn MEM_readLE24(memPtr: *const c_void) -> u32 {
-    (MEM_readLE16(memPtr) as u32).wrapping_add((*(memPtr as *const u8).offset(2) as u32) << 16)
+    (MEM_readLE16(memPtr) as u32).wrapping_add((*(memPtr as *const u8).add(2) as u32) << 16)
 }
 
 #[inline]
 pub(crate) unsafe fn MEM_writeLE24(memPtr: *mut c_void, val: u32) {
     MEM_writeLE16(memPtr, val as u16);
-    *(memPtr as *mut u8).offset(2) = (val >> 16) as u8;
+    *(memPtr as *mut u8).add(2) = (val >> 16) as u8;
 }
 
 #[inline]

--- a/lib/compress/hist.rs
+++ b/lib/compress/hist.rs
@@ -23,7 +23,7 @@ pub unsafe fn HIST_add(
     let end = ip.add(srcSize);
     while ip < end {
         let fresh0 = ip;
-        ip = ip.offset(1);
+        ip = ip.add(1);
         let fresh1 = &mut (*count.offset(*fresh0 as isize));
         *fresh1 = (*fresh1).wrapping_add(1);
     }
@@ -51,7 +51,7 @@ pub unsafe fn HIST_count_simple(
     }
     while ip < end {
         let fresh2 = ip;
-        ip = ip.offset(1);
+        ip = ip.add(1);
         let fresh3 = &mut (*count.offset(*fresh2 as isize));
         *fresh3 = (*fresh3).wrapping_add(1);
     }
@@ -83,9 +83,9 @@ unsafe fn HIST_count_parallel_wksp(
         .wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>() as core::ffi::c_ulong);
     let mut max = 0;
     let Counting1 = workSpace;
-    let Counting2 = Counting1.offset(256);
-    let Counting3 = Counting2.offset(256);
-    let Counting4 = Counting3.offset(256);
+    let Counting2 = Counting1.add(256);
+    let Counting3 = Counting2.add(256);
+    let Counting4 = Counting3.add(256);
     if sourceSize == 0 {
         ptr::write_bytes(count as *mut u8, 0, countSize as libc::size_t);
         *maxSymbolValuePtr = 0;
@@ -99,11 +99,11 @@ unsafe fn HIST_count_parallel_wksp(
             as libc::size_t,
     );
     let mut cached = MEM_read32(ip as *const core::ffi::c_void);
-    ip = ip.offset(4);
-    while ip < iend.offset(-(15)) {
+    ip = ip.add(4);
+    while ip < iend.sub(15) {
         let mut c = cached;
         cached = MEM_read32(ip as *const core::ffi::c_void);
-        ip = ip.offset(4);
+        ip = ip.add(4);
         let fresh4 = &mut (*Counting1.offset(c as u8 as isize));
         *fresh4 = (*fresh4).wrapping_add(1);
         let fresh5 = &mut (*Counting2.offset((c >> 8) as u8 as isize));
@@ -114,7 +114,7 @@ unsafe fn HIST_count_parallel_wksp(
         *fresh7 = (*fresh7).wrapping_add(1);
         c = cached;
         cached = MEM_read32(ip as *const core::ffi::c_void);
-        ip = ip.offset(4);
+        ip = ip.add(4);
         let fresh8 = &mut (*Counting1.offset(c as u8 as isize));
         *fresh8 = (*fresh8).wrapping_add(1);
         let fresh9 = &mut (*Counting2.offset((c >> 8) as u8 as isize));
@@ -125,7 +125,7 @@ unsafe fn HIST_count_parallel_wksp(
         *fresh11 = (*fresh11).wrapping_add(1);
         c = cached;
         cached = MEM_read32(ip as *const core::ffi::c_void);
-        ip = ip.offset(4);
+        ip = ip.add(4);
         let fresh12 = &mut (*Counting1.offset(c as u8 as isize));
         *fresh12 = (*fresh12).wrapping_add(1);
         let fresh13 = &mut (*Counting2.offset((c >> 8) as u8 as isize));
@@ -136,7 +136,7 @@ unsafe fn HIST_count_parallel_wksp(
         *fresh15 = (*fresh15).wrapping_add(1);
         c = cached;
         cached = MEM_read32(ip as *const core::ffi::c_void);
-        ip = ip.offset(4);
+        ip = ip.add(4);
         let fresh16 = &mut (*Counting1.offset(c as u8 as isize));
         *fresh16 = (*fresh16).wrapping_add(1);
         let fresh17 = &mut (*Counting2.offset((c >> 8) as u8 as isize));
@@ -146,10 +146,10 @@ unsafe fn HIST_count_parallel_wksp(
         let fresh19 = &mut (*Counting4.offset((c >> 24) as isize));
         *fresh19 = (*fresh19).wrapping_add(1);
     }
-    ip = ip.offset(-(4));
+    ip = ip.sub(4);
     while ip < iend {
         let fresh20 = ip;
-        ip = ip.offset(1);
+        ip = ip.add(1);
         let fresh21 = &mut (*Counting1.offset(*fresh20 as isize));
         *fresh21 = (*fresh21).wrapping_add(1);
     }

--- a/lib/compress/zstd_compress_literals.rs
+++ b/lib/compress/zstd_compress_literals.rs
@@ -58,7 +58,7 @@ pub unsafe fn ZSTD_noCompressLiterals(
     }
     match flSize {
         1 => {
-            *ostart.offset(0) =
+            *ostart =
                 (set_basic as core::ffi::c_int as u32 as size_t).wrapping_add(srcSize << 3) as u8;
         }
         2 => {
@@ -85,7 +85,7 @@ pub unsafe fn ZSTD_noCompressLiterals(
     srcSize.wrapping_add(flSize as size_t)
 }
 unsafe fn allBytesIdentical(src: *const core::ffi::c_void, srcSize: size_t) -> bool {
-    let b = *(src as *const u8).offset(0);
+    let b = *(src as *const u8);
     let mut p: size_t = 0;
     p = 1;
     while p < srcSize {
@@ -111,7 +111,7 @@ pub unsafe fn ZSTD_compressRleLiteralsBlock(
 
     match flSize {
         1 => {
-            *ostart.offset(0) =
+            *ostart =
                 (set_rle as core::ffi::c_int as u32 as size_t).wrapping_add(srcSize << 3) as u8;
         }
         2 => {
@@ -306,7 +306,7 @@ pub unsafe fn ZSTD_compressLiterals(
                 .wrapping_add((srcSize as u32) << 4)
                 .wrapping_add((cLitSize as u32) << 22);
             MEM_writeLE32(ostart as *mut core::ffi::c_void, lhc_1);
-            *ostart.offset(4) = (cLitSize >> 10) as u8;
+            *ostart.add(4) = (cLitSize >> 10) as u8;
         }
         _ => {}
     }

--- a/lib/compress/zstd_compress_sequences.rs
+++ b/lib/compress/zstd_compress_sequences.rs
@@ -51,7 +51,7 @@ unsafe fn ZSTD_getFSEMaxSymbolValue(ctable: *const FSE_CTable) -> core::ffi::c_u
     let ptr = ctable as *const core::ffi::c_void;
     let u16ptr = ptr as *const u16;
 
-    MEM_read16(u16ptr.offset(1) as *const core::ffi::c_void) as u32
+    MEM_read16(u16ptr.add(1) as *const core::ffi::c_void) as u32
 }
 unsafe fn ZSTD_useLowProbCount(nbSeq: size_t) -> core::ffi::c_uint {
     (nbSeq >= 2048) as core::ffi::c_int as core::ffi::c_uint
@@ -266,7 +266,7 @@ pub unsafe fn ZSTD_buildCTable(
             if dstCapacity == 0 {
                 return Error::dstSize_tooSmall.to_error_code();
             }
-            *op = *codeTable.offset(0);
+            *op = *codeTable;
             1
         }
         3 => {

--- a/lib/compress/zstd_preSplit.rs
+++ b/lib/compress/zstd_preSplit.rs
@@ -27,7 +27,7 @@ pub const KNUTH: core::ffi::c_uint = 0x9e3779b9;
 #[inline(always)]
 unsafe fn hash2(p: *const core::ffi::c_void, hashLog: core::ffi::c_uint) -> core::ffi::c_uint {
     if hashLog == 8 {
-        return *(p as *const u8).offset(0) as u32;
+        return *(p as *const u8) as u32;
     }
     (MEM_read16(p) as u32).wrapping_mul(KNUTH) >> (32 as core::ffi::c_uint).wrapping_sub(hashLog)
 }

--- a/lib/compress/zstdmt_compress.rs
+++ b/lib/compress/zstdmt_compress.rs
@@ -536,9 +536,9 @@ unsafe fn ZSTDMT_createCCtxPool(
         return core::ptr::null_mut();
     }
     (*cctxPool).cMem = cMem;
-    let fresh1 = &mut (*((*cctxPool).cctxs).offset(0));
+    let fresh1 = &mut (*((*cctxPool).cctxs));
     *fresh1 = ZSTD_createCCtx_advanced(cMem);
-    if (*((*cctxPool).cctxs).offset(0)).is_null() {
+    if (*((*cctxPool).cctxs)).is_null() {
         ZSTDMT_freeCCtxPool(cctxPool);
         return core::ptr::null_mut();
     }

--- a/lib/decompress/huf_decompress.rs
+++ b/lib/decompress/huf_decompress.rs
@@ -136,7 +136,7 @@ pub const HUF_DECODER_FAST_TABLELOG: core::ffi::c_int = 11;
 pub const HUF_ENABLE_FAST_DECODE: core::ffi::c_int = 1;
 
 unsafe fn HUF_initFastDStream(ip: *const u8) -> size_t {
-    let lastByte = *ip.offset(7);
+    let lastByte = *ip.add(7);
     let bitsConsumed = match lastByte.checked_ilog2() {
         Some(v) => 8 - v,
         None => 0,

--- a/lib/decompress/zstd_decompress_block.rs
+++ b/lib/decompress/zstd_decompress_block.rs
@@ -1121,8 +1121,8 @@ unsafe fn ZSTD_safecopyDstBeforeSrc(mut op: *mut u8, mut ip: *const u8, length: 
     if length < 8 || diff > -8 as ptrdiff_t {
         while op < oend {
             *op = *ip;
-            ip = ip.offset(1);
-            op = op.offset(1);
+            ip = ip.add(1);
+            op = op.add(1);
         }
         return;
     }
@@ -1138,8 +1138,8 @@ unsafe fn ZSTD_safecopyDstBeforeSrc(mut op: *mut u8, mut ip: *const u8, length: 
     }
     while op < oend {
         *op = *ip;
-        ip = ip.offset(1);
-        op = op.offset(1);
+        ip = ip.add(1);
+        op = op.add(1);
     }
 }
 
@@ -1285,8 +1285,8 @@ unsafe fn ZSTD_execSequence(
     );
     if (sequence.litLength > 16) as core::ffi::c_int as core::ffi::c_long != 0 {
         ZSTD_wildcopy(
-            op.offset(16) as *mut core::ffi::c_void,
-            (*litPtr).offset(16) as *const core::ffi::c_void,
+            op.add(16) as *mut core::ffi::c_void,
+            (*litPtr).add(16) as *const core::ffi::c_void,
             (sequence.litLength).wrapping_sub(16),
             Overlap::NoOverlap,
         );
@@ -1372,8 +1372,8 @@ unsafe fn ZSTD_execSequenceSplitLitBuffer(
     );
     if (sequence.litLength > 16) as core::ffi::c_int as core::ffi::c_long != 0 {
         ZSTD_wildcopy(
-            op.offset(16) as *mut core::ffi::c_void,
-            (*litPtr).offset(16) as *const core::ffi::c_void,
+            op.add(16) as *mut core::ffi::c_void,
+            (*litPtr).add(16) as *const core::ffi::c_void,
             (sequence.litLength).wrapping_sub(16),
             Overlap::NoOverlap,
         );

--- a/lib/dictBuilder/cover.rs
+++ b/lib/dictBuilder/cover.rs
@@ -377,7 +377,7 @@ unsafe fn COVER_lower_bound(
         let mut ptr = first;
         ptr = ptr.add(step);
         if *ptr < value {
-            ptr = ptr.offset(1);
+            ptr = ptr.add(1);
             first = ptr;
             count = count.wrapping_sub(step.wrapping_add(1));
         } else {
@@ -432,18 +432,18 @@ unsafe fn COVER_group(
     let mut freq = 0u32;
     let mut curOffsetPtr: *const size_t = (*ctx).offsets;
     let offsetsEnd: *const size_t = ((*ctx).offsets).add((*ctx).nbSamples);
-    let mut curSampleEnd = *((*ctx).offsets).offset(0);
+    let mut curSampleEnd = *((*ctx).offsets);
     while grpPtr != grpEnd {
         *((*ctx).dmerAt).offset(*grpPtr as isize) = dmerId;
         if (*grpPtr as size_t) >= curSampleEnd {
             freq = freq.wrapping_add(1);
-            if grpPtr.offset(1) != grpEnd {
+            if grpPtr.add(1) != grpEnd {
                 let sampleEndPtr = COVER_lower_bound(curOffsetPtr, offsetsEnd, *grpPtr as size_t);
                 curSampleEnd = *sampleEndPtr;
-                curOffsetPtr = sampleEndPtr.offset(1);
+                curOffsetPtr = sampleEndPtr.add(1);
             }
         }
-        grpPtr = grpPtr.offset(1);
+        grpPtr = grpPtr.add(1);
     }
     *((*ctx).suffix).offset(dmerId as isize) = freq;
 }
@@ -679,7 +679,7 @@ unsafe fn COVER_ctx_init(
     ctx.freqs = core::ptr::null_mut();
     ctx.d = d;
     let mut i: u32 = 0;
-    *(ctx.offsets).offset(0) = 0;
+    *(ctx.offsets) = 0;
     i = 1;
     while i <= nbSamples {
         *(ctx.offsets).offset(i as isize) = (*(ctx.offsets).offset(i.wrapping_sub(1) as isize))

--- a/lib/dictBuilder/divsufsort.rs
+++ b/lib/dictBuilder/divsufsort.rs
@@ -381,11 +381,11 @@ unsafe fn ss_compare(
     let mut U2n = core::ptr::null::<core::ffi::c_uchar>();
     U1 = T.offset(depth as isize).offset(*p1 as isize);
     U2 = T.offset(depth as isize).offset(*p2 as isize);
-    U1n = T.offset(*p1.offset(1) as isize).offset(2);
-    U2n = T.offset(*p2.offset(1) as isize).offset(2);
+    U1n = T.offset(*p1.add(1) as isize).add(2);
+    U2n = T.offset(*p2.add(1) as isize).add(2);
     while U1 < U1n && U2 < U2n && *U1 as core::ffi::c_int == *U2 as core::ffi::c_int {
-        U1 = U1.offset(1);
-        U2 = U2.offset(1);
+        U1 = U1.add(1);
+        U2 = U2.add(1);
     }
     if U1 < U1n {
         if U2 < U2n {
@@ -410,18 +410,18 @@ unsafe fn ss_insertionsort(
     let mut j = core::ptr::null_mut::<core::ffi::c_int>();
     let mut t: core::ffi::c_int = 0;
     let mut r: core::ffi::c_int = 0;
-    i = last.offset(-(2));
+    i = last.sub(2);
     while first <= i {
         t = *i;
-        j = i.offset(1);
+        j = i.add(1);
         loop {
             r = ss_compare(T, PA.offset(t as isize), PA.offset(*j as isize), depth);
             if (0) >= r {
                 break;
             }
             loop {
-                *j.offset(-(1)) = *j;
-                j = j.offset(1);
+                *j.sub(1) = *j;
+                j = j.add(1);
                 if !(j < last && *j < 0) {
                     break;
                 }
@@ -433,8 +433,8 @@ unsafe fn ss_insertionsort(
         if r == 0 {
             *j = !*j;
         }
-        *j.offset(-(1)) = t;
-        i = i.offset(-1);
+        *j.sub(1) = t;
+        i = i.sub(1);
     }
 }
 #[inline]
@@ -502,15 +502,15 @@ unsafe fn ss_heapsort(
         i -= 1;
     }
     if size % 2 == 0 {
-        t = *SA.offset(0);
-        *SA.offset(0) = *SA.offset(m as isize);
+        t = *SA;
+        *SA = *SA.offset(m as isize);
         *SA.offset(m as isize) = t;
         ss_fixdown(Td, PA, SA, 0, m);
     }
     i = m - 1;
     while (0) < i {
-        t = *SA.offset(0);
-        *SA.offset(0) = *SA.offset(i as isize);
+        t = *SA;
+        *SA = *SA.offset(i as isize);
         ss_fixdown(Td, PA, SA, 0, i);
         *SA.offset(i as isize) = t;
         i -= 1;
@@ -617,7 +617,7 @@ unsafe fn ss_pivot(
     middle = first.offset((t / 2) as isize);
     if t <= 512 {
         if t <= 32 {
-            return ss_median3(Td, PA, first, middle, last.offset(-(1)));
+            return ss_median3(Td, PA, first, middle, last.sub(1));
         } else {
             t >>= 2;
             return ss_median5(
@@ -626,8 +626,8 @@ unsafe fn ss_pivot(
                 first,
                 first.offset(t as isize),
                 middle,
-                last.offset(-(1)).offset(-(t as isize)),
-                last.offset(-(1)),
+                last.sub(1).offset(-(t as isize)),
+                last.sub(1),
             );
         }
     }
@@ -649,9 +649,9 @@ unsafe fn ss_pivot(
     last = ss_median3(
         Td,
         PA,
-        last.offset(-(1)).offset(-((t << 1) as isize)),
-        last.offset(-(1)).offset(-(t as isize)),
-        last.offset(-(1)),
+        last.sub(1).offset(-((t << 1) as isize)),
+        last.sub(1).offset(-(t as isize)),
+        last.sub(1),
     );
     ss_median3(Td, PA, first, middle, last)
 }
@@ -665,18 +665,18 @@ unsafe fn ss_partition(
     let mut a = core::ptr::null_mut::<core::ffi::c_int>();
     let mut b = core::ptr::null_mut::<core::ffi::c_int>();
     let mut t: core::ffi::c_int = 0;
-    a = first.offset(-(1));
+    a = first.sub(1);
     b = last;
     loop {
         loop {
-            a = a.offset(1);
+            a = a.add(1);
             if !(a < b && *PA.offset(*a as isize) + depth >= *PA.offset((*a + 1) as isize) + 1) {
                 break;
             }
             *a = !*a;
         }
         loop {
-            b = b.offset(-1);
+            b = b.sub(1);
             if !(a < b && *PA.offset(*b as isize) + depth < *PA.offset((*b + 1) as isize) + 1) {
                 break;
             }
@@ -752,7 +752,7 @@ unsafe fn ss_mintrosort(
                 );
             }
             if limit < 0 {
-                a = first.offset(1);
+                a = first.add(1);
                 v = *Td.offset(*PA.offset(*first as isize) as isize) as core::ffi::c_int;
                 while a < last {
                     x = *Td.offset(*PA.offset(*a as isize) as isize) as core::ffi::c_int;
@@ -763,7 +763,7 @@ unsafe fn ss_mintrosort(
                         v = x;
                         first = a;
                     }
-                    a = a.offset(1);
+                    a = a.add(1);
                 }
                 if (*Td.offset((*PA.offset(*first as isize) - 1) as isize) as core::ffi::c_int) < v
                 {
@@ -816,7 +816,7 @@ unsafe fn ss_mintrosort(
                 *a = t;
                 b = first;
                 loop {
-                    b = b.offset(1);
+                    b = b.add(1);
                     if !(b < last && {
                         x = *Td.offset(*PA.offset(*b as isize) as isize) as core::ffi::c_int;
                         x == v
@@ -827,7 +827,7 @@ unsafe fn ss_mintrosort(
                 a = b;
                 if a < last && x < v {
                     loop {
-                        b = b.offset(1);
+                        b = b.add(1);
                         if !(b < last && {
                             x = *Td.offset(*PA.offset(*b as isize) as isize) as core::ffi::c_int;
                             x <= v
@@ -838,13 +838,13 @@ unsafe fn ss_mintrosort(
                             t = *b;
                             *b = *a;
                             *a = t;
-                            a = a.offset(1);
+                            a = a.add(1);
                         }
                     }
                 }
                 c = last;
                 loop {
-                    c = c.offset(-1);
+                    c = c.sub(1);
                     if !(b < c && {
                         x = *Td.offset(*PA.offset(*c as isize) as isize) as core::ffi::c_int;
                         x == v
@@ -855,7 +855,7 @@ unsafe fn ss_mintrosort(
                 d = c;
                 if b < d && x > v {
                     loop {
-                        c = c.offset(-1);
+                        c = c.sub(1);
                         if !(b < c && {
                             x = *Td.offset(*PA.offset(*c as isize) as isize) as core::ffi::c_int;
                             x >= v
@@ -866,7 +866,7 @@ unsafe fn ss_mintrosort(
                             t = *c;
                             *c = *d;
                             *d = t;
-                            d = d.offset(-1);
+                            d = d.sub(1);
                         }
                     }
                 }
@@ -875,7 +875,7 @@ unsafe fn ss_mintrosort(
                     *b = *c;
                     *c = t;
                     loop {
-                        b = b.offset(1);
+                        b = b.add(1);
                         if !(b < c && {
                             x = *Td.offset(*PA.offset(*b as isize) as isize) as core::ffi::c_int;
                             x <= v
@@ -886,11 +886,11 @@ unsafe fn ss_mintrosort(
                             t = *b;
                             *b = *a;
                             *a = t;
-                            a = a.offset(1);
+                            a = a.add(1);
                         }
                     }
                     loop {
-                        c = c.offset(-1);
+                        c = c.sub(1);
                         if !(b < c && {
                             x = *Td.offset(*PA.offset(*c as isize) as isize) as core::ffi::c_int;
                             x >= v
@@ -901,12 +901,12 @@ unsafe fn ss_mintrosort(
                             t = *c;
                             *c = *d;
                             *d = t;
-                            d = d.offset(-1);
+                            d = d.sub(1);
                         }
                     }
                 }
                 if a <= d {
-                    c = b.offset(-(1));
+                    c = b.sub(1);
                     s = a.offset_from(first) as core::ffi::c_long as core::ffi::c_int;
                     t = b.offset_from(a) as core::ffi::c_long as core::ffi::c_int;
                     if s > t {
@@ -919,8 +919,8 @@ unsafe fn ss_mintrosort(
                         *e = *f;
                         *f = t;
                         s -= 1;
-                        e = e.offset(1);
-                        f = f.offset(1);
+                        e = e.add(1);
+                        f = f.add(1);
                     }
                     s = d.offset_from(c) as core::ffi::c_long as core::ffi::c_int;
                     t = (last.offset_from(d) as core::ffi::c_long - 1) as core::ffi::c_int;
@@ -934,8 +934,8 @@ unsafe fn ss_mintrosort(
                         *e = *f;
                         *f = t;
                         s -= 1;
-                        e = e.offset(1);
-                        f = f.offset(1);
+                        e = e.add(1);
+                        f = f.add(1);
                     }
                     a = first.offset(b.offset_from(a) as core::ffi::c_long as isize);
                     c = last.offset(-(d.offset_from(c) as core::ffi::c_long as isize));
@@ -1118,8 +1118,8 @@ unsafe fn ss_blockswap(
         *a = *b;
         *b = t;
         n -= 1;
-        a = a.offset(1);
-        b = b.offset(1);
+        a = a.add(1);
+        b = b.add(1);
     }
 }
 #[inline]
@@ -1140,15 +1140,15 @@ unsafe fn ss_rotate(
             ss_blockswap(first, middle, l);
             break;
         } else if l < r {
-            a = last.offset(-(1));
-            b = middle.offset(-(1));
+            a = last.sub(1);
+            b = middle.sub(1);
             t = *a;
             loop {
                 let fresh44 = a;
-                a = a.offset(-1);
+                a = a.sub(1);
                 *fresh44 = *b;
                 let fresh45 = b;
-                b = b.offset(-1);
+                b = b.sub(1);
                 *fresh45 = *a;
                 if b >= first {
                     continue;
@@ -1159,8 +1159,8 @@ unsafe fn ss_rotate(
                 if r <= l {
                     break;
                 }
-                a = a.offset(-(1));
-                b = middle.offset(-(1));
+                a = a.sub(1);
+                b = middle.sub(1);
                 t = *a;
             }
         } else {
@@ -1169,21 +1169,21 @@ unsafe fn ss_rotate(
             t = *a;
             loop {
                 let fresh46 = a;
-                a = a.offset(1);
+                a = a.add(1);
                 *fresh46 = *b;
                 let fresh47 = b;
-                b = b.offset(1);
+                b = b.add(1);
                 *fresh47 = *a;
                 if last > b {
                     continue;
                 }
                 *a = t;
-                first = a.offset(1);
+                first = a.add(1);
                 l -= r + 1;
                 if l <= r {
                     break;
                 }
-                a = a.offset(1);
+                a = a.add(1);
                 b = middle;
                 t = *a;
             }
@@ -1207,12 +1207,12 @@ unsafe fn ss_inplacemerge(
     let mut r: core::ffi::c_int = 0;
     let mut x: core::ffi::c_int = 0;
     loop {
-        if *last.offset(-(1)) < 0 {
+        if *last.sub(1) < 0 {
             x = 1;
-            p = PA.offset(!*last.offset(-(1)) as isize);
+            p = PA.offset(!*last.sub(1) as isize);
         } else {
             x = 0;
-            p = PA.offset(*last.offset(-(1)) as isize);
+            p = PA.offset(*last.sub(1) as isize);
         }
         a = first;
         len = middle.offset_from(first) as core::ffi::c_long as core::ffi::c_int;
@@ -1227,7 +1227,7 @@ unsafe fn ss_inplacemerge(
                 depth,
             );
             if q < 0 {
-                a = b.offset(1);
+                a = b.add(1);
                 half -= len & 1 ^ 1;
             } else {
                 r = q;
@@ -1246,10 +1246,10 @@ unsafe fn ss_inplacemerge(
                 break;
             }
         }
-        last = last.offset(-1);
+        last = last.sub(1);
         if x != 0 {
             loop {
-                last = last.offset(-1);
+                last = last.sub(1);
                 if *last >= 0 {
                     break;
                 }
@@ -1277,7 +1277,7 @@ unsafe fn ss_mergeforward(
     let mut r: core::ffi::c_int = 0;
     bufend = buf
         .offset(middle.offset_from(first) as core::ffi::c_long as isize)
-        .offset(-(1));
+        .sub(1);
     ss_blockswap(
         buf,
         first,
@@ -1292,14 +1292,14 @@ unsafe fn ss_mergeforward(
         if r < 0 {
             loop {
                 let fresh48 = a;
-                a = a.offset(1);
+                a = a.add(1);
                 *fresh48 = *b;
                 if bufend <= b {
                     *bufend = t;
                     return;
                 }
                 let fresh49 = b;
-                b = b.offset(1);
+                b = b.add(1);
                 *fresh49 = *a;
                 if *b >= 0 {
                     break;
@@ -1308,18 +1308,18 @@ unsafe fn ss_mergeforward(
         } else if r > 0 {
             loop {
                 let fresh50 = a;
-                a = a.offset(1);
+                a = a.add(1);
                 *fresh50 = *c;
                 let fresh51 = c;
-                c = c.offset(1);
+                c = c.add(1);
                 *fresh51 = *a;
                 if last <= c {
                     while b < bufend {
                         let fresh52 = a;
-                        a = a.offset(1);
+                        a = a.add(1);
                         *fresh52 = *b;
                         let fresh53 = b;
-                        b = b.offset(1);
+                        b = b.add(1);
                         *fresh53 = *a;
                     }
                     *a = *b;
@@ -1334,14 +1334,14 @@ unsafe fn ss_mergeforward(
             *c = !*c;
             loop {
                 let fresh54 = a;
-                a = a.offset(1);
+                a = a.add(1);
                 *fresh54 = *b;
                 if bufend <= b {
                     *bufend = t;
                     return;
                 }
                 let fresh55 = b;
-                b = b.offset(1);
+                b = b.add(1);
                 *fresh55 = *a;
                 if *b >= 0 {
                     break;
@@ -1349,18 +1349,18 @@ unsafe fn ss_mergeforward(
             }
             loop {
                 let fresh56 = a;
-                a = a.offset(1);
+                a = a.add(1);
                 *fresh56 = *c;
                 let fresh57 = c;
-                c = c.offset(1);
+                c = c.add(1);
                 *fresh57 = *a;
                 if last <= c {
                     while b < bufend {
                         let fresh58 = a;
-                        a = a.offset(1);
+                        a = a.add(1);
                         *fresh58 = *b;
                         let fresh59 = b;
-                        b = b.offset(1);
+                        b = b.add(1);
                         *fresh59 = *a;
                     }
                     *a = *b;
@@ -1394,7 +1394,7 @@ unsafe fn ss_mergebackward(
     let mut x: core::ffi::c_int = 0;
     bufend = buf
         .offset(last.offset_from(middle) as core::ffi::c_long as isize)
-        .offset(-(1));
+        .sub(1);
     ss_blockswap(
         buf,
         middle,
@@ -1407,26 +1407,26 @@ unsafe fn ss_mergebackward(
     } else {
         p1 = PA.offset(*bufend as isize);
     }
-    if *middle.offset(-(1)) < 0 {
-        p2 = PA.offset(!*middle.offset(-(1)) as isize);
+    if *middle.sub(1) < 0 {
+        p2 = PA.offset(!*middle.sub(1) as isize);
         x |= 2;
     } else {
-        p2 = PA.offset(*middle.offset(-(1)) as isize);
+        p2 = PA.offset(*middle.sub(1) as isize);
     }
-    a = last.offset(-(1));
+    a = last.sub(1);
     t = *a;
     b = bufend;
-    c = middle.offset(-(1));
+    c = middle.sub(1);
     loop {
         r = ss_compare(T, p1, p2, depth);
         if (0) < r {
             if x & 1 != 0 {
                 loop {
                     let fresh60 = a;
-                    a = a.offset(-1);
+                    a = a.sub(1);
                     *fresh60 = *b;
                     let fresh61 = b;
-                    b = b.offset(-1);
+                    b = b.sub(1);
                     *fresh61 = *a;
                     if *b >= 0 {
                         break;
@@ -1435,14 +1435,14 @@ unsafe fn ss_mergebackward(
                 x ^= 1;
             }
             let fresh62 = a;
-            a = a.offset(-1);
+            a = a.sub(1);
             *fresh62 = *b;
             if b <= buf {
                 *buf = t;
                 break;
             } else {
                 let fresh63 = b;
-                b = b.offset(-1);
+                b = b.sub(1);
                 *fresh63 = *a;
                 if *b < 0 {
                     p1 = PA.offset(!*b as isize);
@@ -1455,10 +1455,10 @@ unsafe fn ss_mergebackward(
             if x & 2 != 0 {
                 loop {
                     let fresh64 = a;
-                    a = a.offset(-1);
+                    a = a.sub(1);
                     *fresh64 = *c;
                     let fresh65 = c;
-                    c = c.offset(-1);
+                    c = c.sub(1);
                     *fresh65 = *a;
                     if *c >= 0 {
                         break;
@@ -1467,18 +1467,18 @@ unsafe fn ss_mergebackward(
                 x ^= 2;
             }
             let fresh66 = a;
-            a = a.offset(-1);
+            a = a.sub(1);
             *fresh66 = *c;
             let fresh67 = c;
-            c = c.offset(-1);
+            c = c.sub(1);
             *fresh67 = *a;
             if c < first {
                 while buf < b {
                     let fresh68 = a;
-                    a = a.offset(-1);
+                    a = a.sub(1);
                     *fresh68 = *b;
                     let fresh69 = b;
-                    b = b.offset(-1);
+                    b = b.sub(1);
                     *fresh69 = *a;
                 }
                 *a = *b;
@@ -1494,10 +1494,10 @@ unsafe fn ss_mergebackward(
             if x & 1 != 0 {
                 loop {
                     let fresh70 = a;
-                    a = a.offset(-1);
+                    a = a.sub(1);
                     *fresh70 = *b;
                     let fresh71 = b;
-                    b = b.offset(-1);
+                    b = b.sub(1);
                     *fresh71 = *a;
                     if *b >= 0 {
                         break;
@@ -1506,22 +1506,22 @@ unsafe fn ss_mergebackward(
                 x ^= 1;
             }
             let fresh72 = a;
-            a = a.offset(-1);
+            a = a.sub(1);
             *fresh72 = !*b;
             if b <= buf {
                 *buf = t;
                 break;
             } else {
                 let fresh73 = b;
-                b = b.offset(-1);
+                b = b.sub(1);
                 *fresh73 = *a;
                 if x & 2 != 0 {
                     loop {
                         let fresh74 = a;
-                        a = a.offset(-1);
+                        a = a.sub(1);
                         *fresh74 = *c;
                         let fresh75 = c;
-                        c = c.offset(-1);
+                        c = c.sub(1);
                         *fresh75 = *a;
                         if *c >= 0 {
                             break;
@@ -1530,18 +1530,18 @@ unsafe fn ss_mergebackward(
                     x ^= 2;
                 }
                 let fresh76 = a;
-                a = a.offset(-1);
+                a = a.sub(1);
                 *fresh76 = *c;
                 let fresh77 = c;
-                c = c.offset(-1);
+                c = c.sub(1);
                 *fresh77 = *a;
                 if c < first {
                     while buf < b {
                         let fresh78 = a;
-                        a = a.offset(-1);
+                        a = a.sub(1);
                         *fresh78 = *b;
                         let fresh79 = b;
-                        b = b.offset(-1);
+                        b = b.sub(1);
                         *fresh79 = *a;
                     }
                     *a = *b;
@@ -1605,10 +1605,10 @@ unsafe fn ss_swapmerge(
                     && ss_compare(
                         T,
                         PA.offset(
-                            (if 0 <= *first.offset(-(1)) {
-                                *first.offset(-(1))
+                            (if 0 <= *first.sub(1) {
+                                *first.sub(1)
                             } else {
-                                !*first.offset(-(1))
+                                !*first.sub(1)
                             }) as isize,
                         ),
                         PA.offset(*first as isize),
@@ -1621,10 +1621,10 @@ unsafe fn ss_swapmerge(
                 && ss_compare(
                     T,
                     PA.offset(
-                        (if 0 <= *last.offset(-(1)) {
-                            *last.offset(-(1))
+                        (if 0 <= *last.sub(1) {
+                            *last.sub(1)
                         } else {
-                            !*last.offset(-(1))
+                            !*last.sub(1)
                         }) as isize,
                     ),
                     PA.offset(*last as isize),
@@ -1651,10 +1651,10 @@ unsafe fn ss_swapmerge(
                     && ss_compare(
                         T,
                         PA.offset(
-                            (if 0 <= *first.offset(-(1)) {
-                                *first.offset(-(1))
+                            (if 0 <= *first.sub(1) {
+                                *first.sub(1)
                             } else {
-                                !*first.offset(-(1))
+                                !*first.sub(1)
                             }) as isize,
                         ),
                         PA.offset(*first as isize),
@@ -1667,10 +1667,10 @@ unsafe fn ss_swapmerge(
                 && ss_compare(
                     T,
                     PA.offset(
-                        (if 0 <= *last.offset(-(1)) {
-                            *last.offset(-(1))
+                        (if 0 <= *last.sub(1) {
+                            *last.sub(1)
                         } else {
-                            !*last.offset(-(1))
+                            !*last.sub(1)
                         }) as isize,
                     ),
                     PA.offset(*last as isize),
@@ -1713,17 +1713,17 @@ unsafe fn ss_swapmerge(
                             <= *middle
                                 .offset(-(m as isize))
                                 .offset(-(half as isize))
-                                .offset(-(1))
+                                .sub(1)
                         {
                             *middle
                                 .offset(-(m as isize))
                                 .offset(-(half as isize))
-                                .offset(-(1))
+                                .sub(1)
                         } else {
                             !*middle
                                 .offset(-(m as isize))
                                 .offset(-(half as isize))
-                                .offset(-(1))
+                                .sub(1)
                         }) as isize,
                     ),
                     depth,
@@ -1747,7 +1747,7 @@ unsafe fn ss_swapmerge(
                         *rm = !*rm;
                         if first < lm {
                             loop {
-                                l = l.offset(-1);
+                                l = l.sub(1);
                                 if *l >= 0 {
                                     break;
                                 }
@@ -1757,7 +1757,7 @@ unsafe fn ss_swapmerge(
                         next |= 1;
                     } else if first < lm {
                         while *r < 0 {
-                            r = r.offset(1);
+                            r = r.add(1);
                         }
                         next |= 2;
                     }
@@ -1800,10 +1800,10 @@ unsafe fn ss_swapmerge(
                 if ss_compare(
                     T,
                     PA.offset(
-                        (if 0 <= *middle.offset(-(1)) {
-                            *middle.offset(-(1))
+                        (if 0 <= *middle.sub(1) {
+                            *middle.sub(1)
                         } else {
-                            !*middle.offset(-(1))
+                            !*middle.sub(1)
                         }) as isize,
                     ),
                     PA.offset(*middle as isize),
@@ -1817,10 +1817,10 @@ unsafe fn ss_swapmerge(
                         && ss_compare(
                             T,
                             PA.offset(
-                                (if 0 <= *first.offset(-(1)) {
-                                    *first.offset(-(1))
+                                (if 0 <= *first.sub(1) {
+                                    *first.sub(1)
                                 } else {
-                                    !*first.offset(-(1))
+                                    !*first.sub(1)
                                 }) as isize,
                             ),
                             PA.offset(*first as isize),
@@ -1833,10 +1833,10 @@ unsafe fn ss_swapmerge(
                     && ss_compare(
                         T,
                         PA.offset(
-                            (if 0 <= *last.offset(-(1)) {
-                                *last.offset(-(1))
+                            (if 0 <= *last.sub(1) {
+                                *last.sub(1)
                             } else {
-                                !*last.offset(-(1))
+                                !*last.sub(1)
                             }) as isize,
                         ),
                         PA.offset(*last as isize),
@@ -1879,7 +1879,7 @@ unsafe fn sssort(
     let mut limit: core::ffi::c_int = 0;
     let mut i: core::ffi::c_int = 0;
     if lastsuffix != 0 {
-        first = first.offset(1);
+        first = first.add(1);
     }
     if bufsize < SS_BLOCKSIZE
         && (bufsize as core::ffi::c_long) < last.offset_from(first) as core::ffi::c_long
@@ -1955,24 +1955,24 @@ unsafe fn sssort(
     }
     if lastsuffix != 0 {
         let mut PAi: [core::ffi::c_int; 2] = [0; 2];
-        *PAi.as_mut_ptr().offset(0) = *PA.offset(*first.offset(-(1)) as isize);
-        *PAi.as_mut_ptr().offset(1) = n - 2;
+        *PAi.as_mut_ptr() = *PA.offset(*first.sub(1) as isize);
+        *PAi.as_mut_ptr().add(1) = n - 2;
         a = first;
-        i = *first.offset(-(1));
+        i = *first.sub(1);
         while a < last
             && (*a < 0
                 || (0)
                     < ss_compare(
                         T,
-                        &*PAi.as_mut_ptr().offset(0),
+                        &*PAi.as_mut_ptr(),
                         PA.offset(*a as isize),
                         depth,
                     ))
         {
-            *a.offset(-(1)) = *a;
-            a = a.offset(1);
+            *a.sub(1) = *a;
+            a = a.add(1);
         }
-        *a.offset(-(1)) = i;
+        *a.sub(1) = i;
     }
 }
 #[inline]
@@ -2006,18 +2006,18 @@ unsafe fn tr_insertionsort(
     let mut b = core::ptr::null_mut::<core::ffi::c_int>();
     let mut t: core::ffi::c_int = 0;
     let mut r: core::ffi::c_int = 0;
-    a = first.offset(1);
+    a = first.add(1);
     while a < last {
         t = *a;
-        b = a.offset(-(1));
+        b = a.sub(1);
         loop {
             r = *ISAd.offset(t as isize) - *ISAd.offset(*b as isize);
             if 0 <= r {
                 break;
             }
             loop {
-                *b.offset(1) = *b;
-                b = b.offset(-1);
+                *b.add(1) = *b;
+                b = b.sub(1);
                 if !(first <= b && *b < 0) {
                     break;
                 }
@@ -2029,8 +2029,8 @@ unsafe fn tr_insertionsort(
         if r == 0 {
             *b = !*b;
         }
-        *b.offset(1) = t;
-        a = a.offset(1);
+        *b.add(1) = t;
+        a = a.add(1);
     }
 }
 #[inline]
@@ -2095,15 +2095,15 @@ unsafe fn tr_heapsort(
         i -= 1;
     }
     if size % 2 == 0 {
-        t = *SA.offset(0);
-        *SA.offset(0) = *SA.offset(m as isize);
+        t = *SA;
+        *SA = *SA.offset(m as isize);
         *SA.offset(m as isize) = t;
         tr_fixdown(ISAd, SA, 0, m);
     }
     i = m - 1;
     while (0) < i {
-        t = *SA.offset(0);
-        *SA.offset(0) = *SA.offset(i as isize);
+        t = *SA;
+        *SA = *SA.offset(i as isize);
         tr_fixdown(ISAd, SA, 0, i);
         *SA.offset(i as isize) = t;
         i -= 1;
@@ -2189,7 +2189,7 @@ unsafe fn tr_pivot(
     middle = first.offset((t / 2) as isize);
     if t <= 512 {
         if t <= 32 {
-            return tr_median3(ISAd, first, middle, last.offset(-(1)));
+            return tr_median3(ISAd, first, middle, last.sub(1));
         } else {
             t >>= 2;
             return tr_median5(
@@ -2197,8 +2197,8 @@ unsafe fn tr_pivot(
                 first,
                 first.offset(t as isize),
                 middle,
-                last.offset(-(1)).offset(-(t as isize)),
-                last.offset(-(1)),
+                last.sub(1).offset(-(t as isize)),
+                last.sub(1),
             );
         }
     }
@@ -2217,9 +2217,9 @@ unsafe fn tr_pivot(
     );
     last = tr_median3(
         ISAd,
-        last.offset(-(1)).offset(-((t << 1) as isize)),
-        last.offset(-(1)).offset(-(t as isize)),
-        last.offset(-(1)),
+        last.sub(1).offset(-((t << 1) as isize)),
+        last.sub(1).offset(-(t as isize)),
+        last.sub(1),
     );
     tr_median3(ISAd, first, middle, last)
 }
@@ -2266,9 +2266,9 @@ unsafe fn tr_partition(
     let mut t: core::ffi::c_int = 0;
     let mut s: core::ffi::c_int = 0;
     let mut x = 0;
-    b = middle.offset(-(1));
+    b = middle.sub(1);
     loop {
-        b = b.offset(1);
+        b = b.add(1);
         if !(b < last && {
             x = *ISAd.offset(*b as isize);
             x == v
@@ -2279,7 +2279,7 @@ unsafe fn tr_partition(
     a = b;
     if a < last && x < v {
         loop {
-            b = b.offset(1);
+            b = b.add(1);
             if !(b < last && {
                 x = *ISAd.offset(*b as isize);
                 x <= v
@@ -2290,13 +2290,13 @@ unsafe fn tr_partition(
                 t = *b;
                 *b = *a;
                 *a = t;
-                a = a.offset(1);
+                a = a.add(1);
             }
         }
     }
     c = last;
     loop {
-        c = c.offset(-1);
+        c = c.sub(1);
         if !(b < c && {
             x = *ISAd.offset(*c as isize);
             x == v
@@ -2307,7 +2307,7 @@ unsafe fn tr_partition(
     d = c;
     if b < d && x > v {
         loop {
-            c = c.offset(-1);
+            c = c.sub(1);
             if !(b < c && {
                 x = *ISAd.offset(*c as isize);
                 x >= v
@@ -2318,7 +2318,7 @@ unsafe fn tr_partition(
                 t = *c;
                 *c = *d;
                 *d = t;
-                d = d.offset(-1);
+                d = d.sub(1);
             }
         }
     }
@@ -2327,7 +2327,7 @@ unsafe fn tr_partition(
         *b = *c;
         *c = t;
         loop {
-            b = b.offset(1);
+            b = b.add(1);
             if !(b < c && {
                 x = *ISAd.offset(*b as isize);
                 x <= v
@@ -2338,11 +2338,11 @@ unsafe fn tr_partition(
                 t = *b;
                 *b = *a;
                 *a = t;
-                a = a.offset(1);
+                a = a.add(1);
             }
         }
         loop {
-            c = c.offset(-1);
+            c = c.sub(1);
             if !(b < c && {
                 x = *ISAd.offset(*c as isize);
                 x >= v
@@ -2353,12 +2353,12 @@ unsafe fn tr_partition(
                 t = *c;
                 *c = *d;
                 *d = t;
-                d = d.offset(-1);
+                d = d.sub(1);
             }
         }
     }
     if a <= d {
-        c = b.offset(-(1));
+        c = b.sub(1);
         s = a.offset_from(first) as core::ffi::c_long as core::ffi::c_int;
         t = b.offset_from(a) as core::ffi::c_long as core::ffi::c_int;
         if s > t {
@@ -2371,8 +2371,8 @@ unsafe fn tr_partition(
             *e = *f;
             *f = t;
             s -= 1;
-            e = e.offset(1);
-            f = f.offset(1);
+            e = e.add(1);
+            f = f.add(1);
         }
         s = d.offset_from(c) as core::ffi::c_long as core::ffi::c_int;
         t = (last.offset_from(d) as core::ffi::c_long - 1) as core::ffi::c_int;
@@ -2386,8 +2386,8 @@ unsafe fn tr_partition(
             *e = *f;
             *f = t;
             s -= 1;
-            e = e.offset(1);
-            f = f.offset(1);
+            e = e.add(1);
+            f = f.add(1);
         }
         first = first.offset(b.offset_from(a) as core::ffi::c_long as isize);
         last = last.offset(-(d.offset_from(c) as core::ffi::c_long as isize));
@@ -2411,27 +2411,27 @@ unsafe fn tr_copy(
     let mut v: core::ffi::c_int = 0;
     v = (b.offset_from(SA) as core::ffi::c_long - 1) as core::ffi::c_int;
     c = first;
-    d = a.offset(-(1));
+    d = a.sub(1);
     while c <= d {
         s = *c - depth;
         if 0 <= s && *ISA.offset(s as isize) == v {
-            d = d.offset(1);
+            d = d.add(1);
             *d = s;
             *ISA.offset(s as isize) = d.offset_from(SA) as core::ffi::c_long as core::ffi::c_int;
         }
-        c = c.offset(1);
+        c = c.add(1);
     }
-    c = last.offset(-(1));
-    e = d.offset(1);
+    c = last.sub(1);
+    e = d.add(1);
     d = b;
     while e < d {
         s = *c - depth;
         if 0 <= s && *ISA.offset(s as isize) == v {
-            d = d.offset(-1);
+            d = d.sub(1);
             *d = s;
             *ISA.offset(s as isize) = d.offset_from(SA) as core::ffi::c_long as core::ffi::c_int;
         }
-        c = c.offset(-1);
+        c = c.sub(1);
     }
 }
 unsafe fn tr_partialcopy(
@@ -2454,11 +2454,11 @@ unsafe fn tr_partialcopy(
     v = (b.offset_from(SA) as core::ffi::c_long - 1) as core::ffi::c_int;
     lastrank = -(1);
     c = first;
-    d = a.offset(-(1));
+    d = a.sub(1);
     while c <= d {
         s = *c - depth;
         if 0 <= s && *ISA.offset(s as isize) == v {
-            d = d.offset(1);
+            d = d.add(1);
             *d = s;
             rank = *ISA.offset((s + depth) as isize);
             if lastrank != rank {
@@ -2467,7 +2467,7 @@ unsafe fn tr_partialcopy(
             }
             *ISA.offset(s as isize) = newrank;
         }
-        c = c.offset(1);
+        c = c.add(1);
     }
     lastrank = -(1);
     e = d;
@@ -2480,16 +2480,16 @@ unsafe fn tr_partialcopy(
         if newrank != rank {
             *ISA.offset(*e as isize) = newrank;
         }
-        e = e.offset(-1);
+        e = e.sub(1);
     }
     lastrank = -(1);
-    c = last.offset(-(1));
-    e = d.offset(1);
+    c = last.sub(1);
+    e = d.add(1);
     d = b;
     while e < d {
         s = *c - depth;
         if 0 <= s && *ISA.offset(s as isize) == v {
-            d = d.offset(-1);
+            d = d.sub(1);
             *d = s;
             rank = *ISA.offset((s + depth) as isize);
             if lastrank != rank {
@@ -2498,7 +2498,7 @@ unsafe fn tr_partialcopy(
             }
             *ISA.offset(s as isize) = newrank;
         }
-        c = c.offset(-1);
+        c = c.sub(1);
     }
 }
 unsafe fn tr_introsort(
@@ -2548,7 +2548,7 @@ unsafe fn tr_introsort(
                     v = (a.offset_from(SA) as core::ffi::c_long - 1) as core::ffi::c_int;
                     while c < a {
                         *ISA.offset(*c as isize) = v;
-                        c = c.offset(1);
+                        c = c.add(1);
                     }
                 }
                 if b < last {
@@ -2556,7 +2556,7 @@ unsafe fn tr_introsort(
                     v = (b.offset_from(SA) as core::ffi::c_long - 1) as core::ffi::c_int;
                     while c < b {
                         *ISA.offset(*c as isize) = v;
-                        c = c.offset(1);
+                        c = c.add(1);
                     }
                 }
                 if (1) < b.offset_from(a) as core::ffi::c_long {
@@ -2693,7 +2693,7 @@ unsafe fn tr_introsort(
                     loop {
                         *ISA.offset(*a as isize) =
                             a.offset_from(SA) as core::ffi::c_long as core::ffi::c_int;
-                        a = a.offset(1);
+                        a = a.add(1);
                         if !(a < last && 0 <= *a) {
                             break;
                         }
@@ -2704,7 +2704,7 @@ unsafe fn tr_introsort(
                     a = first;
                     loop {
                         *a = !*a;
-                        a = a.offset(1);
+                        a = a.add(1);
                         if *a >= 0 {
                             break;
                         }
@@ -2714,13 +2714,13 @@ unsafe fn tr_introsort(
                     } else {
                         -(1)
                     };
-                    a = a.offset(1);
+                    a = a.add(1);
                     if a < last {
                         b = first;
                         v = (a.offset_from(SA) as core::ffi::c_long - 1) as core::ffi::c_int;
                         while b < a {
                             *ISA.offset(*b as isize) = v;
-                            b = b.offset(1);
+                            b = b.add(1);
                         }
                     }
                     if trbudget_check(
@@ -2811,13 +2811,13 @@ unsafe fn tr_introsort(
                     first,
                     last.offset_from(first) as core::ffi::c_long as core::ffi::c_int,
                 );
-                a = last.offset(-(1));
+                a = last.sub(1);
                 while first < a {
                     x = *ISAd.offset(*a as isize);
-                    b = a.offset(-(1));
+                    b = a.sub(1);
                     while first <= b && *ISAd.offset(*b as isize) == x {
                         *b = !*b;
-                        b = b.offset(-1);
+                        b = b.sub(1);
                     }
                     a = b;
                 }
@@ -2828,7 +2828,7 @@ unsafe fn tr_introsort(
                 *first = *a;
                 *a = t;
                 v = *ISAd.offset(*first as isize);
-                tr_partition(ISAd, first, first.offset(1), last, &mut a, &mut b, v);
+                tr_partition(ISAd, first, first.add(1), last, &mut a, &mut b, v);
                 if last.offset_from(first) as core::ffi::c_long
                     != b.offset_from(a) as core::ffi::c_long
                 {
@@ -2841,14 +2841,14 @@ unsafe fn tr_introsort(
                     v = (a.offset_from(SA) as core::ffi::c_long - 1) as core::ffi::c_int;
                     while c < a {
                         *ISA.offset(*c as isize) = v;
-                        c = c.offset(1);
+                        c = c.add(1);
                     }
                     if b < last {
                         c = a;
                         v = (b.offset_from(SA) as core::ffi::c_long - 1) as core::ffi::c_int;
                         while c < b {
                             *ISA.offset(*c as isize) = v;
-                            c = c.offset(1);
+                            c = c.add(1);
                         }
                     }
                     if (1) < b.offset_from(a) as core::ffi::c_long
@@ -3238,7 +3238,7 @@ unsafe fn trsort(
                     *first.offset(skip as isize) = skip;
                     skip = 0;
                 }
-                last = SA.offset(*ISA.offset(t as isize) as isize).offset(1);
+                last = SA.offset(*ISA.offset(t as isize) as isize).add(1);
                 if (1) < last.offset_from(first) as core::ffi::c_long {
                     budget.count = 0;
                     tr_introsort(ISA, ISAd, SA, first, last, &mut budget);
@@ -3496,7 +3496,7 @@ unsafe fn construct_SA(
             i = SA.offset(*bucket_B.offset(((c1 << 8) | (c1 + 1)) as isize) as isize);
             j = SA
                 .offset(*bucket_A.offset((c1 + 1) as isize) as isize)
-                .offset(-(1));
+                .sub(1);
             k = core::ptr::null_mut();
             c2 = -(1);
             while i <= j {
@@ -3529,13 +3529,13 @@ unsafe fn construct_SA(
                     assert!(k < j);
                     assert!(!k.is_null());
                     let fresh192 = k;
-                    k = k.offset(-1);
+                    k = k.sub(1);
                     *fresh192 = s;
                 } else {
                     assert!(s == 0 && *T.offset(s as isize) as core::ffi::c_int == c1 || s < 0);
                     *j = !s;
                 }
-                j = j.offset(-1);
+                j = j.sub(1);
             }
             c1 -= 1;
         }
@@ -3543,7 +3543,7 @@ unsafe fn construct_SA(
     c2 = *T.offset((n - 1) as isize) as core::ffi::c_int;
     k = SA.offset(*bucket_A.offset(c2 as isize) as isize);
     let fresh193 = k;
-    k = k.offset(1);
+    k = k.add(1);
     *fresh193 = if (*T.offset((n - 2) as isize) as core::ffi::c_int) < c2 {
         !(n - 1)
     } else {
@@ -3571,13 +3571,13 @@ unsafe fn construct_SA(
             }
             assert!(i < k);
             let fresh194 = k;
-            k = k.offset(1);
+            k = k.add(1);
             *fresh194 = s;
         } else {
             assert!(s < 0);
             *i = !s;
         }
-        i = i.offset(1);
+        i = i.add(1);
     }
 }
 pub(super) unsafe fn divsufsort(
@@ -3595,10 +3595,10 @@ pub(super) unsafe fn divsufsort(
     } else if n == 0 {
         return 0;
     } else if n == 1 {
-        *SA.offset(0) = 0;
+        *SA = 0;
         return 0;
     } else if n == 2 {
-        m = ((*T.offset(0) as core::ffi::c_int) < *T.offset(1) as core::ffi::c_int)
+        m = ((*T as core::ffi::c_int) < *T.add(1) as core::ffi::c_int)
             as core::ffi::c_int;
         *SA.offset((m ^ 1) as isize) = 0;
         *SA.offset(m as isize) = 1;

--- a/lib/dictBuilder/fastcover.rs
+++ b/lib/dictBuilder/fastcover.rs
@@ -407,7 +407,7 @@ unsafe fn FASTCOVER_ctx_init(
         return Error::memory_allocation.to_error_code();
     }
     let mut i: u32 = 0;
-    *((*ctx).offsets).offset(0) = 0;
+    *((*ctx).offsets) = 0;
     i = 1;
     while i <= nbSamples {
         *((*ctx).offsets).offset(i as isize) = (*((*ctx).offsets)

--- a/lib/legacy/zstd_v05.rs
+++ b/lib/legacy/zstd_v05.rs
@@ -192,8 +192,8 @@ unsafe fn ZSTDv05_wildcopy(dst: *mut core::ffi::c_void, src: *const u8, length: 
     let oend = op.offset(length);
     loop {
         ZSTDv05_copy8(op as *mut core::ffi::c_void, ip as *const core::ffi::c_void);
-        op = op.offset(8);
-        ip = ip.offset(8);
+        op = op.add(8);
+        ip = ip.add(8);
         if op >= oend {
             break;
         }
@@ -259,30 +259,30 @@ impl<'a> BITv05_DStream_t<'a> {
             bitD.bitContainer = unsafe { *bitD.start as size_t };
 
             if srcSize == 7 {
-                bitD.bitContainer += (unsafe { *bitD.start.offset(6) } as size_t)
+                bitD.bitContainer += (unsafe { *bitD.start.add(6) } as size_t)
                     << (::core::mem::size_of::<size_t>() * 8 - 16);
             }
 
             if srcSize >= 6 {
-                bitD.bitContainer += (unsafe { *bitD.start.offset(5) } as size_t)
+                bitD.bitContainer += (unsafe { *bitD.start.add(5) } as size_t)
                     << (::core::mem::size_of::<size_t>() * 8 - 24);
             }
 
             if srcSize >= 5 {
-                bitD.bitContainer += (unsafe { *bitD.start.offset(4) } as size_t)
+                bitD.bitContainer += (unsafe { *bitD.start.add(4) } as size_t)
                     << (::core::mem::size_of::<size_t>() * 8 - 32);
             }
 
             if srcSize >= 4 {
-                bitD.bitContainer += (unsafe { *bitD.start.offset(3) } as size_t) << 24;
+                bitD.bitContainer += (unsafe { *bitD.start.add(3) } as size_t) << 24;
             }
 
             if srcSize >= 3 {
-                bitD.bitContainer += (unsafe { *bitD.start.offset(2) } as size_t) << 16;
+                bitD.bitContainer += (unsafe { *bitD.start.add(2) } as size_t) << 16;
             }
 
             if srcSize >= 2 {
-                bitD.bitContainer += (unsafe { *bitD.start.offset(1) } as size_t) << 8;
+                bitD.bitContainer += (unsafe { *bitD.start.add(1) } as size_t) << 8;
             }
 
             let contain32 = unsafe { *srcBuffer.add(srcSize - 1) } as u32;
@@ -375,7 +375,7 @@ unsafe fn FSEv05_initDState(
     let DTableH = ptr as *const FSEv05_DTableHeader;
     DStatePtr.state = bitD.read_bits((*DTableH).tableLog as core::ffi::c_uint);
     bitD.reload();
-    DStatePtr.table = dt.offset(1) as *const core::ffi::c_void;
+    DStatePtr.table = dt.add(1) as *const core::ffi::c_void;
 }
 #[inline]
 unsafe fn FSEv05_peakSymbol(DStatePtr: &mut FSEv05_DState_t) -> u8 {
@@ -430,7 +430,7 @@ unsafe fn FSEv05_buildDTable(
         tableLog: 0,
         fastMode: 0,
     };
-    let tdPtr = dt.offset(1) as *mut core::ffi::c_void;
+    let tdPtr = dt.add(1) as *mut core::ffi::c_void;
     let tableDecode = tdPtr as *mut FSEv05_decode_t;
     let tableSize = ((1) << tableLog) as u32;
     let tableMask = tableSize.wrapping_sub(1);
@@ -541,8 +541,8 @@ unsafe fn FSEv05_readNCount(
             while bitStream & 0xffff as core::ffi::c_int as u32 == 0xffff as core::ffi::c_int as u32
             {
                 n0 = n0.wrapping_add(24);
-                if ip < iend.offset(-(5)) {
-                    ip = ip.offset(2);
+                if ip < iend.sub(5) {
+                    ip = ip.add(2);
                     bitStream = MEM_readLE32(ip as *const core::ffi::c_void) >> bitCount;
                 } else {
                     bitStream >>= 16;
@@ -564,7 +564,7 @@ unsafe fn FSEv05_readNCount(
                 charnum = charnum.wrapping_add(1);
                 *normalizedCounter.offset(fresh3 as isize) = 0;
             }
-            if ip <= iend.offset(-(7)) || ip.offset((bitCount >> 3) as isize) <= iend.offset(-(4)) {
+            if ip <= iend.sub(7) || ip.offset((bitCount >> 3) as isize) <= iend.sub(4) {
                 ip = ip.offset((bitCount >> 3) as isize);
                 bitCount &= 7;
                 bitStream = MEM_readLE32(ip as *const core::ffi::c_void) >> bitCount;
@@ -594,13 +594,13 @@ unsafe fn FSEv05_readNCount(
             nbBits -= 1;
             threshold >>= 1;
         }
-        if ip <= iend.offset(-(7)) || ip.offset((bitCount >> 3) as isize) <= iend.offset(-(4)) {
+        if ip <= iend.sub(7) || ip.offset((bitCount >> 3) as isize) <= iend.sub(4) {
             ip = ip.offset((bitCount >> 3) as isize);
             bitCount &= 7;
         } else {
             bitCount -=
-                (8 * iend.offset(-(4)).offset_from(ip) as core::ffi::c_long) as core::ffi::c_int;
-            ip = iend.offset(-(4));
+                (8 * iend.sub(4).offset_from(ip) as core::ffi::c_long) as core::ffi::c_int;
+            ip = iend.sub(4);
         }
         bitStream = MEM_readLE32(ip as *const core::ffi::c_void) >> (bitCount & 31);
     }
@@ -617,7 +617,7 @@ unsafe fn FSEv05_readNCount(
 unsafe fn FSEv05_buildDTable_rle(dt: *mut FSEv05_DTable, symbolValue: u8) -> size_t {
     let ptr = dt as *mut core::ffi::c_void;
     let DTableH = ptr as *mut FSEv05_DTableHeader;
-    let dPtr = dt.offset(1) as *mut core::ffi::c_void;
+    let dPtr = dt.add(1) as *mut core::ffi::c_void;
     let cell = dPtr as *mut FSEv05_decode_t;
     (*DTableH).tableLog = 0;
     (*DTableH).fastMode = 0;
@@ -629,7 +629,7 @@ unsafe fn FSEv05_buildDTable_rle(dt: *mut FSEv05_DTable, symbolValue: u8) -> siz
 unsafe fn FSEv05_buildDTable_raw(dt: *mut FSEv05_DTable, nbBits: core::ffi::c_uint) -> size_t {
     let ptr = dt as *mut core::ffi::c_void;
     let DTableH = ptr as *mut FSEv05_DTableHeader;
-    let dPtr = dt.offset(1) as *mut core::ffi::c_void;
+    let dPtr = dt.add(1) as *mut core::ffi::c_void;
     let dinfo = dPtr as *mut FSEv05_decode_t;
     let tableSize = ((1) << nbBits) as core::ffi::c_uint;
     let tableMask = tableSize.wrapping_sub(1);
@@ -661,7 +661,7 @@ unsafe fn FSEv05_decompress_usingDTable_generic(
     let ostart = dst as *mut u8;
     let mut op = ostart;
     let omax = op.add(maxDstSize);
-    let olimit = omax.offset(-(3));
+    let olimit = omax.sub(3);
     let mut state1 = FSEv05_DState_t::default();
     let mut state2 = FSEv05_DState_t::default();
     let mut bitD = match BITv05_DStream_t::new(core::slice::from_raw_parts(cSrc, cSrcSize)) {
@@ -671,7 +671,7 @@ unsafe fn FSEv05_decompress_usingDTable_generic(
     FSEv05_initDState(&mut state1, &mut bitD, dt);
     FSEv05_initDState(&mut state2, &mut bitD, dt);
     while bitD.reload() == StreamStatus::Unfinished && op < olimit {
-        *op.offset(0) = (if fast != 0 {
+        *op = (if fast != 0 {
             FSEv05_decodeSymbolFast(&mut state1, &mut bitD) as core::ffi::c_int
         } else {
             FSEv05_decodeSymbol(&mut state1, &mut bitD) as core::ffi::c_int
@@ -681,7 +681,7 @@ unsafe fn FSEv05_decompress_usingDTable_generic(
         {
             bitD.reload();
         }
-        *op.offset(1) = (if fast != 0 {
+        *op.add(1) = (if fast != 0 {
             FSEv05_decodeSymbolFast(&mut state2, &mut bitD) as core::ffi::c_int
         } else {
             FSEv05_decodeSymbol(&mut state2, &mut bitD) as core::ffi::c_int
@@ -690,10 +690,10 @@ unsafe fn FSEv05_decompress_usingDTable_generic(
             > (::core::mem::size_of::<size_t>()).wrapping_mul(8)
             && bitD.reload() > StreamStatus::Unfinished
         {
-            op = op.offset(2);
+            op = op.add(2);
             break;
         }
-        *op.offset(2) = (if fast != 0 {
+        *op.add(2) = (if fast != 0 {
             FSEv05_decodeSymbolFast(&mut state1, &mut bitD) as core::ffi::c_int
         } else {
             FSEv05_decodeSymbol(&mut state1, &mut bitD) as core::ffi::c_int
@@ -703,19 +703,19 @@ unsafe fn FSEv05_decompress_usingDTable_generic(
         {
             bitD.reload();
         }
-        *op.offset(3) = (if fast != 0 {
+        *op.add(3) = (if fast != 0 {
             FSEv05_decodeSymbolFast(&mut state2, &mut bitD) as core::ffi::c_int
         } else {
             FSEv05_decodeSymbol(&mut state2, &mut bitD) as core::ffi::c_int
         }) as u8;
-        op = op.offset(4);
+        op = op.add(4);
     }
     while !(bitD.reload() > StreamStatus::Completed
         || op == omax
         || bitD.is_empty() && (fast != 0 || FSEv05_endOfDState(&state1) != 0))
     {
         let fresh5 = op;
-        op = op.offset(1);
+        op = op.add(1);
         *fresh5 = (if fast != 0 {
             FSEv05_decodeSymbolFast(&mut state1, &mut bitD) as core::ffi::c_int
         } else {
@@ -728,7 +728,7 @@ unsafe fn FSEv05_decompress_usingDTable_generic(
             break;
         }
         let fresh6 = op;
-        op = op.offset(1);
+        op = op.add(1);
         *fresh6 = (if fast != 0 {
             FSEv05_decodeSymbolFast(&mut state2, &mut bitD) as core::ffi::c_int
         } else {
@@ -821,7 +821,7 @@ unsafe fn HUFv05_readStats(
     if srcSize == 0 {
         return Error::srcSize_wrong.to_error_code();
     }
-    iSize = *ip.offset(0) as size_t;
+    iSize = *ip as size_t;
     if iSize >= 128 {
         if iSize >= 242 {
             static l: [core::ffi::c_int; 14] = [1, 2, 3, 4, 7, 8, 15, 16, 31, 32, 63, 64, 127, 128];
@@ -837,7 +837,7 @@ unsafe fn HUFv05_readStats(
             if oSize >= hwSize {
                 return Error::corruption_detected.to_error_code();
             }
-            ip = ip.offset(1);
+            ip = ip.add(1);
             n = 0;
             while (n as size_t) < oSize {
                 *huffWeight.offset(n as isize) =
@@ -854,7 +854,7 @@ unsafe fn HUFv05_readStats(
         oSize = FSEv05_decompress(
             huffWeight as *mut core::ffi::c_void,
             hwSize.wrapping_sub(1),
-            ip.offset(1),
+            ip.add(1),
             iSize,
         );
         if ERR_isError(oSize) {
@@ -891,7 +891,7 @@ unsafe fn HUFv05_readStats(
     *huffWeight.add(oSize) = lastWeight as u8;
     let fresh8 = &mut (*rankStats.offset(lastWeight as isize));
     *fresh8 = (*fresh8).wrapping_add(1);
-    if *rankStats.offset(1) < 2 || *rankStats.offset(1) & 1 != 0 {
+    if *rankStats.add(1) < 2 || *rankStats.add(1) & 1 != 0 {
         return Error::corruption_detected.to_error_code();
     }
     *nbSymbolsPtr = oSize.wrapping_add(1) as u32;
@@ -906,7 +906,7 @@ unsafe fn HUFv05_readDTableX2(DTable: *mut u16, src: *const u8, srcSize: size_t)
     let mut nbSymbols = 0;
     let mut n: u32 = 0;
     let mut nextRankStart: u32 = 0;
-    let dtPtr = DTable.offset(1) as *mut core::ffi::c_void;
+    let dtPtr = DTable.add(1) as *mut core::ffi::c_void;
     let dt = dtPtr as *mut HUFv05_DEltX2;
     iSize = HUFv05_readStats(
         huffWeight.as_mut_ptr(),
@@ -920,10 +920,10 @@ unsafe fn HUFv05_readDTableX2(DTable: *mut u16, src: *const u8, srcSize: size_t)
     if ERR_isError(iSize) {
         return iSize;
     }
-    if tableLog > *DTable.offset(0) as u32 {
+    if tableLog > *DTable as u32 {
         return Error::tableLog_tooLarge.to_error_code();
     }
-    *DTable.offset(0) = tableLog as u16;
+    *DTable = tableLog as u16;
     nextRankStart = 0;
     n = 1;
     while n <= tableLog {
@@ -974,31 +974,31 @@ unsafe fn HUFv05_decodeStreamX2(
     while bitDPtr.reload() == StreamStatus::Unfinished && p <= pEnd.sub(4) {
         if MEM_64bits() != 0 {
             let fresh10 = p;
-            p = p.offset(1);
+            p = p.add(1);
             *fresh10 = HUFv05_decodeSymbolX2(bitDPtr, dt, dtLog);
         }
         if MEM_64bits() != 0 || HUFv05_MAX_TABLELOG <= 12 {
             let fresh11 = p;
-            p = p.offset(1);
+            p = p.add(1);
             *fresh11 = HUFv05_decodeSymbolX2(bitDPtr, dt, dtLog);
         }
         if MEM_64bits() != 0 {
             let fresh12 = p;
-            p = p.offset(1);
+            p = p.add(1);
             *fresh12 = HUFv05_decodeSymbolX2(bitDPtr, dt, dtLog);
         }
         let fresh13 = p;
-        p = p.offset(1);
+        p = p.add(1);
         *fresh13 = HUFv05_decodeSymbolX2(bitDPtr, dt, dtLog);
     }
     while bitDPtr.reload() == StreamStatus::Unfinished && p < pEnd {
         let fresh14 = p;
-        p = p.offset(1);
+        p = p.add(1);
         *fresh14 = HUFv05_decodeSymbolX2(bitDPtr, dt, dtLog);
     }
     while p < pEnd {
         let fresh15 = p;
-        p = p.offset(1);
+        p = p.add(1);
         *fresh15 = HUFv05_decodeSymbolX2(bitDPtr, dt, dtLog);
     }
     pEnd.offset_from(pStart) as size_t
@@ -1012,9 +1012,9 @@ unsafe fn HUFv05_decompress1X2_usingDTable(
 ) -> size_t {
     let op = dst as *mut u8;
     let oend = op.add(dstSize);
-    let dtLog = *DTable.offset(0) as u32;
+    let dtLog = *DTable as u32;
     let dtPtr = DTable as *const core::ffi::c_void;
-    let dt = (dtPtr as *const HUFv05_DEltX2).offset(1);
+    let dt = (dtPtr as *const HUFv05_DEltX2).add(1);
     if dstSize <= cSrcSize {
         return Error::dstSize_tooSmall.to_error_code();
     }
@@ -1062,13 +1062,13 @@ unsafe fn HUFv05_decompress4X2_usingDTable(
     let ostart = dst as *mut u8;
     let oend = ostart.add(dstSize);
     let dtPtr = DTable as *const core::ffi::c_void;
-    let dt = (dtPtr as *const HUFv05_DEltX2).offset(1);
-    let dtLog = *DTable.offset(0) as u32;
+    let dt = (dtPtr as *const HUFv05_DEltX2).add(1);
+    let dtLog = *DTable as u32;
     let length1 = MEM_readLE16(istart as *const core::ffi::c_void) as size_t;
-    let length2 = MEM_readLE16(istart.offset(2) as *const core::ffi::c_void) as size_t;
-    let length3 = MEM_readLE16(istart.offset(4) as *const core::ffi::c_void) as size_t;
+    let length2 = MEM_readLE16(istart.add(2) as *const core::ffi::c_void) as size_t;
+    let length3 = MEM_readLE16(istart.add(4) as *const core::ffi::c_void) as size_t;
     let mut length4: size_t = 0;
-    let istart1 = istart.offset(6);
+    let istart1 = istart.add(6);
     let istart2 = istart1.add(length1);
     let istart3 = istart2.add(length2);
     let istart4 = istart3.add(length3);
@@ -1113,75 +1113,75 @@ unsafe fn HUFv05_decompress4X2_usingDTable(
     while end_signal && op4 < oend.sub(7) {
         if MEM_64bits() != 0 {
             let fresh16 = op1;
-            op1 = op1.offset(1);
+            op1 = op1.add(1);
             *fresh16 = HUFv05_decodeSymbolX2(&mut bitD1, dt, dtLog);
         }
         if MEM_64bits() != 0 {
             let fresh17 = op2;
-            op2 = op2.offset(1);
+            op2 = op2.add(1);
             *fresh17 = HUFv05_decodeSymbolX2(&mut bitD2, dt, dtLog);
         }
         if MEM_64bits() != 0 {
             let fresh18 = op3;
-            op3 = op3.offset(1);
+            op3 = op3.add(1);
             *fresh18 = HUFv05_decodeSymbolX2(&mut bitD3, dt, dtLog);
         }
         if MEM_64bits() != 0 {
             let fresh19 = op4;
-            op4 = op4.offset(1);
+            op4 = op4.add(1);
             *fresh19 = HUFv05_decodeSymbolX2(&mut bitD4, dt, dtLog);
         }
         if MEM_64bits() != 0 || HUFv05_MAX_TABLELOG <= 12 {
             let fresh20 = op1;
-            op1 = op1.offset(1);
+            op1 = op1.add(1);
             *fresh20 = HUFv05_decodeSymbolX2(&mut bitD1, dt, dtLog);
         }
         if MEM_64bits() != 0 || HUFv05_MAX_TABLELOG <= 12 {
             let fresh21 = op2;
-            op2 = op2.offset(1);
+            op2 = op2.add(1);
             *fresh21 = HUFv05_decodeSymbolX2(&mut bitD2, dt, dtLog);
         }
         if MEM_64bits() != 0 || HUFv05_MAX_TABLELOG <= 12 {
             let fresh22 = op3;
-            op3 = op3.offset(1);
+            op3 = op3.add(1);
             *fresh22 = HUFv05_decodeSymbolX2(&mut bitD3, dt, dtLog);
         }
         if MEM_64bits() != 0 || HUFv05_MAX_TABLELOG <= 12 {
             let fresh23 = op4;
-            op4 = op4.offset(1);
+            op4 = op4.add(1);
             *fresh23 = HUFv05_decodeSymbolX2(&mut bitD4, dt, dtLog);
         }
         if MEM_64bits() != 0 {
             let fresh24 = op1;
-            op1 = op1.offset(1);
+            op1 = op1.add(1);
             *fresh24 = HUFv05_decodeSymbolX2(&mut bitD1, dt, dtLog);
         }
         if MEM_64bits() != 0 {
             let fresh25 = op2;
-            op2 = op2.offset(1);
+            op2 = op2.add(1);
             *fresh25 = HUFv05_decodeSymbolX2(&mut bitD2, dt, dtLog);
         }
         if MEM_64bits() != 0 {
             let fresh26 = op3;
-            op3 = op3.offset(1);
+            op3 = op3.add(1);
             *fresh26 = HUFv05_decodeSymbolX2(&mut bitD3, dt, dtLog);
         }
         if MEM_64bits() != 0 {
             let fresh27 = op4;
-            op4 = op4.offset(1);
+            op4 = op4.add(1);
             *fresh27 = HUFv05_decodeSymbolX2(&mut bitD4, dt, dtLog);
         }
         let fresh28 = op1;
-        op1 = op1.offset(1);
+        op1 = op1.add(1);
         *fresh28 = HUFv05_decodeSymbolX2(&mut bitD1, dt, dtLog);
         let fresh29 = op2;
-        op2 = op2.offset(1);
+        op2 = op2.add(1);
         *fresh29 = HUFv05_decodeSymbolX2(&mut bitD2, dt, dtLog);
         let fresh30 = op3;
-        op3 = op3.offset(1);
+        op3 = op3.add(1);
         *fresh30 = HUFv05_decodeSymbolX2(&mut bitD3, dt, dtLog);
         let fresh31 = op4;
-        op4 = op4.offset(1);
+        op4 = op4.add(1);
         *fresh31 = HUFv05_decodeSymbolX2(&mut bitD4, dt, dtLog);
         end_signal &= bitD1.reload() == StreamStatus::Unfinished;
         end_signal &= bitD2.reload() == StreamStatus::Unfinished;
@@ -1373,16 +1373,16 @@ unsafe fn HUFv05_readDTableX4(
     }; 256];
     let mut rankStats: [u32; 17] = [0; 17];
     let mut rankStart0: [u32; 18] = [0; 18];
-    let rankStart = rankStart0.as_mut_ptr().offset(1);
+    let rankStart = rankStart0.as_mut_ptr().add(1);
     let mut rankVal: rankVal_t = [[0; 17]; 16];
     let mut tableLog: u32 = 0;
     let mut maxW: u32 = 0;
     let mut sizeOfSort: u32 = 0;
     let mut nbSymbols: u32 = 0;
-    let memLog = *DTable.offset(0);
+    let memLog = *DTable;
     let mut iSize: size_t = 0;
     let dtPtr = DTable as *mut core::ffi::c_void;
-    let dt = (dtPtr as *mut HUFv05_DEltX4).offset(1);
+    let dt = (dtPtr as *mut HUFv05_DEltX4).add(1);
     if memLog > HUFv05_ABSOLUTEMAX_TABLELOG as u32 {
         return Error::tableLog_tooLarge.to_error_code();
     }
@@ -1414,7 +1414,7 @@ unsafe fn HUFv05_readDTableX4(
         *rankStart.offset(w as isize) = current;
         w = w.wrapping_add(1);
     }
-    *rankStart.offset(0) = nextRankStart;
+    *rankStart = nextRankStart;
     sizeOfSort = nextRankStart;
     let mut s: u32 = 0;
     s = 0;
@@ -1428,13 +1428,13 @@ unsafe fn HUFv05_readDTableX4(
         (*sortedSymbol.as_mut_ptr().offset(r as isize)).weight = w_0 as u8;
         s = s.wrapping_add(1);
     }
-    *rankStart.offset(0) = 0;
+    *rankStart = 0;
     let minBits = tableLog.wrapping_add(1).wrapping_sub(maxW);
     let mut nextRankVal = 0u32;
     let mut w_1: u32 = 0;
     let mut consumed: u32 = 0;
     let rescale = memLog.wrapping_sub(tableLog).wrapping_sub(1) as core::ffi::c_int;
-    let rankVal0 = (*rankVal.as_mut_ptr().offset(0)).as_mut_ptr();
+    let rankVal0 = (*rankVal.as_mut_ptr()).as_mut_ptr();
     w_1 = 1;
     while w_1 <= maxW {
         let current_0 = nextRankVal;
@@ -1531,7 +1531,7 @@ unsafe fn HUFv05_decodeStreamX4(
             HUFv05_decodeSymbolX4(p as *mut core::ffi::c_void, bitDPtr, dt, dtLog) as isize,
         );
     }
-    while p <= pEnd.offset(-(2)) {
+    while p <= pEnd.sub(2) {
         p = p.offset(
             HUFv05_decodeSymbolX4(p as *mut core::ffi::c_void, bitDPtr, dt, dtLog) as isize,
         );
@@ -1553,9 +1553,9 @@ unsafe fn HUFv05_decompress1X4_usingDTable(
     let istart = cSrc;
     let ostart = dst as *mut u8;
     let oend = ostart.add(dstSize);
-    let dtLog = *DTable.offset(0);
+    let dtLog = *DTable;
     let dtPtr = DTable as *const core::ffi::c_void;
-    let dt = (dtPtr as *const HUFv05_DEltX4).offset(1);
+    let dt = (dtPtr as *const HUFv05_DEltX4).add(1);
     let mut bitD = match BITv05_DStream_t::new(core::slice::from_raw_parts(istart, cSrcSize)) {
         Ok(bitD) => bitD,
         Err(err) => return err.to_error_code(),
@@ -1580,13 +1580,13 @@ unsafe fn HUFv05_decompress4X4_usingDTable(
     let ostart = dst as *mut u8;
     let oend = ostart.add(dstSize);
     let dtPtr = DTable as *const core::ffi::c_void;
-    let dt = (dtPtr as *const HUFv05_DEltX4).offset(1);
-    let dtLog = *DTable.offset(0);
+    let dt = (dtPtr as *const HUFv05_DEltX4).add(1);
+    let dtLog = *DTable;
     let length1 = MEM_readLE16(istart as *const core::ffi::c_void) as size_t;
-    let length2 = MEM_readLE16(istart.offset(2) as *const core::ffi::c_void) as size_t;
-    let length3 = MEM_readLE16(istart.offset(4) as *const core::ffi::c_void) as size_t;
+    let length2 = MEM_readLE16(istart.add(2) as *const core::ffi::c_void) as size_t;
+    let length3 = MEM_readLE16(istart.add(4) as *const core::ffi::c_void) as size_t;
     let mut length4: size_t = 0;
-    let istart1 = istart.offset(6);
+    let istart1 = istart.add(6);
     let istart2 = istart1.add(length1);
     let istart3 = istart2.add(length2);
     let istart4 = istart3.add(length3);
@@ -2144,11 +2144,11 @@ unsafe fn HUFv05_decompress(
             );
         n += 1;
     }
-    let fresh37 = &mut (*Dtime.as_mut_ptr().offset(1));
-    *fresh37 = (*fresh37).wrapping_add(*Dtime.as_mut_ptr().offset(1) >> 4);
-    let fresh38 = &mut (*Dtime.as_mut_ptr().offset(2));
-    *fresh38 = (*fresh38).wrapping_add(*Dtime.as_mut_ptr().offset(2) >> 3);
-    if *Dtime.as_mut_ptr().offset(1) < *Dtime.as_mut_ptr().offset(0) {
+    let fresh37 = &mut (*Dtime.as_mut_ptr().add(1));
+    *fresh37 = (*fresh37).wrapping_add(*Dtime.as_mut_ptr().add(1) >> 4);
+    let fresh38 = &mut (*Dtime.as_mut_ptr().add(2));
+    *fresh38 = (*fresh38).wrapping_add(*Dtime.as_mut_ptr().add(2) >> 3);
+    if *Dtime.as_mut_ptr().add(1) < *Dtime.as_mut_ptr() {
         algoNb = 1;
     }
     decompress[algoNb](dst, dstSize, cSrc, cSrcSize)
@@ -2163,7 +2163,7 @@ unsafe fn ZSTDv05_decompressBegin(dctx: *mut ZSTDv05_DCtx) -> size_t {
     (*dctx).base = core::ptr::null();
     (*dctx).vBase = core::ptr::null();
     (*dctx).dictEnd = core::ptr::null();
-    *((*dctx).hufTableX4).as_mut_ptr().offset(0) =
+    *((*dctx).hufTableX4).as_mut_ptr() =
         ZSTD_HUFFDTABLE_CAPACITY_LOG as core::ffi::c_uint;
     (*dctx).flagStaticTables = 0;
     0
@@ -2215,8 +2215,8 @@ pub(crate) unsafe fn ZSTDv05_getFrameParams(
         ::core::mem::size_of::<ZSTDv05_parameters>(),
     );
     (*params).windowLog =
-        ((*src.offset(4) as core::ffi::c_int & 15) + ZSTDv05_WINDOWLOG_ABSOLUTEMIN) as u32;
-    if *src.offset(4) as core::ffi::c_int >> 4 != 0 {
+        ((*src.add(4) as core::ffi::c_int & 15) + ZSTDv05_WINDOWLOG_ABSOLUTEMIN) as u32;
+    if *src.add(4) as core::ffi::c_int >> 4 != 0 {
         return Error::frameParameter_unsupported.to_error_code();
     }
     0
@@ -2248,9 +2248,9 @@ unsafe fn ZSTDv05_getcBlockSize(
         return Error::srcSize_wrong.to_error_code();
     }
     headerFlags = *in_0;
-    cSize = (*in_0.offset(2) as core::ffi::c_int
-        + ((*in_0.offset(1) as core::ffi::c_int) << 8)
-        + ((*in_0.offset(0) as core::ffi::c_int & 7) << 16)) as u32;
+    cSize = (*in_0.add(2) as core::ffi::c_int
+        + ((*in_0.add(1) as core::ffi::c_int) << 8)
+        + ((*in_0 as core::ffi::c_int & 7) << 16)) as u32;
     (*bpPtr).blockType = (headerFlags as core::ffi::c_int >> 6) as blockType_t;
     (*bpPtr).origSize = if (*bpPtr).blockType as core::ffi::c_uint
         == bt_rle as core::ffi::c_int as core::ffi::c_uint
@@ -2291,45 +2291,45 @@ unsafe fn ZSTDv05_decodeLiteralsBlock(
     if srcSize < MIN_CBLOCK_SIZE as size_t {
         return Error::corruption_detected.to_error_code();
     }
-    match *istart.offset(0) as core::ffi::c_int >> 6 {
+    match *istart as core::ffi::c_int >> 6 {
         IS_HUFv05 => {
             let mut litSize: size_t = 0;
             let mut litCSize: size_t = 0;
             let mut singleStream = 0;
-            let mut lhSize = (*istart.offset(0) as core::ffi::c_int >> 4 & 3) as u32;
+            let mut lhSize = (*istart as core::ffi::c_int >> 4 & 3) as u32;
             if srcSize < 5 {
                 return Error::corruption_detected.to_error_code();
             }
             match lhSize {
                 2 => {
                     lhSize = 4;
-                    litSize = (((*istart.offset(0) as core::ffi::c_int & 15) << 10)
-                        + ((*istart.offset(1) as core::ffi::c_int) << 2)
-                        + (*istart.offset(2) as core::ffi::c_int >> 6))
+                    litSize = (((*istart as core::ffi::c_int & 15) << 10)
+                        + ((*istart.add(1) as core::ffi::c_int) << 2)
+                        + (*istart.add(2) as core::ffi::c_int >> 6))
                         as size_t;
-                    litCSize = (((*istart.offset(2) as core::ffi::c_int & 63) << 8)
-                        + *istart.offset(3) as core::ffi::c_int)
+                    litCSize = (((*istart.add(2) as core::ffi::c_int & 63) << 8)
+                        + *istart.add(3) as core::ffi::c_int)
                         as size_t;
                 }
                 3 => {
                     lhSize = 5;
-                    litSize = (((*istart.offset(0) as core::ffi::c_int & 15) << 14)
-                        + ((*istart.offset(1) as core::ffi::c_int) << 6)
-                        + (*istart.offset(2) as core::ffi::c_int >> 2))
+                    litSize = (((*istart as core::ffi::c_int & 15) << 14)
+                        + ((*istart.add(1) as core::ffi::c_int) << 6)
+                        + (*istart.add(2) as core::ffi::c_int >> 2))
                         as size_t;
-                    litCSize = (((*istart.offset(2) as core::ffi::c_int & 3) << 16)
-                        + ((*istart.offset(3) as core::ffi::c_int) << 8)
-                        + *istart.offset(4) as core::ffi::c_int)
+                    litCSize = (((*istart.add(2) as core::ffi::c_int & 3) << 16)
+                        + ((*istart.add(3) as core::ffi::c_int) << 8)
+                        + *istart.add(4) as core::ffi::c_int)
                         as size_t;
                 }
                 0 | 1 => {
                     lhSize = 3;
-                    singleStream = (*istart.offset(0) as core::ffi::c_int & 16) as size_t;
-                    litSize = (((*istart.offset(0) as core::ffi::c_int & 15) << 6)
-                        + (*istart.offset(1) as core::ffi::c_int >> 2))
+                    singleStream = (*istart as core::ffi::c_int & 16) as size_t;
+                    litSize = (((*istart as core::ffi::c_int & 15) << 6)
+                        + (*istart.add(1) as core::ffi::c_int >> 2))
                         as size_t;
-                    litCSize = (((*istart.offset(1) as core::ffi::c_int & 3) << 8)
-                        + *istart.offset(2) as core::ffi::c_int)
+                    litCSize = (((*istart.add(1) as core::ffi::c_int & 3) << 8)
+                        + *istart.add(2) as core::ffi::c_int)
                         as size_t;
                 }
                 _ => unreachable!(),
@@ -2370,7 +2370,7 @@ unsafe fn ZSTDv05_decodeLiteralsBlock(
             let mut errorCode: size_t = 0;
             let mut litSize_0: size_t = 0;
             let mut litCSize_0: size_t = 0;
-            let mut lhSize = (*istart.offset(0) as core::ffi::c_int >> 4 & 3) as u32;
+            let mut lhSize = (*istart as core::ffi::c_int >> 4 & 3) as u32;
             if lhSize != 1 {
                 return Error::corruption_detected.to_error_code();
             }
@@ -2378,10 +2378,10 @@ unsafe fn ZSTDv05_decodeLiteralsBlock(
                 return Error::dictionary_corrupted.to_error_code();
             }
             lhSize = 3;
-            litSize_0 = (((*istart.offset(0) as core::ffi::c_int & 15) << 6)
-                + (*istart.offset(1) as core::ffi::c_int >> 2)) as size_t;
-            litCSize_0 = (((*istart.offset(1) as core::ffi::c_int & 3) << 8)
-                + *istart.offset(2) as core::ffi::c_int) as size_t;
+            litSize_0 = (((*istart as core::ffi::c_int & 15) << 6)
+                + (*istart.add(1) as core::ffi::c_int >> 2)) as size_t;
+            litCSize_0 = (((*istart.add(1) as core::ffi::c_int & 3) << 8)
+                + *istart.add(2) as core::ffi::c_int) as size_t;
             if litCSize_0.wrapping_add(lhSize as size_t) > srcSize {
                 return Error::corruption_detected.to_error_code();
             }
@@ -2406,22 +2406,22 @@ unsafe fn ZSTDv05_decodeLiteralsBlock(
         }
         IS_RAW => {
             let mut litSize_1: size_t = 0;
-            let mut lhSize_1 = (*istart.offset(0) as core::ffi::c_int >> 4 & 3) as u32;
+            let mut lhSize_1 = (*istart as core::ffi::c_int >> 4 & 3) as u32;
             match lhSize_1 {
                 2 => {
-                    litSize_1 = (((*istart.offset(0) as core::ffi::c_int & 15) << 8)
-                        + *istart.offset(1) as core::ffi::c_int)
+                    litSize_1 = (((*istart as core::ffi::c_int & 15) << 8)
+                        + *istart.add(1) as core::ffi::c_int)
                         as size_t;
                 }
                 3 => {
-                    litSize_1 = (((*istart.offset(0) as core::ffi::c_int & 15) << 16)
-                        + ((*istart.offset(1) as core::ffi::c_int) << 8)
-                        + *istart.offset(2) as core::ffi::c_int)
+                    litSize_1 = (((*istart as core::ffi::c_int & 15) << 16)
+                        + ((*istart.add(1) as core::ffi::c_int) << 8)
+                        + *istart.add(2) as core::ffi::c_int)
                         as size_t;
                 }
                 0 | 1 => {
                     lhSize_1 = 1;
-                    litSize_1 = (*istart.offset(0) as core::ffi::c_int & 31) as size_t;
+                    litSize_1 = (*istart as core::ffi::c_int & 31) as size_t;
                 }
                 _ => unreachable!(),
             }
@@ -2453,17 +2453,17 @@ unsafe fn ZSTDv05_decodeLiteralsBlock(
         }
         IS_RLE => {
             let mut litSize_2: size_t = 0;
-            let mut lhSize_2 = (*istart.offset(0) as core::ffi::c_int >> 4 & 3) as u32;
+            let mut lhSize_2 = (*istart as core::ffi::c_int >> 4 & 3) as u32;
             match lhSize_2 {
                 2 => {
-                    litSize_2 = (((*istart.offset(0) as core::ffi::c_int & 15) << 8)
-                        + *istart.offset(1) as core::ffi::c_int)
+                    litSize_2 = (((*istart as core::ffi::c_int & 15) << 8)
+                        + *istart.add(1) as core::ffi::c_int)
                         as size_t;
                 }
                 3 => {
-                    litSize_2 = (((*istart.offset(0) as core::ffi::c_int & 15) << 16)
-                        + ((*istart.offset(1) as core::ffi::c_int) << 8)
-                        + *istart.offset(2) as core::ffi::c_int)
+                    litSize_2 = (((*istart as core::ffi::c_int & 15) << 16)
+                        + ((*istart.add(1) as core::ffi::c_int) << 8)
+                        + *istart.add(2) as core::ffi::c_int)
                         as size_t;
                     if srcSize < 4 {
                         return Error::corruption_detected.to_error_code();
@@ -2471,7 +2471,7 @@ unsafe fn ZSTDv05_decodeLiteralsBlock(
                 }
                 0 | 1 => {
                     lhSize_2 = 1;
-                    litSize_2 = (*istart.offset(0) as core::ffi::c_int & 31) as size_t;
+                    litSize_2 = (*istart as core::ffi::c_int & 31) as size_t;
                 }
                 _ => unreachable!(),
             }
@@ -2515,7 +2515,7 @@ unsafe fn ZSTDv05_decodeSeqHeaders(
         return Error::srcSize_wrong.to_error_code();
     }
     let fresh39 = ip;
-    ip = ip.offset(1);
+    ip = ip.add(1);
     *nbSeq = *fresh39 as core::ffi::c_int;
     if *nbSeq == 0 {
         return 1;
@@ -2525,8 +2525,8 @@ unsafe fn ZSTDv05_decodeSeqHeaders(
             return Error::srcSize_wrong.to_error_code();
         }
         let fresh40 = ip;
-        ip = ip.offset(1);
-        *nbSeq = ((*nbSeq.offset(0) - 128) << 8) + *fresh40 as core::ffi::c_int;
+        ip = ip.add(1);
+        *nbSeq = ((*nbSeq - 128) << 8) + *fresh40 as core::ffi::c_int;
     }
     if ip >= iend {
         return Error::srcSize_wrong.to_error_code();
@@ -2535,26 +2535,26 @@ unsafe fn ZSTDv05_decodeSeqHeaders(
     Offtype = (*ip as core::ffi::c_int >> 4 & 3) as u32;
     MLtype = (*ip as core::ffi::c_int >> 2 & 3) as u32;
     if *ip as core::ffi::c_int & 2 != 0 {
-        if ip.offset(3) > iend {
+        if ip.add(3) > iend {
             return Error::srcSize_wrong.to_error_code();
         }
-        dumpsLength = *ip.offset(2) as size_t;
+        dumpsLength = *ip.add(2) as size_t;
         dumpsLength =
-            dumpsLength.wrapping_add(((*ip.offset(1) as core::ffi::c_int) << 8) as size_t);
-        ip = ip.offset(3);
+            dumpsLength.wrapping_add(((*ip.add(1) as core::ffi::c_int) << 8) as size_t);
+        ip = ip.add(3);
     } else {
-        if ip.offset(2) > iend {
+        if ip.add(2) > iend {
             return Error::srcSize_wrong.to_error_code();
         }
-        dumpsLength = *ip.offset(1) as size_t;
+        dumpsLength = *ip.add(1) as size_t;
         dumpsLength =
-            dumpsLength.wrapping_add(((*ip.offset(0) as core::ffi::c_int & 1) << 8) as size_t);
-        ip = ip.offset(2);
+            dumpsLength.wrapping_add(((*ip as core::ffi::c_int & 1) << 8) as size_t);
+        ip = ip.add(2);
     }
     *dumpsPtr = ip;
     ip = ip.add(dumpsLength);
     *dumpsLengthPtr = dumpsLength;
-    if ip > iend.offset(-(3)) {
+    if ip > iend.sub(3) {
         return Error::srcSize_wrong.to_error_code();
     }
     let mut norm: [i16; 128] = [0; 128];
@@ -2563,7 +2563,7 @@ unsafe fn ZSTDv05_decodeSeqHeaders(
         1 => {
             LLlog = 0;
             let fresh41 = ip;
-            ip = ip.offset(1);
+            ip = ip.add(1);
             FSEv05_buildDTable_rle(DTableLL, *fresh41);
         }
         0 => {
@@ -2598,11 +2598,11 @@ unsafe fn ZSTDv05_decodeSeqHeaders(
     match Offtype {
         1 => {
             Offlog = 0;
-            if ip > iend.offset(-(2)) {
+            if ip > iend.sub(2) {
                 return Error::srcSize_wrong.to_error_code();
             }
             let fresh42 = ip;
-            ip = ip.offset(1);
+            ip = ip.add(1);
             FSEv05_buildDTable_rle(
                 DTableOffb,
                 *fresh42 as core::ffi::c_uchar & (MaxOff as core::ffi::c_uchar),
@@ -2640,11 +2640,11 @@ unsafe fn ZSTDv05_decodeSeqHeaders(
     match MLtype {
         1 => {
             MLlog = 0;
-            if ip > iend.offset(-(2)) {
+            if ip > iend.sub(2) {
                 return Error::srcSize_wrong.to_error_code();
             }
             let fresh43 = ip;
-            ip = ip.offset(1);
+            ip = ip.add(1);
             FSEv05_buildDTable_rle(DTableML, *fresh43);
         }
         0 => {
@@ -2693,21 +2693,21 @@ unsafe fn ZSTDv05_decodeSequence(seq: &mut seq_t, seqState: &mut seqState_t) {
     };
     if litLength == MaxLL as size_t {
         let fresh44 = dumps;
-        dumps = dumps.offset(1);
+        dumps = dumps.add(1);
         let add = *fresh44 as u32;
         if add < 255 {
             litLength = litLength.wrapping_add(add as size_t);
-        } else if dumps.offset(2) <= de {
+        } else if dumps.add(2) <= de {
             litLength = MEM_readLE16(dumps as *const core::ffi::c_void) as size_t;
-            dumps = dumps.offset(2);
+            dumps = dumps.add(2);
             if litLength & 1 != 0 && dumps < de {
                 litLength = litLength.wrapping_add(((*dumps as core::ffi::c_int) << 16) as size_t);
-                dumps = dumps.offset(1);
+                dumps = dumps.add(1);
             }
             litLength >>= 1;
         }
         if dumps >= de {
-            dumps = de.offset(-(1));
+            dumps = de.sub(1);
         }
     }
     static offsetPrefix: [u32; 32] = [
@@ -2740,25 +2740,25 @@ unsafe fn ZSTDv05_decodeSequence(seq: &mut seq_t, seqState: &mut seqState_t) {
     if matchLength == MaxML as size_t {
         let add_0 = (if dumps < de {
             let fresh45 = dumps;
-            dumps = dumps.offset(1);
+            dumps = dumps.add(1);
             *fresh45 as core::ffi::c_int
         } else {
             0
         }) as u32;
         if add_0 < 255 {
             matchLength = matchLength.wrapping_add(add_0 as size_t);
-        } else if dumps.offset(2) <= de {
+        } else if dumps.add(2) <= de {
             matchLength = MEM_readLE16(dumps as *const core::ffi::c_void) as size_t;
-            dumps = dumps.offset(2);
+            dumps = dumps.add(2);
             if matchLength & 1 != 0 && dumps < de {
                 matchLength =
                     matchLength.wrapping_add(((*dumps as core::ffi::c_int) << 16) as size_t);
-                dumps = dumps.offset(1);
+                dumps = dumps.add(1);
             }
             matchLength >>= 1;
         }
         if dumps >= de {
-            dumps = de.offset(-(1));
+            dumps = de.sub(1);
         }
     }
     matchLength = matchLength.wrapping_add(MINMATCH as size_t);
@@ -2825,9 +2825,9 @@ unsafe fn ZSTDv05_execSequence(
         if op > oend_8 || sequence.matchLength < MINMATCH as size_t {
             while op < oMatchEnd {
                 let fresh46 = match_0;
-                match_0 = match_0.offset(1);
+                match_0 = match_0.add(1);
                 let fresh47 = op;
-                op = op.offset(1);
+                op = op.add(1);
                 *fresh47 = *fresh46;
             }
             return sequenceLength;
@@ -2835,13 +2835,13 @@ unsafe fn ZSTDv05_execSequence(
     }
     if sequence.offset < 8 {
         let sub2 = *dec64table.as_ptr().add(sequence.offset);
-        *op.offset(0) = *match_0.offset(0);
-        *op.offset(1) = *match_0.offset(1);
-        *op.offset(2) = *match_0.offset(2);
-        *op.offset(3) = *match_0.offset(3);
+        *op = *match_0;
+        *op.add(1) = *match_0.add(1);
+        *op.add(2) = *match_0.add(2);
+        *op.add(3) = *match_0.add(3);
         match_0 = match_0.offset(*dec32table.as_ptr().add(sequence.offset) as isize);
         ZSTDv05_copy4(
-            op.offset(4) as *mut core::ffi::c_void,
+            op.add(4) as *mut core::ffi::c_void,
             match_0 as *const core::ffi::c_void,
         );
         match_0 = match_0.offset(-(sub2 as isize));
@@ -2851,8 +2851,8 @@ unsafe fn ZSTDv05_execSequence(
             match_0 as *const core::ffi::c_void,
         );
     }
-    op = op.offset(8);
-    match_0 = match_0.offset(8);
+    op = op.add(8);
+    match_0 = match_0.add(8);
     if oMatchEnd > oend.offset(-((16 - MINMATCH) as isize)) {
         if op < oend_8 {
             ZSTDv05_wildcopy(
@@ -2865,9 +2865,9 @@ unsafe fn ZSTDv05_execSequence(
         }
         while op < oMatchEnd {
             let fresh48 = match_0;
-            match_0 = match_0.offset(1);
+            match_0 = match_0.add(1);
             let fresh49 = op;
-            op = op.offset(1);
+            op = op.add(1);
             *fresh49 = *fresh48;
         }
     } else {


### PR DESCRIPTION
uses https://github.com/rust-lang/rust-clippy/pull/15606

this is easy to regenerate to work around merge conflicts, so merge as you see fit.

