### PR TITLE
Fix TRACE_enable panic on missing file to match C fopen append behavior

### DIFF
--- a/programs/zstdcli_trace.rs
+++ b/programs/zstdcli_trace.rs
@@ -24,6 +24,7 @@ pub unsafe fn TRACE_enable(filename: *const core::ffi::c_char) {
     assert!(traceFile.is_none());
     let traceFile = traceFile.insert(
         OpenOptions::new()
+            .create(true)
             .append(true)
             .open(CStr::from_ptr(filename).to_str().unwrap())
             .unwrap(),


### PR DESCRIPTION
# Description

Fixes https://github.com/trifectatechfoundation/libzstd-rs-sys/issues/312

## Changes
* **File Creation Parity**: Added `.create(true)` to `OpenOptions` in `programs/zstdcli_trace.rs`. This ensures that opening a trace log file with `--trace` automatically creates the file if it does not exist, matching C's `fopen(..., "a")` append behavior and resolving the runtime panic on fresh runs.

## Verification
Verified locally that running `zstdcli` on a fresh run successfully creates `trace.log`, writes the CSV header row, and captures compression metrics without panicking.

PR was supported by AI.