### PR TITLE
Allow using the rust global allocator for memory allocations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,11 @@ features = ["xxh64", "xxh32"]
 
 
 [features]
+default = ["rust-allocator"]
 export-symbols = [] # whether the zlib api symbols are publicly exported
 semver-prefix = ["export-symbols"] # prefix all symbols in a semver-compatible way
 no-prefetch = [] # do not prefetch
 trace = []
 nightly = []
+c-allocator = []
+rust-allocator = []

--- a/lib/common/allocations.rs
+++ b/lib/common/allocations.rs
@@ -1,12 +1,10 @@
 use std::ptr;
 
-use libc::{calloc, free, malloc, size_t};
-
 use crate::lib::zstd::ZSTD_customMem;
 
 #[inline]
 pub(crate) unsafe fn ZSTD_customMalloc(
-    size: size_t,
+    size: usize,
     customMem: ZSTD_customMem,
 ) -> *mut core::ffi::c_void {
     if customMem.customAlloc.is_some() ^ customMem.customFree.is_some() {
@@ -17,11 +15,15 @@ pub(crate) unsafe fn ZSTD_customMalloc(
         return f(customMem.opaque, size);
     }
 
-    malloc(size)
+    #[cfg(feature = "rust-allocator")]
+    return std::alloc::alloc(core::alloc::Layout::from_size_align_unchecked(size, 16)).cast();
+
+    #[cfg(feature = "c-allocator")]
+    return libc::malloc(size);
 }
 #[inline]
 pub(crate) unsafe fn ZSTD_customCalloc(
-    size: size_t,
+    size: usize,
     customMem: ZSTD_customMem,
 ) -> *mut core::ffi::c_void {
     if customMem.customAlloc.is_some() ^ customMem.customFree.is_some() {
@@ -33,15 +35,32 @@ pub(crate) unsafe fn ZSTD_customCalloc(
         ptr::write_bytes(ptr, 0, size);
         return ptr;
     }
-    calloc(1, size)
+
+    #[cfg(feature = "rust-allocator")]
+    return std::alloc::alloc_zeroed(core::alloc::Layout::from_size_align_unchecked(size, 16))
+        .cast();
+
+    #[cfg(feature = "c-allocator")]
+    return libc::calloc(1, size);
 }
 #[inline]
-pub(crate) unsafe fn ZSTD_customFree(ptr: *mut core::ffi::c_void, customMem: ZSTD_customMem) {
+pub(crate) unsafe fn ZSTD_customFree(
+    ptr: *mut core::ffi::c_void,
+    _size: usize,
+    customMem: ZSTD_customMem,
+) {
     if !ptr.is_null() {
         if let Some(f) = customMem.customFree {
             f(customMem.opaque, ptr);
         } else {
-            free(ptr);
+            #[cfg(feature = "rust-allocator")]
+            return std::alloc::dealloc(
+                ptr.cast(),
+                core::alloc::Layout::from_size_align_unchecked(_size, 16),
+            );
+
+            #[cfg(feature = "c-allocator")]
+            return libc::free(ptr);
         }
     }
 }

--- a/lib/decompress/zstd_ddict.rs
+++ b/lib/decompress/zstd_ddict.rs
@@ -297,8 +297,12 @@ pub unsafe extern "C" fn ZSTD_freeDDict(ddict: *mut ZSTD_DDict) -> size_t {
         return 0;
     }
     let cMem = (*ddict).cMem;
-    ZSTD_customFree((*ddict).dictBuffer, cMem);
-    ZSTD_customFree(ddict as *mut core::ffi::c_void, cMem);
+    ZSTD_customFree((*ddict).dictBuffer, (*ddict).dictSize, cMem);
+    ZSTD_customFree(
+        ddict as *mut core::ffi::c_void,
+        size_of::<ZSTD_DDict>(),
+        cMem,
+    );
     0
 }
 


### PR DESCRIPTION
I'm not fully certain I got the allocation sizes correct on the compressor size, but everything should be fine on the decompression side.