### PR TITLE
Relwithdebinfo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ crate-type = ["staticlib", "rlib"]
 name = "programs"
 path = "programs/main.rs"
 
+[profile.relwithdebinfo]
+inherits = "release"
+debug = true
+
 [dependencies]
 libc = "0.2"
 
@@ -37,7 +41,6 @@ zstd-sys = { version = "2.0.15", features = ["experimental"] }
 [dev-dependencies.xxhash-rust]
 version = "0.8.15"
 features = ["xxh64", "xxh32"]
-
 
 [features]
 export-symbols = [] # whether the zlib api symbols are publicly exported

--- a/lib/common/xxhash.rs
+++ b/lib/common/xxhash.rs
@@ -51,6 +51,7 @@ const XXH_PRIME64_3: u64 = 0x165667b19e3779f9;
 const XXH_PRIME64_4: u64 = 0x85ebca77c2b2ae63;
 const XXH_PRIME64_5: u64 = 0x27d4eb2f165667c5;
 
+#[inline(always)]
 const fn XXH64_round(acc: u64, input: u64) -> u64 {
     input
         .wrapping_mul(XXH_PRIME64_2)
@@ -59,12 +60,14 @@ const fn XXH64_round(acc: u64, input: u64) -> u64 {
         .wrapping_mul(XXH_PRIME64_1)
 }
 
+#[inline(always)]
 const fn XXH64_mergeRound(acc: u64, val: u64) -> u64 {
     (acc ^ XXH64_round(0, val))
         .wrapping_mul(XXH_PRIME64_1)
         .wrapping_add(XXH_PRIME64_4)
 }
 
+#[inline(always)]
 const fn XXH64_avalanche(mut hash: u64) -> u64 {
     hash ^= hash >> 33;
     hash = hash.wrapping_mul(XXH_PRIME64_2);

--- a/lib/decompress/zstd_decompress_block.rs
+++ b/lib/decompress/zstd_decompress_block.rs
@@ -1572,7 +1572,7 @@ fn ZSTD_updateFseStateWithDInfo(
     nbBits: u32,
 ) {
     let lowBits = bitD.read_bits(nbBits);
-    DStatePtr.state = (nextState as size_t).wrapping_add(lowBits as size_t);
+    DStatePtr.state = usize::from(nextState) + lowBits;
 }
 
 /// We need to add at most (ZSTD_WINDOWLOG_MAX_32 - 1) bits to read the maximum


### PR DESCRIPTION
Based on my measurements, or performance on `silesia-small.tar.zst` has not changed since the example for it was first added. We do see a slight increase in instructions (due to e.g. bounds checks), but no significant change in cycles/wall time.

I also don't really see where we loose performance versus C right now. The flame graphs ect all look roughly similar, with no clear differences between the C and rust runs.