### PR TITLE
Fix a couple of warnings

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -132,8 +132,8 @@ jobs:
           - target: x86_64-unknown-linux-gnu
         features:
           - ""
-          # - '--no-default-features --features="c-allocator"'
-          # - '--no-default-features --features="std,rust-allocator"'
+          - '--no-default-features --features="c-allocator"'
+          - '--no-default-features --features="rust-allocator"'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/lib/common/allocations.rs
+++ b/lib/common/allocations.rs
@@ -15,11 +15,14 @@ pub(crate) unsafe fn ZSTD_customMalloc(
         return f(customMem.opaque, size);
     }
 
-    #[cfg(feature = "rust-allocator")]
-    return std::alloc::alloc(core::alloc::Layout::from_size_align_unchecked(size, 16)).cast();
+    #[allow(unreachable_code)]
+    {
+        #[cfg(feature = "rust-allocator")]
+        return std::alloc::alloc(core::alloc::Layout::from_size_align_unchecked(size, 16)).cast();
 
-    #[cfg(feature = "c-allocator")]
-    return libc::malloc(size);
+        #[cfg(feature = "c-allocator")]
+        return libc::malloc(size);
+    }
 }
 #[inline]
 pub(crate) unsafe fn ZSTD_customCalloc(
@@ -36,12 +39,15 @@ pub(crate) unsafe fn ZSTD_customCalloc(
         return ptr;
     }
 
-    #[cfg(feature = "rust-allocator")]
-    return std::alloc::alloc_zeroed(core::alloc::Layout::from_size_align_unchecked(size, 16))
-        .cast();
+    #[allow(unreachable_code)]
+    {
+        #[cfg(feature = "rust-allocator")]
+        return std::alloc::alloc_zeroed(core::alloc::Layout::from_size_align_unchecked(size, 16))
+            .cast();
 
-    #[cfg(feature = "c-allocator")]
-    return libc::calloc(1, size);
+        #[cfg(feature = "c-allocator")]
+        return libc::calloc(1, size);
+    }
 }
 #[inline]
 pub(crate) unsafe fn ZSTD_customFree(
@@ -51,8 +57,11 @@ pub(crate) unsafe fn ZSTD_customFree(
 ) {
     if !ptr.is_null() {
         if let Some(f) = customMem.customFree {
-            f(customMem.opaque, ptr);
-        } else {
+            return f(customMem.opaque, ptr);
+        }
+
+        #[allow(unreachable_code)]
+        {
             #[cfg(feature = "rust-allocator")]
             return std::alloc::dealloc(
                 ptr.cast(),

--- a/lib/common/allocations.rs
+++ b/lib/common/allocations.rs
@@ -1,4 +1,4 @@
-use std::ptr;
+use core::ptr;
 
 use crate::lib::zstd::ZSTD_customMem;
 

--- a/lib/common/bitstream.rs
+++ b/lib/common/bitstream.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use libc::size_t;
 

--- a/lib/common/error_private.rs
+++ b/lib/common/error_private.rs
@@ -109,7 +109,7 @@ impl TryFrom<u32> for Error {
 type ERR_enum = ZSTD_ErrorCode;
 
 pub(crate) const fn ERR_isError(code: size_t) -> bool {
-    code > -(ZSTD_error_maxCode as std::ffi::c_int) as size_t
+    code > -(ZSTD_error_maxCode as core::ffi::c_int) as size_t
 }
 
 pub(crate) const fn ERR_getErrorCode(code: size_t) -> ZSTD_ErrorCode {

--- a/lib/common/zstd_trace.rs
+++ b/lib/common/zstd_trace.rs
@@ -64,6 +64,10 @@ mod statics {
     use super::{ZSTD_CCtx, ZSTD_Trace, ZSTD_TraceCtx};
     use crate::lib::decompress::ZSTD_DCtx;
 
+    #[expect(
+        improper_ctypes,
+        reason = "ZSTD_CCtx contains types that are not FFI-safe. This is fine as it is opaque to C"
+    )]
     extern "C" {
         pub(super) fn ZSTD_trace_compress_begin(cctx: *const ZSTD_CCtx) -> ZSTD_TraceCtx;
         pub(super) fn ZSTD_trace_compress_end(ctx: ZSTD_TraceCtx, trace: *const ZSTD_Trace);

--- a/lib/decompress/zstd_decompress.rs
+++ b/lib/decompress/zstd_decompress.rs
@@ -3194,14 +3194,14 @@ pub unsafe extern "C" fn ZSTD_decompressStream(
                     return Error::frameParameter_windowTooLarge.to_error_code();
                 }
                 if zds.maxBlockSizeParam != 0 {
-                    zds.fParams.blockSizeMax = std::cmp::min(
+                    zds.fParams.blockSizeMax = core::cmp::min(
                         zds.fParams.blockSizeMax,
                         zds.maxBlockSizeParam as core::ffi::c_uint,
                     );
                 }
 
                 // Adapt buffer sizes to frame header instructions
-                let neededInBuffSize = std::cmp::max(zds.fParams.blockSizeMax, 4) as size_t;
+                let neededInBuffSize = core::cmp::max(zds.fParams.blockSizeMax, 4) as size_t;
                 let neededOutBuffSize = if zds.outBufferMode == BufferMode::Buffered {
                     ZSTD_decodingBufferSize_internal(
                         zds.fParams.windowSize,

--- a/lib/legacy/zstd_v06.rs
+++ b/lib/legacy/zstd_v06.rs
@@ -3841,7 +3841,7 @@ pub(crate) unsafe fn ZBUFFv06_decompressContinue(
 
                     // Frame header instruct buffer sizes
                     let blockSize =
-                        std::cmp::min(1 << (*zbd).fParams.windowLog, 128 * 1024) as size_t;
+                        core::cmp::min(1 << (*zbd).fParams.windowLog, 128 * 1024) as size_t;
                     (*zbd).blockSize = blockSize;
                     if (*zbd).inBuffSize < blockSize {
                         free((*zbd).inBuff as *mut core::ffi::c_void);

--- a/lib/legacy/zstd_v07.rs
+++ b/lib/legacy/zstd_v07.rs
@@ -1,5 +1,5 @@
+use core::marker::PhantomData;
 use core::ptr;
-use std::marker::PhantomData;
 
 use libc::{free, malloc};
 
@@ -3252,10 +3252,10 @@ pub(crate) unsafe fn ZBUFFv07_decompressContinue(
                         h2Size,
                     )?;
                 }
-                (*zbd).fParams.windowSize = std::cmp::max((*zbd).fParams.windowSize, 1 << 10);
+                (*zbd).fParams.windowSize = core::cmp::max((*zbd).fParams.windowSize, 1 << 10);
 
                 // Frame header instruct buffer sizes
-                let blockSize = std::cmp::min((*zbd).fParams.windowSize, 128 * 1024) as usize;
+                let blockSize = core::cmp::min((*zbd).fParams.windowSize, 128 * 1024) as usize;
                 (*zbd).blockSize = blockSize;
                 if (*zbd).inBuffSize < blockSize {
                     free((*zbd).inBuff as *mut core::ffi::c_void);


### PR DESCRIPTION
These only show up with non-default features enabled.

Also replace a bunch of `std::` with `core::`.