### PR TITLE
Add repository field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 [package]
 name = "libzstd-rs-sys"
 version = "0.0.1-prerelease.2"
+repository = "https://github.com/trifectatechfoundation/libzstd-rs-sys"
 description = "a rust implementation of zstd compression and decompression"
 license = "BSD-3-Clause"
 publish = true


### PR DESCRIPTION
The crates.io page doesn't link to the repository at the moment.