### PR TITLE
Fix erroneous semicolons with void returns

### DIFF
--- a/lib/common/allocations.rs
+++ b/lib/common/allocations.rs
@@ -73,7 +73,7 @@ pub(crate) unsafe fn ZSTD_customFree(
         cfg_select! {
             feature = "rust-allocator" => {
                 let layout = core::alloc::Layout::from_size_align_unchecked(_size, 16);
-                std::alloc::dealloc(ptr.cast(), layout)
+                std::alloc::dealloc(ptr.cast(), layout);
             }
             feature = "c-allocator" => {
                 libc::free(ptr);

--- a/lib/common/mem.rs
+++ b/lib/common/mem.rs
@@ -30,15 +30,15 @@ pub(crate) unsafe fn MEM_readST(ptr: *const c_void) -> size_t {
 
 #[inline]
 pub(crate) unsafe fn MEM_write16(memPtr: *mut c_void, value: u16) {
-    memPtr.cast::<u16>().write_unaligned(value)
+    memPtr.cast::<u16>().write_unaligned(value);
 }
 #[inline]
 pub(crate) unsafe fn MEM_write32(memPtr: *mut c_void, value: u32) {
-    memPtr.cast::<u32>().write_unaligned(value)
+    memPtr.cast::<u32>().write_unaligned(value);
 }
 #[inline]
 pub(crate) unsafe fn MEM_write64(memPtr: *mut c_void, value: u64) {
-    memPtr.cast::<u64>().write_unaligned(value)
+    memPtr.cast::<u64>().write_unaligned(value);
 }
 
 #[inline]

--- a/lib/common/pool.rs
+++ b/lib/common/pool.rs
@@ -110,7 +110,7 @@ pub(crate) unsafe fn POOL_create_advanced(
             (*ctx.0).threads.add(i),
             std::thread::spawn(|| {
                 let ctx = ctx;
-                POOL_thread(ctx.0)
+                POOL_thread(ctx.0);
             }),
         );
     }
@@ -203,7 +203,7 @@ unsafe fn POOL_resize_internal(ctx: *mut POOL_ctx, numThreads: size_t) -> core::
             ((*ctx.0).threads).add(threadId),
             std::thread::spawn(|| {
                 let ctx = ctx;
-                POOL_thread(ctx.0)
+                POOL_thread(ctx.0);
             }),
         );
     }

--- a/lib/common/xxhash.rs
+++ b/lib/common/xxhash.rs
@@ -155,7 +155,7 @@ pub unsafe fn ZSTD_XXH64(input: *const core::ffi::c_void, len: usize, seed: u64)
 }
 
 pub(crate) fn ZSTD_XXH64_reset(state: &mut XXH64_state_t, seed: u64) {
-    state.reset(seed)
+    state.reset(seed);
 }
 
 pub(crate) fn ZSTD_XXH64_update_slice(state: &mut XXH64_state_t, mut slice: &[u8]) {

--- a/lib/compress/zstd_compress.rs
+++ b/lib/compress/zstd_compress.rs
@@ -3801,7 +3801,7 @@ pub unsafe extern "C" fn ZSTD_getFrameProgression(cctx: *const ZSTD_CCtx) -> ZST
     };
 
     if buffered != 0 {
-        assert!((*cctx).inBuffPos >= (*cctx).inToCompress)
+        assert!((*cctx).inBuffPos >= (*cctx).inToCompress);
     }
     assert!(buffered <= ZSTD_BLOCKSIZE_MAX as usize);
 

--- a/lib/compress/zstd_compress_literals.rs
+++ b/lib/compress/zstd_compress_literals.rs
@@ -284,7 +284,7 @@ pub unsafe fn ZSTD_compressLiterals(
     match lhSize {
         3 => {
             if singleStream == 0 {
-                assert!(srcSize >= MIN_LITERALS_FOR_4_STREAMS)
+                assert!(srcSize >= MIN_LITERALS_FOR_4_STREAMS);
             }
 
             let lhc = (hType as core::ffi::c_uint)

--- a/lib/decompress/zstd_decompress.rs
+++ b/lib/decompress/zstd_decompress.rs
@@ -287,7 +287,7 @@ fn find_frame_size_info_legacy(src: &[u8]) -> Result<ZSTD_frameSizeInfo, Error> 
                 src.len(),
                 &mut frameSizeInfo.compressedSize,
                 &mut frameSizeInfo.decompressedBound,
-            )
+            );
         },
         7 => {
             ZSTDv07_findFrameSizeInfoLegacy(
@@ -1649,7 +1649,7 @@ fn decompression_margin(mut src: &[u8]) -> Result<size_t, Error> {
             margin += zfh.headerSize as size_t;
             margin += if zfh.checksumFlag != 0 { 4 } else { 0 };
             margin += 3 * frameSizeInfo.nbBlocks;
-            maxBlockSize = Ord::max(maxBlockSize, zfh.blockSizeMax)
+            maxBlockSize = Ord::max(maxBlockSize, zfh.blockSizeMax);
         } else {
             debug_assert!(zfh.frameType == ZSTD_skippableFrame);
             // add the entire skippable frame size to our margin.
@@ -1939,7 +1939,7 @@ unsafe fn ZSTD_decompressMultiFrame<'a>(
 
             if let Some(ddict) = ddict {
                 Error::from_error_code(ZSTD_decompressBegin_usingDDict(dctx, ddict))
-                    .map_or(Ok(()), Err)?
+                    .map_or(Ok(()), Err)?;
             } else {
                 // this will initialize correctly with no dict if `dict == NULL`, so
                 // use this in all cases but for ddict

--- a/lib/decompress/zstd_decompress_block.rs
+++ b/lib/decompress/zstd_decompress_block.rs
@@ -337,7 +337,7 @@ fn ZSTD_decodeLiteralsBlock(
                         let len = litSize - ZSTD_LITBUFFEREXTRASIZE;
                         let src = &src[lhSize..][..len];
 
-                        core::ptr::copy_nonoverlapping(src.as_ptr(), dctx.litBuffer, len)
+                        core::ptr::copy_nonoverlapping(src.as_ptr(), dctx.litBuffer, len);
                     };
 
                     dctx.litExtraBuffer[..ZSTD_LITBUFFEREXTRASIZE].copy_from_slice(
@@ -348,7 +348,7 @@ fn ZSTD_decodeLiteralsBlock(
                     unsafe {
                         let src = &src[lhSize..][..litSize];
 
-                        core::ptr::copy_nonoverlapping(src.as_ptr(), dctx.litBuffer, litSize)
+                        core::ptr::copy_nonoverlapping(src.as_ptr(), dctx.litBuffer, litSize);
                     };
                 }
                 dctx.litPtr = dctx.litBuffer;
@@ -402,7 +402,7 @@ fn ZSTD_decodeLiteralsBlock(
                         dctx.litBuffer,
                         src[lhSize],
                         litSize - ZSTD_LITBUFFEREXTRASIZE,
-                    )
+                    );
                 };
 
                 dctx.litExtraBuffer[..ZSTD_LITBUFFEREXTRASIZE].fill(src[lhSize]);
@@ -1814,7 +1814,7 @@ fn ZSTD_decompressSequences_bodySplitLitBuffer(
                         "nop",
                         ".p2align 3",
                         options(preserves_flags)
-                    )
+                    );
                 }
             }
 
@@ -1974,7 +1974,7 @@ fn prefetch_area<T>(ptr: *const T, bytes: usize) {
 
 #[inline(always)]
 fn prefetch_val<T>(ptr: *const T) {
-    prefetch_area(ptr, size_of::<T>())
+    prefetch_area(ptr, size_of::<T>());
 }
 
 #[inline(always)]

--- a/lib/dictBuilder/cover.rs
+++ b/lib/dictBuilder/cover.rs
@@ -1068,7 +1068,7 @@ pub(super) fn COVER_dictSelectionIsError(selection: &COVER_dictSelection_t) -> b
 }
 
 pub(super) fn COVER_dictSelectionFree(selection: COVER_dictSelection_t) {
-    drop(selection)
+    drop(selection);
 }
 
 pub(super) fn COVER_selectDict(
@@ -1181,7 +1181,7 @@ pub(super) fn COVER_selectDict(
 }
 
 unsafe fn COVER_tryParameters_wrapper(opaque: *mut core::ffi::c_void) {
-    COVER_tryParameters(unsafe { Box::from_raw(opaque.cast()) })
+    COVER_tryParameters(unsafe { Box::from_raw(opaque.cast()) });
 }
 
 fn COVER_tryParameters(data: Box<COVER_tryParameters_data_t>) {

--- a/lib/dictBuilder/fastcover.rs
+++ b/lib/dictBuilder/fastcover.rs
@@ -394,7 +394,7 @@ fn FASTCOVER_buildDictionary<'a>(
 }
 
 unsafe fn FASTCOVER_tryParameters_wrapper(opaque: *mut core::ffi::c_void) {
-    FASTCOVER_tryParameters(unsafe { Box::from_raw(opaque.cast()) })
+    FASTCOVER_tryParameters(unsafe { Box::from_raw(opaque.cast()) });
 }
 
 fn FASTCOVER_tryParameters(data: Box<FASTCOVER_tryParameters_data_t>) {
@@ -870,7 +870,7 @@ fn optimize_train_from_buffer_fastcover(
                             pool,
                             FASTCOVER_tryParameters_wrapper,
                             Box::leak(data) as *mut _ as *mut core::ffi::c_void,
-                        )
+                        );
                     }
                 } else {
                     FASTCOVER_tryParameters(data);

--- a/lib/dictBuilder/zdict.rs
+++ b/lib/dictBuilder/zdict.rs
@@ -82,7 +82,7 @@ fn ZDICT_printHex(bytes: &[u8]) {
             '.' // non-printable character
         }
     });
-    eprint!("{}", s.collect::<String>())
+    eprint!("{}", s.collect::<String>());
 }
 
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZDICT_isError))]
@@ -1241,7 +1241,7 @@ unsafe fn ZDICT_addEntropyTablesFromBuffer_advanced(
                 .byte_sub(dictContentSize),
             dictBuffer.byte_add(hSize),
             dictContentSize,
-        )
+        );
     }
     Ord::min(dictBufferCapacity, hSize.wrapping_add(dictContentSize))
 }

--- a/lib/legacy/zstd_v07.rs
+++ b/lib/legacy/zstd_v07.rs
@@ -1145,7 +1145,7 @@ fn HUFv07_readDTableX4(DTable: &mut HUFv07_DTable, src: &[u8]) -> Result<usize, 
     }
     let mut maxW = tableLog;
     while rankStats[maxW as usize] == 0 {
-        maxW -= 1
+        maxW -= 1;
     }
     let mut nextRankStart = 0u32;
     for w in 1..maxW + 1 {

--- a/lib/polyfill.rs
+++ b/lib/polyfill.rs
@@ -59,7 +59,7 @@ unsafe fn prefetch_read_data_internal<T, const LOCALITY: i32>(ptr: *const T) {
         }
         target_arch = "x86_64" => {
             use core::arch::x86_64;
-            x86_64::_mm_prefetch(ptr as *const i8, LOCALITY)
+            x86_64::_mm_prefetch(ptr as *const i8, LOCALITY);
         }
         target_arch = "x86" => {
             use core::arch::x86;


### PR DESCRIPTION
Fixed lints from clippy::semicolon_if_nothing_returned