### PR TITLE
Add no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,16 +31,12 @@ name = "libzstd_rs_sys"
 path = "c2rust-lib.rs"
 crate-type = ["staticlib", "rlib"]
 
-[[bin]]
-name = "programs"
-path = "programs/main.rs"
-
 [profile.relwithdebinfo]
 inherits = "release"
 debug = true
 
 [dependencies]
-libc = "0.2"
+libc = { version = "0.2", optional = true }
 
 [target.'cfg(target_arch = "x86_64")'.build-dependencies]
 cc = "1.2.30"
@@ -54,7 +50,8 @@ version = "0.8.15"
 features = ["xxh64", "xxh32"]
 
 [features]
-default = ["rust-allocator"]
+default = ["rust-allocator", "std"]
+std = ["dep:libc"]
 export-symbols = [] # whether the zlib api symbols are publicly exported
 custom-prefix = ["export-symbols"] # use the LIBZSTD_RS_SYS_PREFIX to prefix all exported symbols
 semver-prefix = ["export-symbols"] # prefix all symbols in a semver-compatible way

--- a/c2rust-lib.rs
+++ b/c2rust-lib.rs
@@ -42,6 +42,7 @@
 #![cfg_attr(feature = "nightly", feature(hint_prefetch))]
 // FIXME
 #![allow(clippy::missing_safety_doc)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod lib {
     pub mod common {

--- a/lib/common/bitstream.rs
+++ b/lib/common/bitstream.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use libc::size_t;
+
 
 use crate::lib::common::error_private::Error;
 use crate::lib::common::mem::MEM_writeLEST;
@@ -22,8 +22,8 @@ pub(crate) struct BIT_CStream_t {
 pub(crate) unsafe fn BIT_initCStream(
     bitC: &mut BIT_CStream_t,
     startPtr: *mut core::ffi::c_void,
-    dstCapacity: size_t,
-) -> size_t {
+    dstCapacity: usize,
+) -> usize {
     bitC.bitContainer = 0;
     bitC.bitPos = 0;
     bitC.startPtr = startPtr as *mut core::ffi::c_char;
@@ -71,7 +71,7 @@ unsafe fn BIT_addBitsFast(
 
 #[inline]
 pub(crate) unsafe fn BIT_flushBits(bitC: &mut BIT_CStream_t) {
-    let nbBytes = (bitC.bitPos >> 3) as size_t;
+    let nbBytes = (bitC.bitPos >> 3) as usize;
     MEM_writeLEST(bitC.ptr as *mut core::ffi::c_void, bitC.bitContainer);
     bitC.ptr = bitC.ptr.add(nbBytes);
     if bitC.ptr > bitC.endPtr {
@@ -83,7 +83,7 @@ pub(crate) unsafe fn BIT_flushBits(bitC: &mut BIT_CStream_t) {
 
 #[inline]
 pub(crate) unsafe fn BIT_flushBitsFast(bitC: &mut BIT_CStream_t) {
-    let nbBytes = (bitC.bitPos >> 3) as size_t;
+    let nbBytes = (bitC.bitPos >> 3) as usize;
     MEM_writeLEST(bitC.ptr as *mut core::ffi::c_void, bitC.bitContainer);
     bitC.ptr = bitC.ptr.add(nbBytes);
     bitC.bitPos &= 7;
@@ -91,7 +91,7 @@ pub(crate) unsafe fn BIT_flushBitsFast(bitC: &mut BIT_CStream_t) {
 }
 
 #[inline]
-pub(crate) unsafe fn BIT_closeCStream(bitC: &mut BIT_CStream_t) -> size_t {
+pub(crate) unsafe fn BIT_closeCStream(bitC: &mut BIT_CStream_t) -> usize {
     BIT_addBitsFast(bitC, 1, 1);
     BIT_flushBits(bitC);
     if bitC.ptr >= bitC.endPtr {

--- a/lib/common/entropy_common.rs
+++ b/lib/common/entropy_common.rs
@@ -1,4 +1,4 @@
-use libc::size_t;
+
 
 use crate::lib::common::error_private::Error;
 use crate::lib::common::fse::{
@@ -16,7 +16,7 @@ fn FSE_readNCount_body(
     maxSVPtr: &mut core::ffi::c_uint,
     tableLogPtr: &mut core::ffi::c_uint,
     headerBuffer: &[u8],
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let hbSize = headerBuffer.len();
 
     let iend = hbSize;
@@ -173,7 +173,7 @@ fn FSE_readNCount_body_default(
     maxSVPtr: &mut core::ffi::c_uint,
     tableLogPtr: &mut core::ffi::c_uint,
     headerBuffer: &[u8],
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     FSE_readNCount_body(normalizedCounter, maxSVPtr, tableLogPtr, headerBuffer)
 }
 fn FSE_readNCount_body_bmi2(
@@ -181,7 +181,7 @@ fn FSE_readNCount_body_bmi2(
     maxSVPtr: &mut core::ffi::c_uint,
     tableLogPtr: &mut core::ffi::c_uint,
     headerBuffer: &[u8],
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     FSE_readNCount_body(normalizedCounter, maxSVPtr, tableLogPtr, headerBuffer)
 }
 
@@ -191,7 +191,7 @@ pub(super) fn FSE_readNCount_bmi2(
     tableLogPtr: &mut core::ffi::c_uint,
     headerBuffer: &[u8],
     bmi2: core::ffi::c_int,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     if bmi2 != 0 {
         FSE_readNCount_body_bmi2(normalizedCounter, maxSVPtr, tableLogPtr, headerBuffer)
     } else {
@@ -204,8 +204,8 @@ pub(crate) unsafe fn FSE_readNCount(
     maxSVPtr: &mut core::ffi::c_uint,
     tableLogPtr: &mut core::ffi::c_uint,
     headerBuffer: *const core::ffi::c_void,
-    hbSize: size_t,
-) -> size_t {
+    hbSize: usize,
+) -> usize {
     let ret = FSE_readNCount_slice(
         normalizedCounter,
         maxSVPtr,
@@ -224,18 +224,18 @@ pub(crate) fn FSE_readNCount_slice(
     maxSVPtr: &mut core::ffi::c_uint,
     tableLogPtr: &mut core::ffi::c_uint,
     headerBuffer: &[u8],
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     FSE_readNCount_bmi2(normalizedCounter, maxSVPtr, tableLogPtr, headerBuffer, 0)
 }
 
 pub(crate) fn HUF_readStats(
     huffWeight: &mut [u8; 256],
-    hwSize: size_t,
+    hwSize: usize,
     rankStats: &mut [u32; 13],
     nbSymbolsPtr: &mut u32,
     tableLogPtr: &mut u32,
     src: &[u8],
-) -> size_t {
+) -> usize {
     // We can remove this at some point, it's just a check that the constants are correct.
     const _: () = assert!(HUF_READ_STATS_WORKSPACE_SIZE_U32 == 219);
 
@@ -257,19 +257,19 @@ pub(crate) fn HUF_readStats(
 #[inline(always)]
 fn HUF_readStats_body(
     huffWeight: &mut [u8; 256],
-    hwSize: size_t,
+    hwSize: usize,
     rankStats: &mut [u32; 13],
     nbSymbolsPtr: &mut u32,
     tableLogPtr: &mut u32,
     mut ip: &[u8],
     workspace: &mut Workspace,
     bmi2: bool,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let srcSize = ip.len();
 
     let mut weightTotal: u32 = 0;
-    let mut iSize: size_t = 0;
-    let mut oSize: size_t = 0;
+    let mut iSize: usize = 0;
+    let mut oSize: usize = 0;
     if srcSize == 0 {
         return Err(Error::srcSize_wrong);
     }
@@ -465,14 +465,14 @@ impl quickcheck::Arbitrary for DTable {
 
 pub(crate) fn HUF_readStats_wksp(
     huffWeight: &mut [u8; 256],
-    hwSize: size_t,
+    hwSize: usize,
     rankStats: &mut [u32; 13],
     nbSymbolsPtr: &mut u32,
     tableLogPtr: &mut u32,
     src: &[u8],
     workspace: &mut Workspace,
     flags: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let use_bmi2 = flags & HUF_flags_bmi2 as core::ffi::c_int != 0;
 
     let ret = HUF_readStats_body(
@@ -565,7 +565,7 @@ mod tests {
                     extern "C" {
                         fn HUF_readStats_wksp(
                             huffWeight: &mut [u8; 256],
-                            hwSize: size_t,
+                            hwSize: usize,
                             rankStats: &mut [u32; 13],
                             nbSymbolsPtr: &mut u32,
                             tableLogPtr: &mut u32,
@@ -574,7 +574,7 @@ mod tests {
                             workspace: &mut [u32; 219],
                             workspace_size: usize,
                             flags: core::ffi::c_int,
-                        ) -> size_t;
+                        ) -> usize;
                     }
 
                     let v = HUF_readStats_wksp(

--- a/lib/common/error_private.rs
+++ b/lib/common/error_private.rs
@@ -1,6 +1,6 @@
 use core::ffi::c_char;
 
-use libc::size_t;
+
 
 use crate::lib::zstd::{ZSTD_ErrorCode, ZSTD_error_maxCode};
 
@@ -45,12 +45,12 @@ pub enum Error {
 }
 
 impl Error {
-    pub fn to_error_code(self) -> size_t {
-        -(self as core::ffi::c_int) as size_t
+    pub fn to_error_code(self) -> usize {
+        -(self as core::ffi::c_int) as usize
     }
 
     #[allow(unused)]
-    pub fn from_error_code(code: size_t) -> Option<Self> {
+    pub fn from_error_code(code: usize) -> Option<Self> {
         if !ERR_isError(code) {
             return None;
         }
@@ -108,11 +108,11 @@ impl TryFrom<u32> for Error {
 
 type ERR_enum = ZSTD_ErrorCode;
 
-pub(crate) const fn ERR_isError(code: size_t) -> bool {
-    code > -(ZSTD_error_maxCode as core::ffi::c_int) as size_t
+pub(crate) const fn ERR_isError(code: usize) -> bool {
+    code > -(ZSTD_error_maxCode as core::ffi::c_int) as usize
 }
 
-pub(crate) const fn ERR_getErrorCode(code: size_t) -> ZSTD_ErrorCode {
+pub(crate) const fn ERR_getErrorCode(code: usize) -> ZSTD_ErrorCode {
     if !ERR_isError(code) {
         return 0;
     }
@@ -178,6 +178,6 @@ pub(crate) fn ERR_getErrorString(code: ERR_enum) -> *const c_char {
     }
 }
 
-pub(crate) fn ERR_getErrorName(code: size_t) -> *const core::ffi::c_char {
+pub(crate) fn ERR_getErrorName(code: usize) -> *const core::ffi::c_char {
     ERR_getErrorString(ERR_getErrorCode(code))
 }

--- a/lib/common/fse_decompress.rs
+++ b/lib/common/fse_decompress.rs
@@ -1,4 +1,4 @@
-use libc::size_t;
+
 
 use crate::lib::common::fse::{
     FSE_DTableHeader, FSE_decode_t, FSE_MAX_SYMBOL_VALUE, FSE_MAX_TABLELOG,
@@ -128,12 +128,12 @@ fn FSE_buildDTable_internal(
     *header = DTableH;
 
     if highThreshold == tableSize.wrapping_sub(1) {
-        let tableMask = tableSize.wrapping_sub(1) as size_t;
+        let tableMask = tableSize.wrapping_sub(1) as usize;
         let step = (tableSize >> 1)
             .wrapping_add(tableSize >> 3)
-            .wrapping_add(3) as size_t;
+            .wrapping_add(3) as usize;
         let add = 0x101010101010101u64;
-        let mut pos = 0 as size_t;
+        let mut pos = 0 as usize;
         let mut sv = 0u64;
 
         for s_0 in 0..maxSV1 {
@@ -145,16 +145,16 @@ fn FSE_buildDTable_internal(
                 spread[pos as usize..][i as usize..][..8].copy_from_slice(&sv.to_le_bytes());
                 i += 8;
             }
-            pos = pos.wrapping_add(n as size_t);
+            pos = pos.wrapping_add(n as usize);
             sv = sv.wrapping_add(add);
         }
 
-        let mut position = 0 as size_t;
-        let mut s_1: size_t = 0;
+        let mut position = 0 as usize;
+        let mut s_1: usize = 0;
         let unroll = 2;
         s_1 = 0;
-        while s_1 < tableSize as size_t {
-            let mut u: size_t = 0;
+        while s_1 < tableSize as usize {
+            let mut u: usize = 0;
             u = 0;
             while u < unroll {
                 let uPosition = position.wrapping_add(u * step) & tableMask;
@@ -324,7 +324,7 @@ fn FSE_decompress_wksp_body(
     maxLog: core::ffi::c_uint,
     workspace: &mut Workspace,
     bmi2: core::ffi::c_int,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let mut wkspSize = size_of::<Workspace>();
 
     let mut tableLog: core::ffi::c_uint = 0;
@@ -395,7 +395,7 @@ fn FSE_decompress_wksp_body_default(
     cSrc: &[u8],
     maxLog: core::ffi::c_uint,
     workSpace: &mut Workspace,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     FSE_decompress_wksp_body(dst, cSrc, maxLog, workSpace, 0)
 }
 
@@ -404,7 +404,7 @@ fn FSE_decompress_wksp_body_bmi2(
     cSrc: &[u8],
     maxLog: core::ffi::c_uint,
     workSpace: &mut Workspace,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     FSE_decompress_wksp_body(dst, cSrc, maxLog, workSpace, 1)
 }
 
@@ -414,7 +414,7 @@ pub(super) fn FSE_decompress_wksp_bmi2(
     maxLog: core::ffi::c_uint,
     workSpace: &mut Workspace,
     bmi2: bool,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     if bmi2 {
         FSE_decompress_wksp_body_bmi2(dst, cSrc, maxLog, workSpace)
     } else {

--- a/lib/common/huf.rs
+++ b/lib/common/huf.rs
@@ -1,4 +1,4 @@
-use libc::size_t;
+
 
 use crate::lib::common::fse::FSE_DECOMPRESS_WKSP_SIZE_U32;
 use crate::lib::zstd::ZSTD_btultra;
@@ -28,14 +28,14 @@ const _: () = assert!(
 
 pub(crate) const HUF_CTABLEBOUND: usize = 129;
 
-pub(crate) type HUF_CElt = size_t;
+pub(crate) type HUF_CElt = usize;
 
 pub(crate) const fn HUF_CTABLE_SIZE_ST(maxSymbolValue: usize) -> usize {
-    (maxSymbolValue) + 2 /* Use tables of size_t, for proper alignment */
+    (maxSymbolValue) + 2 /* Use tables of usize, for proper alignment */
 }
 
 pub const fn HUF_CTABLE_SIZE(maxSymbolValue: usize) -> usize {
-    HUF_CTABLE_SIZE_ST(maxSymbolValue) * size_of::<size_t>()
+    HUF_CTABLE_SIZE_ST(maxSymbolValue) * size_of::<usize>()
 }
 
 pub(crate) const HUF_flags_bmi2: core::ffi::c_uint = 1;

--- a/lib/common/mem.rs
+++ b/lib/common/mem.rs
@@ -1,6 +1,6 @@
 use core::ffi::c_void;
 
-use libc::size_t;
+
 
 #[inline]
 pub(crate) const fn MEM_32bits() -> bool {
@@ -24,7 +24,7 @@ pub(crate) unsafe fn MEM_read64(ptr: *const c_void) -> u64 {
     ptr.cast::<u64>().read_unaligned()
 }
 #[inline]
-pub(crate) unsafe fn MEM_readST(ptr: *const c_void) -> size_t {
+pub(crate) unsafe fn MEM_readST(ptr: *const c_void) -> usize {
     ptr.cast::<usize>().read_unaligned()
 }
 
@@ -83,17 +83,17 @@ pub(crate) unsafe fn MEM_writeLE64(memPtr: *mut c_void, val64: u64) {
 }
 
 #[inline]
-pub(crate) unsafe fn MEM_readLEST(memPtr: *const c_void) -> size_t {
-    match size_of::<size_t>() {
-        4 => MEM_readLE32(memPtr) as size_t,
-        8 => MEM_readLE64(memPtr) as size_t,
+pub(crate) unsafe fn MEM_readLEST(memPtr: *const c_void) -> usize {
+    match size_of::<usize>() {
+        4 => MEM_readLE32(memPtr) as usize,
+        8 => MEM_readLE64(memPtr) as usize,
         _ => unreachable!(),
     }
 }
 
 #[inline]
-pub(crate) unsafe fn MEM_writeLEST(memPtr: *mut c_void, val: size_t) {
-    match size_of::<size_t>() {
+pub(crate) unsafe fn MEM_writeLEST(memPtr: *mut c_void, val: usize) {
+    match size_of::<usize>() {
         4 => MEM_writeLE32(memPtr, val as u32),
         8 => MEM_writeLE64(memPtr, val as u64),
         _ => unreachable!(),
@@ -101,5 +101,5 @@ pub(crate) unsafe fn MEM_writeLEST(memPtr: *mut c_void, val: size_t) {
 }
 
 const _: () = {
-    assert!(size_of::<size_t>() == 4 || size_of::<size_t>() == 8);
+    assert!(size_of::<usize>() == 4 || size_of::<usize>() == 8);
 };

--- a/lib/common/pool.rs
+++ b/lib/common/pool.rs
@@ -2,7 +2,7 @@ use core::ptr;
 use std::sync::{Condvar, Mutex};
 use std::thread::JoinHandle;
 
-use libc::size_t;
+
 
 use crate::lib::common::allocations::{ZSTD_customCalloc, ZSTD_customFree};
 use crate::lib::zstd::ZSTD_customMem;
@@ -10,13 +10,13 @@ use crate::lib::zstd::ZSTD_customMem;
 pub struct POOL_ctx {
     customMem: ZSTD_customMem,
     threads: *mut JoinHandle<()>,
-    threadCapacity: size_t,
-    threadLimit: size_t,
+    threadCapacity: usize,
+    threadLimit: usize,
     queue: *mut POOL_job,
-    queueHead: size_t,
-    queueTail: size_t,
-    queueSize: size_t,
-    numThreadsBusy: size_t,
+    queueHead: usize,
+    queueTail: usize,
+    queueSize: usize,
+    numThreadsBusy: usize,
     queueEmpty: core::ffi::c_int,
     queueMutex: Mutex<()>,
     queuePushCond: Condvar,
@@ -62,15 +62,15 @@ unsafe fn POOL_thread(ctx: *mut POOL_ctx) {
     }
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_createThreadPool))]
-pub unsafe extern "C" fn ZSTD_createThreadPool(numThreads: size_t) -> *mut ZSTD_threadPool {
+pub unsafe extern "C" fn ZSTD_createThreadPool(numThreads: usize) -> *mut ZSTD_threadPool {
     POOL_create(numThreads, 0)
 }
-pub unsafe fn POOL_create(numThreads: size_t, queueSize: size_t) -> *mut POOL_ctx {
+pub unsafe fn POOL_create(numThreads: usize, queueSize: usize) -> *mut POOL_ctx {
     POOL_create_advanced(numThreads, queueSize, ZSTD_customMem::default())
 }
 pub(crate) unsafe fn POOL_create_advanced(
-    numThreads: size_t,
-    queueSize: size_t,
+    numThreads: usize,
+    queueSize: usize,
     customMem: ZSTD_customMem,
 ) -> *mut POOL_ctx {
     let mut ctx = core::ptr::null_mut::<POOL_ctx>();
@@ -163,7 +163,7 @@ pub unsafe fn POOL_joinJobs(ctx: *mut POOL_ctx) {
 pub unsafe extern "C" fn ZSTD_freeThreadPool(pool: *mut ZSTD_threadPool) {
     POOL_free(pool);
 }
-pub(crate) unsafe fn POOL_sizeof(ctx: *const POOL_ctx) -> size_t {
+pub(crate) unsafe fn POOL_sizeof(ctx: *const POOL_ctx) -> usize {
     if ctx.is_null() {
         return 0;
     }
@@ -171,7 +171,7 @@ pub(crate) unsafe fn POOL_sizeof(ctx: *const POOL_ctx) -> size_t {
         + (*ctx).queueSize * ::core::mem::size_of::<POOL_job>()
         + (*ctx).threadCapacity * ::core::mem::size_of::<JoinHandle<()>>()
 }
-unsafe fn POOL_resize_internal(ctx: *mut POOL_ctx, numThreads: size_t) -> core::ffi::c_int {
+unsafe fn POOL_resize_internal(ctx: *mut POOL_ctx, numThreads: usize) -> core::ffi::c_int {
     if numThreads <= (*ctx).threadCapacity {
         if numThreads == 0 {
             return 1;
@@ -211,7 +211,7 @@ unsafe fn POOL_resize_internal(ctx: *mut POOL_ctx, numThreads: size_t) -> core::
     (*ctx).threadLimit = numThreads;
     0
 }
-pub(crate) unsafe fn POOL_resize(ctx: *mut POOL_ctx, numThreads: size_t) -> core::ffi::c_int {
+pub(crate) unsafe fn POOL_resize(ctx: *mut POOL_ctx, numThreads: usize) -> core::ffi::c_int {
     if ctx.is_null() {
         return 1;
     }

--- a/lib/common/zstd_common.rs
+++ b/lib/common/zstd_common.rs
@@ -1,4 +1,4 @@
-use libc::size_t;
+
 
 use crate::lib::common::error_private::{
     ERR_getErrorCode, ERR_getErrorName, ERR_getErrorString, ERR_isError,
@@ -25,32 +25,32 @@ pub const extern "C" fn ZSTD_versionString() -> *const core::ffi::c_char {
     c"1.5.8".as_ptr()
 }
 
-/// Most functions returning a `size_t` value can be tested for errors, using [`ZSTD_isError`].
+/// Most functions returning a `usize` value can be tested for errors, using [`ZSTD_isError`].
 ///
 /// # Returns
 ///
 /// - 1 if the provided code is an error
 /// - 0 otherwise
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_isError))]
-pub const extern "C" fn ZSTD_isError(code: size_t) -> core::ffi::c_uint {
+pub const extern "C" fn ZSTD_isError(code: usize) -> core::ffi::c_uint {
     ERR_isError(code) as _
 }
 
 /// Provides a readable error string from a function result
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_getErrorName))]
-pub extern "C" fn ZSTD_getErrorName(code: size_t) -> *const core::ffi::c_char {
+pub extern "C" fn ZSTD_getErrorName(code: usize) -> *const core::ffi::c_char {
     ERR_getErrorName(code)
 }
 
 /// Convert a result into an error code, which can be compared to the errors enum list
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_getErrorCode))]
-pub extern "C" fn ZSTD_getErrorCode(code: size_t) -> ZSTD_ErrorCode {
+pub extern "C" fn ZSTD_getErrorCode(code: usize) -> ZSTD_ErrorCode {
     ERR_getErrorCode(code)
 }
 
 /// Provides a readable error string from an error code
 ///
-/// Unlike [`ZSTD_getErrorName`], this method should not be used on `size_t` function results
+/// Unlike [`ZSTD_getErrorName`], this method should not be used on `usize` function results
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_getErrorString))]
 pub extern "C" fn ZSTD_getErrorString(code: ZSTD_ErrorCode) -> *const core::ffi::c_char {
     ERR_getErrorString(code)

--- a/lib/common/zstd_internal.rs
+++ b/lib/common/zstd_internal.rs
@@ -1,6 +1,6 @@
 use core::mem::MaybeUninit;
 
-use libc::size_t;
+
 
 const fn const_max(a: usize, b: usize) -> usize {
     if a > b {
@@ -18,7 +18,7 @@ pub(crate) static repStartValue: [u32; ZSTD_REP_NUM as usize] = [1, 4, 8];
 pub(crate) const ZSTD_FRAMEIDSIZE: usize = 4;
 
 const ZSTD_BLOCKHEADERSIZE: core::ffi::c_int = 3;
-pub(crate) static ZSTD_blockHeaderSize: size_t = ZSTD_BLOCKHEADERSIZE as size_t;
+pub(crate) static ZSTD_blockHeaderSize: usize = ZSTD_BLOCKHEADERSIZE as usize;
 pub(crate) type blockType_e = core::ffi::c_uint;
 pub(crate) const bt_raw: blockType_e = 0;
 pub(crate) const bt_rle: blockType_e = 1;
@@ -113,7 +113,7 @@ pub(crate) enum Overlap {
 pub(crate) unsafe fn ZSTD_wildcopy(
     mut op: *mut u8,
     mut ip: *const u8,
-    length: size_t,
+    length: usize,
     ovtype: Overlap,
 ) {
     let diff = op as isize - ip as isize;
@@ -172,10 +172,10 @@ pub(crate) unsafe fn ZSTD_wildcopy(
 #[inline]
 pub(crate) unsafe fn ZSTD_limitCopy(
     dst: *mut u8,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const u8,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let length = Ord::min(dstCapacity, srcSize);
     core::ptr::copy_nonoverlapping(src, dst, length);
     length

--- a/lib/common/zstd_trace.rs
+++ b/lib/common/zstd_trace.rs
@@ -1,4 +1,4 @@
-use libc::size_t;
+
 
 use crate::lib::compress::zstd_compress::{ZSTD_CCtx, ZSTD_CCtx_params_s, ZSTD_CCtx_s};
 use crate::lib::decompress::{ZSTD_DCtx, ZSTD_DCtx_s};
@@ -11,9 +11,9 @@ pub struct ZSTD_Trace {
     pub dictionaryID: core::ffi::c_uint,
     pub dictionaryIsCold: bool,
     _padding: [u8; 3],
-    pub dictionarySize: size_t,
-    pub uncompressedSize: size_t,
-    pub compressedSize: size_t,
+    pub dictionarySize: usize,
+    pub uncompressedSize: usize,
+    pub compressedSize: usize,
     pub params: *const ZSTD_CCtx_params_s,
     pub cctx: *const ZSTD_CCtx_s,
     pub dctx: *const ZSTD_DCtx_s,

--- a/lib/compress/fse_compress.rs
+++ b/lib/compress/fse_compress.rs
@@ -1,4 +1,4 @@
-use libc::{ptrdiff_t, size_t};
+use libc::ptrdiff_t;
 
 use crate::lib::common::bits::ZSTD_highbit32;
 use crate::lib::common::bitstream::{
@@ -55,8 +55,8 @@ pub(crate) unsafe fn FSE_buildCTable_wksp(
     maxSymbolValue: core::ffi::c_uint,
     tableLog: core::ffi::c_uint,
     workSpace: *mut core::ffi::c_void,
-    wkspSize: size_t,
-) -> size_t {
+    wkspSize: usize,
+) -> usize {
     let tableSize = ((1) << tableLog) as u32;
     let tableMask = tableSize.wrapping_sub(1);
     let ptr = ct as *mut core::ffi::c_void;
@@ -112,7 +112,7 @@ pub(crate) unsafe fn FSE_buildCTable_wksp(
     if highThreshold == tableSize.wrapping_sub(1) {
         let spread = tableSymbol.offset(tableSize as isize);
         let add = 0x101010101010101u64;
-        let mut pos = 0 as size_t;
+        let mut pos = 0 as usize;
         let mut sv = 0u64;
         let mut s: u32 = 0;
         s = 0;
@@ -128,23 +128,23 @@ pub(crate) unsafe fn FSE_buildCTable_wksp(
                 );
                 i += 8;
             }
-            pos = pos.wrapping_add(n as size_t);
+            pos = pos.wrapping_add(n as usize);
             s = s.wrapping_add(1);
             sv = sv.wrapping_add(add);
         }
-        let mut position = 0 as size_t;
-        let mut s_0: size_t = 0;
+        let mut position = 0 as usize;
+        let mut s_0: usize = 0;
         let unroll = 2;
         s_0 = 0;
-        while s_0 < tableSize as size_t {
-            let mut u_0: size_t = 0;
+        while s_0 < tableSize as usize {
+            let mut u_0: usize = 0;
             u_0 = 0;
             while u_0 < unroll {
-                let uPosition = position.wrapping_add(u_0 * step as size_t) & tableMask as size_t;
+                let uPosition = position.wrapping_add(u_0 * step as usize) & tableMask as usize;
                 *tableSymbol.add(uPosition) = *spread.add(s_0.wrapping_add(u_0));
                 u_0 = u_0.wrapping_add(1);
             }
-            position = position.wrapping_add(unroll * step as size_t) & tableMask as size_t;
+            position = position.wrapping_add(unroll * step as usize) & tableMask as usize;
             s_0 = s_0.wrapping_add(unroll);
         }
     } else {
@@ -213,7 +213,7 @@ pub(crate) unsafe fn FSE_buildCTable_wksp(
 unsafe fn FSE_NCountWriteBound(
     maxSymbolValue: core::ffi::c_uint,
     tableLog: core::ffi::c_uint,
-) -> size_t {
+) -> usize {
     let maxHeaderSize = maxSymbolValue
         .wrapping_add(1)
         .wrapping_mul(tableLog)
@@ -221,21 +221,21 @@ unsafe fn FSE_NCountWriteBound(
         .wrapping_add(2)
         .wrapping_div(8)
         .wrapping_add(1)
-        .wrapping_add(2) as size_t;
+        .wrapping_add(2) as usize;
     if maxSymbolValue != 0 {
         maxHeaderSize
     } else {
-        FSE_NCOUNTBOUND as size_t
+        FSE_NCOUNTBOUND as usize
     }
 }
 unsafe fn FSE_writeNCount_generic(
     header: *mut core::ffi::c_void,
-    headerBufferSize: size_t,
+    headerBufferSize: usize,
     normalizedCounter: *const core::ffi::c_short,
     maxSymbolValue: core::ffi::c_uint,
     tableLog: core::ffi::c_uint,
     writeIsSafe: core::ffi::c_uint,
-) -> size_t {
+) -> usize {
     let ostart = header as *mut u8;
     let mut out = ostart;
     let oend = ostart.add(headerBufferSize);
@@ -338,11 +338,11 @@ unsafe fn FSE_writeNCount_generic(
 }
 pub(crate) unsafe fn FSE_writeNCount(
     buffer: *mut core::ffi::c_void,
-    bufferSize: size_t,
+    bufferSize: usize,
     normalizedCounter: *const core::ffi::c_short,
     maxSymbolValue: core::ffi::c_uint,
     tableLog: core::ffi::c_uint,
-) -> size_t {
+) -> usize {
     if tableLog > FSE_MAX_TABLELOG as core::ffi::c_uint {
         return Error::tableLog_tooLarge.to_error_code();
     }
@@ -368,7 +368,7 @@ pub(crate) unsafe fn FSE_writeNCount(
         1,
     )
 }
-unsafe fn FSE_minTableLog(srcSize: size_t, maxSymbolValue: core::ffi::c_uint) -> core::ffi::c_uint {
+unsafe fn FSE_minTableLog(srcSize: usize, maxSymbolValue: core::ffi::c_uint) -> core::ffi::c_uint {
     let minBitsSrc = (ZSTD_highbit32(srcSize as u32)).wrapping_add(1);
     let minBitsSymbols = (ZSTD_highbit32(maxSymbolValue)).wrapping_add(2);
     if minBitsSrc < minBitsSymbols {
@@ -379,7 +379,7 @@ unsafe fn FSE_minTableLog(srcSize: size_t, maxSymbolValue: core::ffi::c_uint) ->
 }
 pub(crate) unsafe fn FSE_optimalTableLog_internal(
     maxTableLog: core::ffi::c_uint,
-    srcSize: size_t,
+    srcSize: usize,
     maxSymbolValue: core::ffi::c_uint,
     minus: core::ffi::c_uint,
 ) -> core::ffi::c_uint {
@@ -405,7 +405,7 @@ pub(crate) unsafe fn FSE_optimalTableLog_internal(
 }
 pub(crate) unsafe fn FSE_optimalTableLog(
     maxTableLog: core::ffi::c_uint,
-    srcSize: size_t,
+    srcSize: usize,
     maxSymbolValue: core::ffi::c_uint,
 ) -> core::ffi::c_uint {
     FSE_optimalTableLog_internal(maxTableLog, srcSize, maxSymbolValue, 2)
@@ -414,10 +414,10 @@ unsafe fn FSE_normalizeM2(
     norm: *mut core::ffi::c_short,
     tableLog: u32,
     count: *const core::ffi::c_uint,
-    mut total: size_t,
+    mut total: usize,
     maxSymbolValue: u32,
     lowProbCount: core::ffi::c_short,
-) -> size_t {
+) -> usize {
     let NOT_YET_ASSIGNED = -(2) as core::ffi::c_short;
     let mut s: u32 = 0;
     let mut distributed = 0u32;
@@ -431,11 +431,11 @@ unsafe fn FSE_normalizeM2(
         } else if *count.offset(s as isize) <= lowThreshold {
             *norm.offset(s as isize) = lowProbCount;
             distributed = distributed.wrapping_add(1);
-            total = total.wrapping_sub(*count.offset(s as isize) as size_t);
+            total = total.wrapping_sub(*count.offset(s as isize) as usize);
         } else if *count.offset(s as isize) <= lowOne {
             *norm.offset(s as isize) = 1;
             distributed = distributed.wrapping_add(1);
-            total = total.wrapping_sub(*count.offset(s as isize) as size_t);
+            total = total.wrapping_sub(*count.offset(s as isize) as usize);
         } else {
             *norm.offset(s as isize) = NOT_YET_ASSIGNED;
         }
@@ -445,8 +445,8 @@ unsafe fn FSE_normalizeM2(
     if ToDistribute == 0 {
         return 0;
     }
-    if total / ToDistribute as size_t > lowOne as size_t {
-        lowOne = (total * 3 / (ToDistribute * 2) as size_t) as u32;
+    if total / ToDistribute as usize > lowOne as usize {
+        lowOne = (total * 3 / (ToDistribute * 2) as usize) as u32;
         s = 0;
         while s <= maxSymbolValue {
             if *norm.offset(s as isize) as core::ffi::c_int == NOT_YET_ASSIGNED as core::ffi::c_int
@@ -454,7 +454,7 @@ unsafe fn FSE_normalizeM2(
             {
                 *norm.offset(s as isize) = 1;
                 distributed = distributed.wrapping_add(1);
-                total = total.wrapping_sub(*count.offset(s as isize) as size_t);
+                total = total.wrapping_sub(*count.offset(s as isize) as usize);
             }
             s = s.wrapping_add(1);
         }
@@ -514,10 +514,10 @@ pub(crate) unsafe fn FSE_normalizeCount(
     normalizedCounter: *mut core::ffi::c_short,
     mut tableLog: core::ffi::c_uint,
     count: *const core::ffi::c_uint,
-    total: size_t,
+    total: usize,
     maxSymbolValue: core::ffi::c_uint,
     useLowProbCount: core::ffi::c_uint,
-) -> size_t {
+) -> usize {
     if tableLog == 0 {
         tableLog = FSE_DEFAULT_TABLELOG as core::ffi::c_uint;
     }
@@ -542,7 +542,7 @@ pub(crate) unsafe fn FSE_normalizeCount(
     let lowThreshold = (total >> tableLog) as u32;
     s = 0;
     while s <= maxSymbolValue {
-        if *count.offset(s as isize) as size_t == total {
+        if *count.offset(s as isize) as usize == total {
             return 0;
         }
         if *count.offset(s as isize) == 0 {
@@ -588,9 +588,9 @@ pub(crate) unsafe fn FSE_normalizeCount(
             + stillToDistribute as core::ffi::c_short as core::ffi::c_int)
             as core::ffi::c_short;
     }
-    tableLog as size_t
+    tableLog as usize
 }
-pub(crate) unsafe fn FSE_buildCTable_rle(ct: *mut FSE_CTable, symbolValue: u8) -> size_t {
+pub(crate) unsafe fn FSE_buildCTable_rle(ct: *mut FSE_CTable, symbolValue: u8) -> usize {
     let ptr = ct as *mut core::ffi::c_void;
     let tableU16 = (ptr as *mut u16).add(2);
     let FSCTptr = (ptr as *mut u32).add(2) as *mut core::ffi::c_void;
@@ -605,12 +605,12 @@ pub(crate) unsafe fn FSE_buildCTable_rle(ct: *mut FSE_CTable, symbolValue: u8) -
 }
 unsafe fn FSE_compress_usingCTable_generic(
     dst: *mut core::ffi::c_void,
-    dstSize: size_t,
+    dstSize: usize,
     src: *const core::ffi::c_void,
-    mut srcSize: size_t,
+    mut srcSize: usize,
     ct: *const FSE_CTable,
     fast: core::ffi::c_uint,
-) -> size_t {
+) -> usize {
     let istart = src as *const u8;
     let iend = istart.add(srcSize);
     let mut ip = iend;
@@ -707,16 +707,16 @@ unsafe fn FSE_compress_usingCTable_generic(
 }
 pub(crate) unsafe fn FSE_compress_usingCTable(
     dst: *mut core::ffi::c_void,
-    dstSize: size_t,
+    dstSize: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     ct: *const FSE_CTable,
-) -> size_t {
+) -> usize {
     let fast = (dstSize
         >= srcSize
             .wrapping_add(srcSize >> 7)
             .wrapping_add(4)
-            .wrapping_add(::core::mem::size_of::<size_t>())) as core::ffi::c_int
+            .wrapping_add(::core::mem::size_of::<usize>())) as core::ffi::c_int
         as core::ffi::c_uint;
     if fast != 0 {
         FSE_compress_usingCTable_generic(dst, dstSize, src, srcSize, ct, 1)

--- a/lib/compress/hist.rs
+++ b/lib/compress/hist.rs
@@ -3,21 +3,21 @@ pub const checkMaxSymbolValue: HIST_checkInput_e = 1;
 pub const trustInput: HIST_checkInput_e = 0;
 use core::ptr;
 
-use libc::size_t;
+
 
 use crate::lib::common::error_private::{ERR_isError, Error};
 use crate::lib::common::mem::MEM_read32;
 pub const HIST_WKSP_SIZE_U32: core::ffi::c_int = 1024;
-pub const HIST_WKSP_SIZE: size_t =
-    (HIST_WKSP_SIZE_U32 as size_t).wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>());
+pub const HIST_WKSP_SIZE: usize =
+    (HIST_WKSP_SIZE_U32 as usize).wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>());
 pub const HIST_FAST_THRESHOLD: core::ffi::c_int = 1500;
-pub unsafe fn HIST_isError(code: size_t) -> core::ffi::c_uint {
+pub unsafe fn HIST_isError(code: usize) -> core::ffi::c_uint {
     ERR_isError(code) as _
 }
 pub unsafe fn HIST_add(
     count: *mut core::ffi::c_uint,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
 ) {
     let mut ip = src as *const u8;
     let end = ip.add(srcSize);
@@ -32,7 +32,7 @@ pub unsafe fn HIST_count_simple(
     count: *mut core::ffi::c_uint,
     maxSymbolValuePtr: *mut core::ffi::c_uint,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
 ) -> core::ffi::c_uint {
     let mut ip = src as *const u8;
     let end = ip.add(srcSize);
@@ -43,7 +43,7 @@ pub unsafe fn HIST_count_simple(
         0,
         (maxSymbolValue.wrapping_add(1) as core::ffi::c_ulong)
             .wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>() as core::ffi::c_ulong)
-            as libc::size_t,
+            as usize,
     );
     if srcSize == 0 {
         *maxSymbolValuePtr = 0;
@@ -73,10 +73,10 @@ unsafe fn HIST_count_parallel_wksp(
     count: *mut core::ffi::c_uint,
     maxSymbolValuePtr: *mut core::ffi::c_uint,
     source: *const core::ffi::c_void,
-    sourceSize: size_t,
+    sourceSize: usize,
     check: HIST_checkInput_e,
     workSpace: *mut u32,
-) -> size_t {
+) -> usize {
     let mut ip = source as *const u8;
     let iend = ip.add(sourceSize);
     let countSize = ((*maxSymbolValuePtr).wrapping_add(1) as core::ffi::c_ulong)
@@ -87,7 +87,7 @@ unsafe fn HIST_count_parallel_wksp(
     let Counting3 = Counting2.add(256);
     let Counting4 = Counting3.add(256);
     if sourceSize == 0 {
-        ptr::write_bytes(count as *mut u8, 0, countSize as libc::size_t);
+        ptr::write_bytes(count as *mut u8, 0, countSize as usize);
         *maxSymbolValuePtr = 0;
         return 0;
     }
@@ -96,7 +96,7 @@ unsafe fn HIST_count_parallel_wksp(
         0,
         ((4 * 256) as core::ffi::c_ulong)
             .wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>() as core::ffi::c_ulong)
-            as libc::size_t,
+            as usize,
     );
     let mut cached = MEM_read32(ip as *const core::ffi::c_void);
     ip = ip.add(4);
@@ -176,20 +176,20 @@ unsafe fn HIST_count_parallel_wksp(
     }
     *maxSymbolValuePtr = maxSymbolValue;
     core::ptr::copy(Counting1 as *const u8, count as *mut u8, countSize as usize);
-    max as size_t
+    max as usize
 }
 pub unsafe fn HIST_countFast_wksp(
     count: *mut core::ffi::c_uint,
     maxSymbolValuePtr: *mut core::ffi::c_uint,
     source: *const core::ffi::c_void,
-    sourceSize: size_t,
+    sourceSize: usize,
     workSpace: *mut core::ffi::c_void,
-    workSpaceSize: size_t,
-) -> size_t {
-    if sourceSize < HIST_FAST_THRESHOLD as size_t {
-        return HIST_count_simple(count, maxSymbolValuePtr, source, sourceSize) as size_t;
+    workSpaceSize: usize,
+) -> usize {
+    if sourceSize < HIST_FAST_THRESHOLD as usize {
+        return HIST_count_simple(count, maxSymbolValuePtr, source, sourceSize) as usize;
     }
-    if workSpace as size_t & 3 != 0 {
+    if workSpace as usize & 3 != 0 {
         return Error::GENERIC.to_error_code();
     }
     if workSpaceSize < HIST_WKSP_SIZE {
@@ -208,11 +208,11 @@ pub unsafe fn HIST_count_wksp(
     count: *mut core::ffi::c_uint,
     maxSymbolValuePtr: *mut core::ffi::c_uint,
     source: *const core::ffi::c_void,
-    sourceSize: size_t,
+    sourceSize: usize,
     workSpace: *mut core::ffi::c_void,
-    workSpaceSize: size_t,
-) -> size_t {
-    if workSpace as size_t & 3 != 0 {
+    workSpaceSize: usize,
+) -> usize {
+    if workSpace as usize & 3 != 0 {
         return Error::GENERIC.to_error_code();
     }
     if workSpaceSize < HIST_WKSP_SIZE {
@@ -242,8 +242,8 @@ pub unsafe fn HIST_countFast(
     count: *mut core::ffi::c_uint,
     maxSymbolValuePtr: *mut core::ffi::c_uint,
     source: *const core::ffi::c_void,
-    sourceSize: size_t,
-) -> size_t {
+    sourceSize: usize,
+) -> usize {
     let mut tmpCounters: [core::ffi::c_uint; 1024] = [0; 1024];
     HIST_countFast_wksp(
         count,
@@ -258,8 +258,8 @@ pub unsafe fn HIST_count(
     count: *mut core::ffi::c_uint,
     maxSymbolValuePtr: *mut core::ffi::c_uint,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let mut tmpCounters: [core::ffi::c_uint; 1024] = [0; 1024];
     HIST_count_wksp(
         count,

--- a/lib/compress/huf_compress.rs
+++ b/lib/compress/huf_compress.rs
@@ -1,7 +1,7 @@
 use core::ffi::{c_int, c_uint, c_ulong, c_void};
 use core::ptr;
 
-use libc::size_t;
+
 
 use crate::lib::common::bits::ZSTD_highbit32;
 use crate::lib::common::entropy_common::HUF_readStats;
@@ -41,11 +41,11 @@ pub const HUF_WORKSPACE_MAX_ALIGNMENT: usize = 8;
 
 unsafe fn HUF_alignUpWorkspace(
     workspace: *mut c_void,
-    workspaceSizePtr: *mut size_t,
-    align: size_t,
+    workspaceSizePtr: *mut usize,
+    align: usize,
 ) -> *mut c_void {
     let mask = align - 1;
-    let rem = workspace as size_t & mask;
+    let rem = workspace as usize & mask;
     let add = (align - (rem)) & mask;
     let aligned = (workspace as *mut u8).add(add);
 
@@ -54,7 +54,7 @@ unsafe fn HUF_alignUpWorkspace(
 
     if *workspaceSizePtr >= add {
         debug_assert!(add < align);
-        debug_assert!(((aligned as size_t) & mask) == 0);
+        debug_assert!(((aligned as usize) & mask) == 0);
         *workspaceSizePtr -= add;
         aligned as *mut c_void
     } else {
@@ -83,12 +83,12 @@ pub struct HUF_CompressWeightsWksp {
 /// Note : all elements within weightTable are supposed to be <= [`HUF_TABLELOG_MAX`].
 unsafe fn HUF_compressWeights(
     dst: *mut c_void,
-    dstSize: size_t,
+    dstSize: usize,
     weightTable: *const c_void,
-    wtSize: size_t,
+    wtSize: usize,
     workspace: *mut c_void,
-    mut workspaceSize: size_t,
-) -> size_t {
+    mut workspaceSize: usize,
+) -> usize {
     let ostart = dst as *mut u8;
     let mut op = ostart;
     let oend = ostart.add(dstSize);
@@ -116,7 +116,7 @@ unsafe fn HUF_compressWeights(
             wtSize,
         ); /* never fails */
 
-        if maxCount as size_t == wtSize {
+        if maxCount as usize == wtSize {
             return 1; /* only a single symbol in src : rle */
         }
 
@@ -185,28 +185,28 @@ unsafe fn HUF_compressWeights(
     op.offset_from_unsigned(ostart)
 }
 
-fn HUF_getNbBits(elt: HUF_CElt) -> size_t {
+fn HUF_getNbBits(elt: HUF_CElt) -> usize {
     elt & 0xff as c_int as HUF_CElt
 }
 
-fn HUF_getNbBitsFast(elt: HUF_CElt) -> size_t {
+fn HUF_getNbBitsFast(elt: HUF_CElt) -> usize {
     elt
 }
 
-fn HUF_getValue(elt: HUF_CElt) -> size_t {
-    elt & !(0xff as c_int as size_t)
+fn HUF_getValue(elt: HUF_CElt) -> usize {
+    elt & !(0xff as c_int as usize)
 }
 
-fn HUF_getValueFast(elt: HUF_CElt) -> size_t {
+fn HUF_getValueFast(elt: HUF_CElt) -> usize {
     elt
 }
 
-unsafe fn HUF_setNbBits(elt: *mut HUF_CElt, nbBits: size_t) {
+unsafe fn HUF_setNbBits(elt: *mut HUF_CElt, nbBits: usize) {
     debug_assert!(nbBits <= HUF_TABLELOG_ABSOLUTEMAX);
     *elt = nbBits;
 }
 
-unsafe fn HUF_setValue(elt: *mut HUF_CElt, value: size_t) {
+unsafe fn HUF_setValue(elt: *mut HUF_CElt, value: usize) {
     let nbBits = HUF_getNbBits(*elt);
     if nbBits > 0 {
         debug_assert!((value >> nbBits) == 0);
@@ -223,7 +223,7 @@ pub(super) unsafe fn HUF_readCTableHeader(ctable: *const HUF_CElt) -> HUF_CTable
     libc::memcpy(
         &mut header as *mut HUF_CTableHeader as *mut c_void,
         ctable as *const c_void,
-        size_of::<HUF_CTableHeader>() as c_ulong as libc::size_t,
+        size_of::<HUF_CTableHeader>() as c_ulong as usize,
     );
     header
 }
@@ -249,7 +249,7 @@ unsafe fn HUF_writeCTableHeader(ctable: *mut HUF_CElt, tableLog: u32, maxSymbolV
     libc::memcpy(
         ctable as *mut c_void,
         &mut header as *mut HUF_CTableHeader as *const c_void,
-        size_of::<HUF_CTableHeader>() as c_ulong as libc::size_t,
+        size_of::<HUF_CTableHeader>() as c_ulong as usize,
     );
 }
 
@@ -263,17 +263,17 @@ pub struct HUF_WriteCTableWksp {
 
 pub unsafe fn HUF_writeCTable_wksp(
     dst: *mut c_void,
-    maxDstSize: size_t,
+    maxDstSize: usize,
     CTable: *const HUF_CElt,
     maxSymbolValue: c_uint,
     huffLog: c_uint,
     workspace: *mut c_void,
-    mut workspaceSize: size_t,
-) -> size_t {
+    mut workspaceSize: usize,
+) -> usize {
     let ct = CTable.add(1);
     let op = dst as *mut u8;
     let mut n: u32 = 0;
-    let wksp = HUF_alignUpWorkspace(workspace, &mut workspaceSize, align_of::<u32>() as size_t)
+    let wksp = HUF_alignUpWorkspace(workspace, &mut workspaceSize, align_of::<u32>() as usize)
         as *mut HUF_WriteCTableWksp;
 
     const {
@@ -315,14 +315,14 @@ pub unsafe fn HUF_writeCTable_wksp(
             op.add(1) as *mut c_void,
             maxDstSize - 1,
             ((*wksp).huffWeight).as_mut_ptr() as *const c_void,
-            maxSymbolValue as size_t,
+            maxSymbolValue as usize,
             &mut (*wksp).wksp as *mut HUF_CompressWeightsWksp as *mut c_void,
             size_of::<HUF_CompressWeightsWksp>(),
         );
         if ERR_isError(hSize) {
             return hSize;
         }
-        if (hSize > 1) as c_int & (hSize < (maxSymbolValue / 2) as size_t) as c_int != 0 {
+        if (hSize > 1) as c_int & (hSize < (maxSymbolValue / 2) as usize) as c_int != 0 {
             /* FSE compressed */
             *op = hSize as u8;
             return hSize + 1;
@@ -333,7 +333,7 @@ pub unsafe fn HUF_writeCTable_wksp(
     if maxSymbolValue > (256 - 128) as c_uint {
         return Error::GENERIC.to_error_code(); /* should not happen : likely means source cannot be compressed */
     }
-    if (maxSymbolValue.div_ceil(2) + 1) as size_t > maxDstSize {
+    if (maxSymbolValue.div_ceil(2) + 1) as usize > maxDstSize {
         return Error::dstSize_tooSmall.to_error_code(); /* not enough space within dst buffer */
     }
     *op = ((128 as c_uint/*special case*/) + (maxSymbolValue - 1)) as u8;
@@ -348,16 +348,16 @@ pub unsafe fn HUF_writeCTable_wksp(
                 as u8;
         n += 2;
     }
-    (maxSymbolValue.div_ceil(2) + 1) as size_t
+    (maxSymbolValue.div_ceil(2) + 1) as usize
 }
 
 pub unsafe fn HUF_readCTable(
     CTable: *mut HUF_CElt,
     maxSymbolValuePtr: *mut c_uint,
     src: *const c_void,
-    srcSize: size_t,
+    srcSize: usize,
     hasZeroWeights: *mut c_uint,
-) -> size_t {
+) -> usize {
     let src = core::slice::from_raw_parts(src.cast(), srcSize);
 
     let mut huffWeight: [u8; HUF_SYMBOLVALUE_MAX as usize + 1] =
@@ -370,7 +370,7 @@ pub unsafe fn HUF_readCTable(
     let ct = CTable.add(1);
     let readSize = HUF_readStats(
         &mut huffWeight,
-        (255 + 1) as size_t,
+        (255 + 1) as usize,
         &mut rankVal,
         &mut nbSymbols,
         &mut tableLog,
@@ -414,7 +414,7 @@ pub unsafe fn HUF_readCTable(
             let w = *huffWeight.as_mut_ptr().offset(n_0 as isize) as u32;
             HUF_setNbBits(
                 ct.offset(n_0 as isize),
-                ((tableLog + 1 - w) as u8 as c_int & -((w != 0) as c_int) as c_int) as size_t,
+                ((tableLog + 1 - w) as u8 as c_int & -((w != 0) as c_int) as c_int) as usize,
             );
             n_0 += 1;
         }
@@ -461,7 +461,7 @@ pub unsafe fn HUF_readCTable(
                     .add(HUF_getNbBits(*ct.offset(n_3 as isize))));
                 let fresh2 = *fresh1;
                 *fresh1 += 1;
-                HUF_setValue(ct.offset(n_3 as isize), fresh2 as size_t);
+                HUF_setValue(ct.offset(n_3 as isize), fresh2 as usize);
                 n_3 += 1;
             }
         }
@@ -1016,7 +1016,7 @@ unsafe fn HUF_buildCTableFromTree(
     while n < alphabetSize {
         HUF_setNbBits(
             ct.offset((*huffNode.offset(n as isize)).byte as c_int as isize),
-            (*huffNode.offset(n as isize)).nbBits as size_t,
+            (*huffNode.offset(n as isize)).nbBits as usize,
         ); /* push nbBits per symbol, symbol order */
         n += 1;
     }
@@ -1028,7 +1028,7 @@ unsafe fn HUF_buildCTableFromTree(
             .add(HUF_getNbBits(*ct.offset(n as isize))));
         let fresh20 = *fresh19;
         *fresh19 += 1;
-        HUF_setValue(ct.offset(n as isize), fresh20 as size_t); /* assign value within rank, symbol order */
+        HUF_setValue(ct.offset(n as isize), fresh20 as usize); /* assign value within rank, symbol order */
         n += 1;
     }
     HUF_writeCTableHeader(CTable, maxNbBits, maxSymbolValue);
@@ -1042,9 +1042,9 @@ pub unsafe fn HUF_buildCTable_wksp(
     maxSymbolValue: u32,
     mut maxNbBits: u32,
     workSpace: *mut c_void,
-    mut wkspSize: size_t,
-) -> size_t {
-    let wksp_tables = HUF_alignUpWorkspace(workSpace, &mut wkspSize, align_of::<u32>() as size_t)
+    mut wkspSize: usize,
+) -> usize {
+    let wksp_tables = HUF_alignUpWorkspace(workSpace, &mut wkspSize, align_of::<u32>() as usize)
         as *mut HUF_buildCTable_wksp_tables;
     let huffNode0 = ((*wksp_tables).huffNodeTbl).as_mut_ptr();
     let huffNode = huffNode0.add(1);
@@ -1082,20 +1082,20 @@ pub unsafe fn HUF_buildCTable_wksp(
         return Error::GENERIC.to_error_code(); /* check fit into table */
     }
     HUF_buildCTableFromTree(CTable, huffNode, nonNullRank, maxSymbolValue, maxNbBits);
-    maxNbBits as size_t
+    maxNbBits as usize
 }
 
 pub unsafe fn HUF_estimateCompressedSize(
     CTable: *const HUF_CElt,
     count: *const c_uint,
     maxSymbolValue: c_uint,
-) -> size_t {
+) -> usize {
     let ct = CTable.add(1);
-    let mut nbBits = 0 as size_t;
+    let mut nbBits = 0 as usize;
     let mut s: c_int = 0;
     s = 0;
     while s <= maxSymbolValue as c_int {
-        nbBits += HUF_getNbBits(*ct.offset(s as isize)) * *count.offset(s as isize) as size_t;
+        nbBits += HUF_getNbBits(*ct.offset(s as isize)) * *count.offset(s as isize) as usize;
         s += 1;
     }
     nbBits >> 3
@@ -1125,15 +1125,15 @@ pub unsafe fn HUF_validateCTable(
     (bad == 0) as c_int
 }
 
-pub fn HUF_compressBound(size: size_t) -> size_t {
+pub fn HUF_compressBound(size: usize) -> usize {
     HUF_CTABLEBOUND + (size + (size >> 8) + 8)
 }
 
-pub const HUF_BITS_IN_CONTAINER: size_t = size_t::BITS as usize;
+pub const HUF_BITS_IN_CONTAINER: usize = usize::BITS as usize;
 
 /// Huffman uses its own `BIT_CStream_t` implementation.
 /// There are three major differences from `BIT_CStream_t`:
-///   1. `HUF_addBits` takes a `HUF_CElt` (size_t) which is
+///   1. `HUF_addBits` takes a `HUF_CElt` (usize) which is
 ///      the pair (nbBits, value) in the format:
 ///      format:
 ///        - Bits [0, 4)            = nbBits
@@ -1148,8 +1148,8 @@ pub const HUF_BITS_IN_CONTAINER: size_t = size_t::BITS as usize;
 ///      the first container.
 #[repr(C)]
 pub struct HUF_CStream_t {
-    pub bitContainer: [size_t; 2],
-    pub bitPos: [size_t; 2],
+    pub bitContainer: [usize; 2],
+    pub bitPos: [usize; 2],
     pub startPtr: *mut u8,
     pub ptr: *mut u8,
     pub endPtr: *mut u8,
@@ -1163,15 +1163,15 @@ pub struct HUF_CStream_t {
 unsafe fn HUF_initCStream(
     bitC: *mut HUF_CStream_t,
     startPtr: *mut c_void,
-    dstCapacity: size_t,
-) -> size_t {
+    dstCapacity: usize,
+) -> usize {
     ptr::write_bytes(bitC as *mut u8, 0, size_of::<HUF_CStream_t>());
     (*bitC).startPtr = startPtr as *mut u8;
     (*bitC).ptr = (*bitC).startPtr;
     (*bitC).endPtr = ((*bitC).startPtr)
         .add(dstCapacity)
-        .offset(-(size_of::<size_t>() as c_ulong as isize));
-    if dstCapacity <= size_of::<size_t>() {
+        .offset(-(size_of::<usize>() as c_ulong as isize));
+    if dstCapacity <= size_of::<usize>() {
         return Error::dstSize_tooSmall.to_error_code();
     }
     0
@@ -1228,7 +1228,7 @@ unsafe fn HUF_zeroIndex1(bitC: *mut HUF_CStream_t) {
 unsafe fn HUF_mergeIndex1(bitC: *mut HUF_CStream_t) {
     debug_assert!((*((*bitC).bitPos).as_ptr().add(1) & 0xFF) < HUF_BITS_IN_CONTAINER);
     *((*bitC).bitContainer).as_mut_ptr() >>=
-        *((*bitC).bitPos).as_mut_ptr().add(1) & 0xff as c_int as size_t;
+        *((*bitC).bitPos).as_mut_ptr().add(1) & 0xff as c_int as usize;
     *((*bitC).bitContainer).as_mut_ptr() |= *((*bitC).bitContainer).as_mut_ptr().add(1);
     *((*bitC).bitPos).as_mut_ptr() += *((*bitC).bitPos).as_mut_ptr().add(1);
     debug_assert!((*((*bitC).bitPos).as_ptr() & 0xFF) <= HUF_BITS_IN_CONTAINER);
@@ -1247,14 +1247,14 @@ unsafe fn HUF_mergeIndex1(bitC: *mut HUF_CStream_t) {
 #[inline(always)]
 unsafe fn HUF_flushBits(bitC: *mut HUF_CStream_t, kFast: c_int) {
     /* The upper bits of bitPos are noisy, so we must mask by 0xFF. */
-    let nbBits = *((*bitC).bitPos).as_mut_ptr() & 0xff as c_int as size_t;
+    let nbBits = *((*bitC).bitPos).as_mut_ptr() & 0xff as c_int as usize;
     let nbBytes = nbBits >> 3;
     /* The top nbBits bits of bitContainer are the ones we need. */
     let bitContainer = *((*bitC).bitContainer).as_mut_ptr() >> (HUF_BITS_IN_CONTAINER - (nbBits));
     /* Mask bitPos to account for the bytes we consumed. */
     *((*bitC).bitPos).as_mut_ptr() &= 7;
     debug_assert!(nbBits > 0);
-    debug_assert!(nbBits <= core::mem::size_of::<size_t>() * 8);
+    debug_assert!(nbBits <= core::mem::size_of::<usize>() * 8);
     debug_assert!((*bitC).ptr <= (*bitC).endPtr);
     MEM_writeLEST((*bitC).ptr as *mut c_void, bitContainer);
     (*bitC).ptr = ((*bitC).ptr).add(nbBytes);
@@ -1281,14 +1281,14 @@ unsafe fn HUF_endMark() -> HUF_CElt {
 /// # Returns
 ///
 /// Size of CStream, in bytes, or 0 if it could not fit into dstBuffer
-unsafe fn HUF_closeCStream(bitC: *mut HUF_CStream_t) -> size_t {
+unsafe fn HUF_closeCStream(bitC: *mut HUF_CStream_t) -> usize {
     HUF_addBits(bitC, HUF_endMark(), 0, 0);
     HUF_flushBits(bitC, 0);
-    let nbBits = *((*bitC).bitPos).as_mut_ptr() & 0xff as c_int as size_t;
+    let nbBits = *((*bitC).bitPos).as_mut_ptr() & 0xff as c_int as usize;
     if (*bitC).ptr >= (*bitC).endPtr {
         return 0; /* overflow detected */
     }
-    (((*bitC).ptr).offset_from((*bitC).startPtr) as size_t) + ((nbBits > 0) as c_int as size_t)
+    (((*bitC).ptr).offset_from((*bitC).startPtr) as usize) + ((nbBits > 0) as c_int as usize)
 }
 
 #[inline(always)]
@@ -1306,7 +1306,7 @@ unsafe fn HUF_encodeSymbol(
 unsafe fn HUF_compress1X_usingCTable_internal_body_loop(
     bitC: *mut HUF_CStream_t,
     ip: *const u8,
-    srcSize: size_t,
+    srcSize: usize,
     ct: *const HUF_CElt,
     kUnroll: c_int,
     kFastFlush: c_int,
@@ -1395,18 +1395,18 @@ unsafe fn HUF_compress1X_usingCTable_internal_body_loop(
 /// Returns a tight upper bound on the output space needed by Huffman
 /// with 8 bytes buffer to handle over-writes. If the output is at least
 /// this large we don't need to do bounds checks during Huffman encoding.
-fn HUF_tightCompressBound(srcSize: size_t, tableLog: size_t) -> size_t {
+fn HUF_tightCompressBound(srcSize: usize, tableLog: usize) -> usize {
     ((srcSize * tableLog) >> 3) + 8
 }
 
 #[inline(always)]
 unsafe fn HUF_compress1X_usingCTable_internal_body(
     dst: *mut c_void,
-    dstSize: size_t,
+    dstSize: usize,
     src: *const c_void,
-    srcSize: size_t,
+    srcSize: usize,
     CTable: *const HUF_CElt,
-) -> size_t {
+) -> usize {
     let tableLog = (HUF_readCTableHeader(CTable)).tableLog as u32;
     let ct = CTable.add(1);
     let ip = src as *const u8;
@@ -1432,7 +1432,7 @@ unsafe fn HUF_compress1X_usingCTable_internal_body(
         }
     }
 
-    if dstSize < HUF_tightCompressBound(srcSize, tableLog as size_t) || tableLog > 11 {
+    if dstSize < HUF_tightCompressBound(srcSize, tableLog as usize) || tableLog > 11 {
         HUF_compress1X_usingCTable_internal_body_loop(
             &mut bitC,
             ip,
@@ -1482,32 +1482,32 @@ unsafe fn HUF_compress1X_usingCTable_internal_body(
 
 unsafe fn HUF_compress1X_usingCTable_internal_bmi2(
     dst: *mut c_void,
-    dstSize: size_t,
+    dstSize: usize,
     src: *const c_void,
-    srcSize: size_t,
+    srcSize: usize,
     CTable: *const HUF_CElt,
-) -> size_t {
+) -> usize {
     HUF_compress1X_usingCTable_internal_body(dst, dstSize, src, srcSize, CTable)
 }
 
 unsafe fn HUF_compress1X_usingCTable_internal_default(
     dst: *mut c_void,
-    dstSize: size_t,
+    dstSize: usize,
     src: *const c_void,
-    srcSize: size_t,
+    srcSize: usize,
     CTable: *const HUF_CElt,
-) -> size_t {
+) -> usize {
     HUF_compress1X_usingCTable_internal_body(dst, dstSize, src, srcSize, CTable)
 }
 
 unsafe fn HUF_compress1X_usingCTable_internal(
     dst: *mut c_void,
-    dstSize: size_t,
+    dstSize: usize,
     src: *const c_void,
-    srcSize: size_t,
+    srcSize: usize,
     CTable: *const HUF_CElt,
     flags: c_int,
-) -> size_t {
+) -> usize {
     if flags & HUF_flags_bmi2 as c_int != 0 {
         return HUF_compress1X_usingCTable_internal_bmi2(dst, dstSize, src, srcSize, CTable);
     }
@@ -1516,23 +1516,23 @@ unsafe fn HUF_compress1X_usingCTable_internal(
 
 pub unsafe fn HUF_compress1X_usingCTable(
     dst: *mut c_void,
-    dstSize: size_t,
+    dstSize: usize,
     src: *const c_void,
-    srcSize: size_t,
+    srcSize: usize,
     CTable: *const HUF_CElt,
     flags: c_int,
-) -> size_t {
+) -> usize {
     HUF_compress1X_usingCTable_internal(dst, dstSize, src, srcSize, CTable, flags)
 }
 
 unsafe fn HUF_compress4X_usingCTable_internal(
     dst: *mut c_void,
-    dstSize: size_t,
+    dstSize: usize,
     src: *const c_void,
-    srcSize: size_t,
+    srcSize: usize,
     CTable: *const HUF_CElt,
     flags: c_int,
-) -> size_t {
+) -> usize {
     let segmentSize = srcSize.div_ceil(4); /* first 3 segments */
     let mut ip = src as *const u8;
     let iend = ip.add(srcSize);
@@ -1639,12 +1639,12 @@ unsafe fn HUF_compress4X_usingCTable_internal(
 
 pub unsafe fn HUF_compress4X_usingCTable(
     dst: *mut c_void,
-    dstSize: size_t,
+    dstSize: usize,
     src: *const c_void,
-    srcSize: size_t,
+    srcSize: usize,
     CTable: *const HUF_CElt,
     flags: c_int,
-) -> size_t {
+) -> usize {
     HUF_compress4X_usingCTable_internal(dst, dstSize, src, srcSize, CTable, flags)
 }
 
@@ -1659,11 +1659,11 @@ unsafe fn HUF_compressCTable_internal(
     mut op: *mut u8,
     oend: *mut u8,
     src: *const c_void,
-    srcSize: size_t,
+    srcSize: usize,
     nbStreams: HUF_nbStreams_e,
     CTable: *const HUF_CElt,
     flags: c_int,
-) -> size_t {
+) -> usize {
     let cSize = if nbStreams as c_uint == HUF_singleStream as c_int as c_uint {
         HUF_compress1X_usingCTable_internal(
             op as *mut c_void,
@@ -1740,10 +1740,10 @@ pub fn HUF_minTableLog(symbolCardinality: c_uint) -> c_uint {
 
 pub unsafe fn HUF_optimalTableLog(
     maxTableLog: c_uint,
-    srcSize: size_t,
+    srcSize: usize,
     maxSymbolValue: c_uint,
     workSpace: *mut c_void,
-    wkspSize: size_t,
+    wkspSize: usize,
     table: *mut HUF_CElt,
     count: *const c_uint,
     flags: c_int,
@@ -1757,11 +1757,11 @@ pub unsafe fn HUF_optimalTableLog(
     }
     let dst = (workSpace as *mut u8).offset(size_of::<HUF_WriteCTableWksp>() as c_ulong as isize);
     let dstSize = wkspSize - (size_of::<HUF_WriteCTableWksp>());
-    let mut hSize: size_t = 0;
-    let mut newSize: size_t = 0;
+    let mut hSize: usize = 0;
+    let mut newSize: usize = 0;
     let symbolCardinality = HUF_cardinality(count, maxSymbolValue);
     let minTableLog = HUF_minTableLog(symbolCardinality);
-    let mut optSize = (!(0) as size_t) - 1;
+    let mut optSize = (!(0) as usize) - 1;
     let mut optLog = maxTableLog;
     let mut optLogGuess: c_uint = 0;
 
@@ -1777,7 +1777,7 @@ pub unsafe fn HUF_optimalTableLog(
             wkspSize,
         );
         if !ERR_isError(maxBits) {
-            if maxBits < optLogGuess as size_t && optLogGuess > minTableLog {
+            if maxBits < optLogGuess as usize && optLogGuess > minTableLog {
                 break;
             }
             hSize = HUF_writeCTable_wksp(
@@ -1810,19 +1810,19 @@ pub unsafe fn HUF_optimalTableLog(
 /// and occupies the same space as a table of HUF_WORKSPACE_SIZE_U64 unsigned
 unsafe fn HUF_compress_internal(
     dst: *mut c_void,
-    dstSize: size_t,
+    dstSize: usize,
     src: *const c_void,
-    srcSize: size_t,
+    srcSize: usize,
     mut maxSymbolValue: c_uint,
     mut huffLog: c_uint,
     nbStreams: HUF_nbStreams_e,
     workSpace: *mut c_void,
-    mut wkspSize: size_t,
+    mut wkspSize: usize,
     oldHufTable: *mut HUF_CElt,
     repeat: *mut HUF_repeat,
     flags: c_int,
-) -> size_t {
-    let table = HUF_alignUpWorkspace(workSpace, &mut wkspSize, align_of::<size_t>() as size_t)
+) -> usize {
+    let table = HUF_alignUpWorkspace(workSpace, &mut wkspSize, align_of::<usize>() as usize)
         as *mut HUF_compress_tables_t;
     let ostart = dst as *mut u8;
     let oend = ostart.add(dstSize);
@@ -1887,16 +1887,16 @@ unsafe fn HUF_compress_internal(
     /* If uncompressible data is suspected, do a smaller sampling first */
     if flags & HUF_flags_suspectUncompressible as c_int != 0
         && srcSize
-            >= (SUSPECT_INCOMPRESSIBLE_SAMPLE_SIZE * SUSPECT_INCOMPRESSIBLE_SAMPLE_RATIO) as size_t
+            >= (SUSPECT_INCOMPRESSIBLE_SAMPLE_SIZE * SUSPECT_INCOMPRESSIBLE_SAMPLE_RATIO) as usize
     {
-        let mut largestTotal = 0 as size_t;
+        let mut largestTotal = 0 as usize;
         let mut maxSymbolValueBegin = maxSymbolValue;
         let largestBegin = HIST_count_simple(
             ((*table).count).as_mut_ptr(),
             &mut maxSymbolValueBegin,
             src as *const u8 as *const c_void,
             4096,
-        ) as size_t;
+        ) as usize;
         if ERR_isError(largestBegin) {
             return largestBegin;
         }
@@ -1907,12 +1907,12 @@ unsafe fn HUF_compress_internal(
             &mut maxSymbolValueEnd,
             (src as *const u8).add(srcSize).sub(4096) as *const c_void,
             4096,
-        ) as size_t;
+        ) as usize;
         if ERR_isError(largestEnd) {
             return largestEnd;
         }
         largestTotal += largestEnd;
-        if largestTotal <= (((2 * SUSPECT_INCOMPRESSIBLE_SAMPLE_SIZE) >> 7) + 4) as size_t {
+        if largestTotal <= (((2 * SUSPECT_INCOMPRESSIBLE_SAMPLE_SIZE) >> 7) + 4) as usize {
             return 0; /* heuristic : probably not compressible enough */
         }
     }
@@ -2041,7 +2041,7 @@ unsafe fn HUF_compress_internal(
             libc::memcpy(
                 oldHufTable as *mut c_void,
                 ((*table).CTable).as_mut_ptr() as *const c_void,
-                size_of::<[HUF_CElt; 257]>() as c_ulong as libc::size_t,
+                size_of::<[HUF_CElt; 257]>() as c_ulong as usize,
             );
         }
     }
@@ -2059,17 +2059,17 @@ unsafe fn HUF_compress_internal(
 
 pub unsafe extern "C" fn HUF_compress1X_repeat(
     dst: *mut c_void,
-    dstSize: size_t,
+    dstSize: usize,
     src: *const c_void,
-    srcSize: size_t,
+    srcSize: usize,
     maxSymbolValue: c_uint,
     huffLog: c_uint,
     workSpace: *mut c_void,
-    wkspSize: size_t,
+    wkspSize: usize,
     hufTable: *mut HUF_CElt,
     repeat: *mut HUF_repeat,
     flags: c_int,
-) -> size_t {
+) -> usize {
     HUF_compress_internal(
         dst,
         dstSize,
@@ -2091,17 +2091,17 @@ pub unsafe extern "C" fn HUF_compress1X_repeat(
 /// reuse an existing huffman compression table
 pub unsafe extern "C" fn HUF_compress4X_repeat(
     dst: *mut c_void,
-    dstSize: size_t,
+    dstSize: usize,
     src: *const c_void,
-    srcSize: size_t,
+    srcSize: usize,
     maxSymbolValue: c_uint,
     huffLog: c_uint,
     workSpace: *mut c_void,
-    wkspSize: size_t,
+    wkspSize: usize,
     hufTable: *mut HUF_CElt,
     repeat: *mut HUF_repeat,
     flags: c_int,
-) -> size_t {
+) -> usize {
     HUF_compress_internal(
         dst,
         dstSize,

--- a/lib/compress/zstd_compress.rs
+++ b/lib/compress/zstd_compress.rs
@@ -12,42 +12,42 @@ pub struct ZSTD_CCtx_s {
     pub(super) appliedParams: ZSTD_CCtx_params,
     pub(super) simpleApiParams: ZSTD_CCtx_params,
     pub(super) dictID: u32,
-    pub(super) dictContentSize: size_t,
+    pub(super) dictContentSize: usize,
     pub(super) workspace: ZSTD_cwksp,
-    pub(super) blockSizeMax: size_t,
+    pub(super) blockSizeMax: usize,
     pub(super) pledgedSrcSizePlusOne: core::ffi::c_ulonglong,
     pub(super) consumedSrcSize: core::ffi::c_ulonglong,
     pub(super) producedCSize: core::ffi::c_ulonglong,
     pub(super) xxhState: XXH64_state_t,
     pub(super) customMem: ZSTD_customMem,
     pub(super) pool: *mut ZSTD_threadPool,
-    pub(super) staticSize: size_t,
+    pub(super) staticSize: usize,
     pub(super) seqCollector: SeqCollector,
     pub(super) isFirstBlock: core::ffi::c_int,
     pub(super) initialized: core::ffi::c_int,
     pub(super) seqStore: SeqStore_t,
     pub(super) ldmState: ldmState_t,
     pub(super) ldmSequences: *mut rawSeq,
-    pub(super) maxNbLdmSequences: size_t,
+    pub(super) maxNbLdmSequences: usize,
     pub(super) externSeqStore: RawSeqStore_t,
     pub(super) blockState: ZSTD_blockState_t,
     pub(super) tmpWorkspace: *mut core::ffi::c_void,
-    pub(super) tmpWkspSize: size_t,
+    pub(super) tmpWkspSize: usize,
     pub(super) bufferedPolicy: ZSTD_buffered_policy_e,
     pub(super) inBuff: *mut u8,
-    pub(super) inBuffSize: size_t,
-    pub(super) inToCompress: size_t,
-    pub(super) inBuffPos: size_t,
-    pub(super) inBuffTarget: size_t,
+    pub(super) inBuffSize: usize,
+    pub(super) inToCompress: usize,
+    pub(super) inBuffPos: usize,
+    pub(super) inBuffTarget: usize,
     pub(super) outBuff: *mut u8,
-    pub(super) outBuffSize: size_t,
-    pub(super) outBuffContentSize: size_t,
-    pub(super) outBuffFlushedSize: size_t,
+    pub(super) outBuffSize: usize,
+    pub(super) outBuffContentSize: usize,
+    pub(super) outBuffFlushedSize: usize,
     pub(super) streamStage: ZSTD_cStreamStage,
     pub(super) frameEnded: u32,
     pub(super) expectedInBuffer: ZSTD_inBuffer,
-    pub(super) stableIn_notConsumed: size_t,
-    pub(super) expectedOutBufferSize: size_t,
+    pub(super) stableIn_notConsumed: usize,
+    pub(super) expectedOutBufferSize: usize,
     pub(super) localDict: ZSTD_localDict,
     pub(super) cdict: *const ZSTD_CDict,
     pub(super) prefixDict: ZSTD_prefixDict,
@@ -55,7 +55,7 @@ pub struct ZSTD_CCtx_s {
     pub(super) traceCtx: ZSTD_TraceCtx,
     pub(super) blockSplitCtx: ZSTD_blockSplitCtx,
     pub(super) extSeqBuf: *mut ZSTD_Sequence,
-    pub(super) extSeqBufCapacity: size_t,
+    pub(super) extSeqBufCapacity: usize,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -89,8 +89,8 @@ pub struct ZSTD_fseCTablesMetadata_t {
     pub ofType: SymbolEncodingType_e,
     pub mlType: SymbolEncodingType_e,
     pub fseTablesBuffer: [u8; 133],
-    pub fseTablesSize: size_t,
-    pub lastCountSize: size_t,
+    pub fseTablesSize: usize,
+    pub lastCountSize: usize,
 }
 pub type SymbolEncodingType_e = core::ffi::c_uint;
 pub const set_repeat: SymbolEncodingType_e = 3;
@@ -102,7 +102,7 @@ pub const set_basic: SymbolEncodingType_e = 0;
 pub struct ZSTD_hufCTablesMetadata_t {
     pub hType: SymbolEncodingType_e,
     pub hufDesBuffer: [u8; 128],
-    pub hufDesSize: size_t,
+    pub hufDesSize: usize,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -114,8 +114,8 @@ pub struct SeqStore_t {
     pub llCode: *mut u8,
     pub mlCode: *mut u8,
     pub ofCode: *mut u8,
-    pub maxNbSeq: size_t,
-    pub maxNbLit: size_t,
+    pub maxNbSeq: usize,
+    pub maxNbLit: usize,
     pub longLengthType: ZSTD_longLengthType_e,
     pub longLengthPos: u32,
 }
@@ -132,14 +132,14 @@ pub type ZSTD_prefixDict = ZSTD_prefixDict_s;
 #[repr(C)]
 pub struct ZSTD_prefixDict_s {
     pub dict: *const core::ffi::c_void,
-    pub dictSize: size_t,
+    pub dictSize: usize,
     pub dictContentType: ZSTD_dictContentType_e,
 }
 pub type ZSTD_CDict = ZSTD_CDict_s;
 #[repr(C)]
 pub struct ZSTD_CDict_s {
     pub dictContent: *const core::ffi::c_void,
-    pub dictContentSize: size_t,
+    pub dictContentSize: usize,
     pub dictContentType: ZSTD_dictContentType_e,
     pub entropyWorkspace: *mut u32,
     pub workspace: ZSTD_cwksp,
@@ -227,10 +227,10 @@ pub struct ZSTD_MatchState_t {
 #[repr(C)]
 pub struct RawSeqStore_t {
     pub seq: *mut rawSeq,
-    pub pos: size_t,
-    pub posInSequence: size_t,
-    pub size: size_t,
-    pub capacity: size_t,
+    pub pos: usize,
+    pub posInSequence: usize,
+    pub size: usize,
+    pub capacity: usize,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -312,7 +312,7 @@ pub const ZSTD_cwksp_alloc_objects: ZSTD_cwksp_alloc_phase_e = 0;
 pub struct ZSTD_localDict {
     pub dictBuffer: *mut core::ffi::c_void,
     pub dict: *const core::ffi::c_void,
-    pub dictSize: size_t,
+    pub dictSize: usize,
     pub dictContentType: ZSTD_dictContentType_e,
     pub cdict: *mut ZSTD_CDict,
 }
@@ -333,8 +333,8 @@ pub struct ZSTD_blockState_t {
 pub struct SeqCollector {
     pub collectSequences: core::ffi::c_int,
     pub seqStart: *mut ZSTD_Sequence,
-    pub seqIndex: size_t,
-    pub maxSequences: size_t,
+    pub seqIndex: usize,
+    pub maxSequences: usize,
 }
 pub type ZSTD_CCtx_params = ZSTD_CCtx_params_s;
 #[derive(Copy, Clone)]
@@ -345,12 +345,12 @@ pub struct ZSTD_CCtx_params_s {
     pub fParams: ZSTD_frameParameters,
     pub compressionLevel: core::ffi::c_int,
     pub forceWindow: core::ffi::c_int,
-    pub targetCBlockSize: size_t,
+    pub targetCBlockSize: usize,
     pub srcSizeHint: core::ffi::c_int,
     pub attachDictPref: ZSTD_dictAttachPref_e,
     pub literalCompressionMode: ParamSwitch,
     pub nbWorkers: core::ffi::c_int,
-    pub jobSize: size_t,
+    pub jobSize: usize,
     pub overlapLog: core::ffi::c_int,
     pub rsyncable: core::ffi::c_int,
     pub ldmParams: ldmParams_t,
@@ -361,7 +361,7 @@ pub struct ZSTD_CCtx_params_s {
     pub validateSequences: core::ffi::c_int,
     pub postBlockSplitter: ZSTD_ParamSwitch_e,
     pub preBlockSplitter_level: core::ffi::c_int,
-    pub maxBlockSize: size_t,
+    pub maxBlockSize: usize,
     pub useRowMatchFinder: ZSTD_ParamSwitch_e,
     pub deterministicRefPrefix: core::ffi::c_int,
     pub customMem: ZSTD_customMem,
@@ -375,14 +375,14 @@ pub type ZSTD_sequenceProducer_F = Option<
     unsafe extern "C" fn(
         *mut core::ffi::c_void,
         *mut ZSTD_Sequence,
-        size_t,
+        usize,
         *const core::ffi::c_void,
-        size_t,
+        usize,
         *const core::ffi::c_void,
-        size_t,
+        usize,
         core::ffi::c_int,
-        size_t,
-    ) -> size_t,
+        usize,
+    ) -> usize,
 >;
 pub type ZSTD_SequenceFormat_e = core::ffi::c_uint;
 pub const ZSTD_sf_explicitBlockDelimiters: ZSTD_SequenceFormat_e = 1;
@@ -392,15 +392,15 @@ pub const ZSTDcs_ending: ZSTD_compressionStage_e = 3;
 pub const ZSTDcs_ongoing: ZSTD_compressionStage_e = 2;
 pub const ZSTDcs_init: ZSTD_compressionStage_e = 1;
 pub const ZSTDcs_created: ZSTD_compressionStage_e = 0;
-pub type unalignArch = size_t;
+pub type unalignArch = usize;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct ZSTD_symbolEncodingTypeStats_t {
     pub LLtype: u32,
     pub Offtype: u32,
     pub MLtype: u32,
-    pub size: size_t,
-    pub lastCountSize: size_t,
+    pub size: usize,
+    pub lastCountSize: usize,
     pub longOffsets: core::ffi::c_int,
 }
 pub type S16 = i16;
@@ -421,8 +421,8 @@ pub type ZSTD_BlockCompressor_f = Option<
         &mut SeqStore_t,
         *mut u32,
         *const core::ffi::c_void,
-        size_t,
-    ) -> size_t,
+        usize,
+    ) -> usize,
 >;
 pub type ZSTD_dictMode_e = core::ffi::c_uint;
 pub const ZSTD_dedicatedDictSearch: ZSTD_dictMode_e = 3;
@@ -434,13 +434,13 @@ pub const ZSTD_noDict: ZSTD_dictMode_e = 0;
 pub struct ZSTD_SequencePosition {
     pub idx: u32,
     pub posInSequence: u32,
-    pub posInSrc: size_t,
+    pub posInSrc: usize,
 }
 pub type S64 = i64;
 #[repr(C)]
 pub struct seqStoreSplits {
     pub splitLocations: *mut u32,
-    pub idx: size_t,
+    pub idx: usize,
 }
 
 pub type ZSTD_dictTableLoadMethod_e = core::ffi::c_uint;
@@ -474,7 +474,7 @@ pub struct ZSTD_cpuid_t {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct ZSTD_bounds {
-    pub error: size_t,
+    pub error: usize,
     pub lowerBound: core::ffi::c_int,
     pub upperBound: core::ffi::c_int,
 }
@@ -488,18 +488,18 @@ pub type ZSTD_SequenceCopier_f = Option<
         *mut ZSTD_CCtx,
         *mut ZSTD_SequencePosition,
         *const ZSTD_Sequence,
-        size_t,
+        usize,
         *const core::ffi::c_void,
-        size_t,
+        usize,
         ZSTD_ParamSwitch_e,
-    ) -> size_t,
+    ) -> usize,
 >;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct BlockSummary {
-    pub nbSequences: size_t,
-    pub blockSize: size_t,
-    pub litSize: size_t,
+    pub nbSequences: usize,
+    pub blockSize: usize,
+    pub litSize: usize,
 }
 pub type C2RustUnnamed_2 = core::ffi::c_uint;
 pub const ZSTD_WINDOWLOG_MIN: core::ffi::c_int = 10;
@@ -608,11 +608,11 @@ unsafe fn ZSTD_cParam_withinBounds(
 #[inline]
 unsafe fn ZSTD_noCompressBlock(
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     lastBlock: u32,
-) -> size_t {
+) -> usize {
     let cBlockHeader24 = lastBlock
         .wrapping_add((bt_raw as core::ffi::c_int as u32) << 1)
         .wrapping_add((srcSize << 3) as u32);
@@ -623,18 +623,18 @@ unsafe fn ZSTD_noCompressBlock(
     libc::memcpy(
         (dst as *mut u8).add(ZSTD_blockHeaderSize) as *mut core::ffi::c_void,
         src,
-        srcSize as libc::size_t,
+        srcSize as usize,
     );
     ZSTD_blockHeaderSize.wrapping_add(srcSize)
 }
 #[inline]
 unsafe fn ZSTD_rleCompressBlock(
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: u8,
-    srcSize: size_t,
+    srcSize: usize,
     lastBlock: u32,
-) -> size_t {
+) -> usize {
     let op = dst as *mut u8;
     let cBlockHeader = lastBlock
         .wrapping_add((bt_rle as core::ffi::c_int as u32) << 1)
@@ -647,7 +647,7 @@ unsafe fn ZSTD_rleCompressBlock(
     4
 }
 #[inline]
-unsafe fn ZSTD_minGain(srcSize: size_t, strat: ZSTD_strategy) -> size_t {
+unsafe fn ZSTD_minGain(srcSize: usize, strat: ZSTD_strategy) -> usize {
     let minlog =
         if strat as core::ffi::c_uint >= ZSTD_btultra as core::ffi::c_int as core::ffi::c_uint {
             strat.wrapping_sub(1)
@@ -675,7 +675,7 @@ pub const REPCODE3_TO_OFFBASE: core::ffi::c_int = 3;
 
 #[inline]
 unsafe fn ZSTD_window_clear(window: *mut ZSTD_window_t) {
-    let endT = ((*window).nextSrc).wrapping_offset_from((*window).base) as size_t;
+    let endT = ((*window).nextSrc).wrapping_offset_from((*window).base) as usize;
     let end = endT as u32;
     (*window).lowLimit = end;
     (*window).dictLimit = end;
@@ -814,7 +814,7 @@ unsafe fn ZSTD_window_init(window: *mut ZSTD_window_t) {
 unsafe fn ZSTD_window_update(
     window: *mut ZSTD_window_t,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     forceNonContiguous: core::ffi::c_int,
 ) -> u32 {
     let ip = src as *const u8;
@@ -823,7 +823,7 @@ unsafe fn ZSTD_window_update(
         return contiguous;
     }
     if src != (*window).nextSrc as *const core::ffi::c_void || forceNonContiguous != 0 {
-        let distanceFromBase = ((*window).nextSrc).wrapping_offset_from((*window).base) as size_t;
+        let distanceFromBase = ((*window).nextSrc).wrapping_offset_from((*window).base) as usize;
         (*window).lowLimit = (*window).dictLimit;
         (*window).dictLimit = distanceFromBase as u32;
         (*window).dictBase = (*window).base;
@@ -837,8 +837,8 @@ unsafe fn ZSTD_window_update(
     if (ip.add(srcSize) > ((*window).dictBase).wrapping_offset((*window).lowLimit as isize))
         && (ip < ((*window).dictBase).wrapping_offset((*window).dictLimit as isize))
     {
-        let highInputIdx = ip.add(srcSize).offset_from((*window).dictBase) as size_t;
-        let lowLimitMax = if highInputIdx > (*window).dictLimit as size_t {
+        let highInputIdx = ip.add(srcSize).offset_from((*window).dictBase) as usize;
+        let lowLimitMax = if highInputIdx > (*window).dictLimit as usize {
             (*window).dictLimit
         } else {
             highInputIdx as u32
@@ -853,7 +853,7 @@ unsafe fn ZSTD_hasExtSeqProd(params: *const ZSTD_CCtx_params) -> core::ffi::c_in
     ((*params).extSeqProdFunc).is_some() as core::ffi::c_int
 }
 
-use libc::{ptrdiff_t, size_t};
+use libc::ptrdiff_t;
 
 use crate::lib::common::allocations::{ZSTD_customCalloc, ZSTD_customFree, ZSTD_customMalloc};
 use crate::lib::common::bits::ZSTD_highbit32;
@@ -959,7 +959,7 @@ use crate::lib::zstd::{
     ZSTD_WINDOWLOG_MAX_64,
 };
 pub const ZSTD_BLOCKHEADERSIZE: core::ffi::c_int = 3;
-static ZSTD_blockHeaderSize: size_t = ZSTD_BLOCKHEADERSIZE as size_t;
+static ZSTD_blockHeaderSize: usize = ZSTD_BLOCKHEADERSIZE as usize;
 pub const MIN_CBLOCK_SIZE: core::ffi::c_int = 1 + 1;
 pub const LONGNBSEQ: core::ffi::c_int = 0x7f00 as core::ffi::c_int;
 pub const ZSTD_CWKSP_ALIGNMENT_BYTES: core::ffi::c_int = 64;
@@ -975,45 +975,45 @@ unsafe fn ZSTD_cwksp_assert_internal_consistency(ws: *mut ZSTD_cwksp) {
     assert!((*ws).workspace <= (*ws).initOnceStart);
 }
 #[inline]
-unsafe fn ZSTD_cwksp_align(size: size_t, align: size_t) -> size_t {
+unsafe fn ZSTD_cwksp_align(size: usize, align: usize) -> usize {
     let mask = align.wrapping_sub(1);
     size.wrapping_add(mask) & !mask
 }
 #[inline]
-unsafe fn ZSTD_cwksp_alloc_size(size: size_t) -> size_t {
+unsafe fn ZSTD_cwksp_alloc_size(size: usize) -> usize {
     if size == 0 {
         return 0;
     }
     size
 }
 #[inline]
-unsafe fn ZSTD_cwksp_aligned_alloc_size(size: size_t, alignment: size_t) -> size_t {
+unsafe fn ZSTD_cwksp_aligned_alloc_size(size: usize, alignment: usize) -> usize {
     ZSTD_cwksp_alloc_size(ZSTD_cwksp_align(size, alignment))
 }
 #[inline]
-unsafe fn ZSTD_cwksp_aligned64_alloc_size(size: size_t) -> size_t {
-    ZSTD_cwksp_aligned_alloc_size(size, ZSTD_CWKSP_ALIGNMENT_BYTES as size_t)
+unsafe fn ZSTD_cwksp_aligned64_alloc_size(size: usize) -> usize {
+    ZSTD_cwksp_aligned_alloc_size(size, ZSTD_CWKSP_ALIGNMENT_BYTES as usize)
 }
 #[inline]
-unsafe fn ZSTD_cwksp_slack_space_required() -> size_t {
-    (ZSTD_CWKSP_ALIGNMENT_BYTES * 2) as size_t
+unsafe fn ZSTD_cwksp_slack_space_required() -> usize {
+    (ZSTD_CWKSP_ALIGNMENT_BYTES * 2) as usize
 }
 #[inline]
-unsafe fn ZSTD_cwksp_bytes_to_align_ptr(ptr: *mut core::ffi::c_void, alignBytes: size_t) -> size_t {
+unsafe fn ZSTD_cwksp_bytes_to_align_ptr(ptr: *mut core::ffi::c_void, alignBytes: usize) -> usize {
     let alignBytesMask = alignBytes.wrapping_sub(1);
 
-    alignBytes.wrapping_sub(ptr as size_t & alignBytesMask) & alignBytesMask
+    alignBytes.wrapping_sub(ptr as usize & alignBytesMask) & alignBytesMask
 }
 #[inline]
 unsafe fn ZSTD_cwksp_initialAllocStart(ws: *mut ZSTD_cwksp) -> *mut core::ffi::c_void {
     let mut endPtr = (*ws).workspaceEnd as *mut core::ffi::c_char;
-    endPtr = endPtr.offset(-((endPtr as size_t % ZSTD_CWKSP_ALIGNMENT_BYTES as size_t) as isize));
+    endPtr = endPtr.offset(-((endPtr as usize % ZSTD_CWKSP_ALIGNMENT_BYTES as usize) as isize));
     endPtr as *mut core::ffi::c_void
 }
 #[inline]
 unsafe fn ZSTD_cwksp_reserve_internal_buffer_space(
     ws: *mut ZSTD_cwksp,
-    bytes: size_t,
+    bytes: usize,
 ) -> *mut core::ffi::c_void {
     let alloc = ((*ws).allocStart as *mut u8).offset(-(bytes as isize)) as *mut core::ffi::c_void;
     let bottom = (*ws).tableEnd;
@@ -1032,7 +1032,7 @@ unsafe fn ZSTD_cwksp_reserve_internal_buffer_space(
 unsafe fn ZSTD_cwksp_internal_advance_phase(
     ws: *mut ZSTD_cwksp,
     phase: ZSTD_cwksp_alloc_phase_e,
-) -> size_t {
+) -> usize {
     if phase as core::ffi::c_uint > (*ws).phase as core::ffi::c_uint {
         if ((*ws).phase as core::ffi::c_uint)
             < ZSTD_cwksp_alloc_aligned_init_once as core::ffi::c_int as core::ffi::c_uint
@@ -1043,7 +1043,7 @@ unsafe fn ZSTD_cwksp_internal_advance_phase(
             (*ws).initOnceStart = ZSTD_cwksp_initialAllocStart(ws);
             let alloc = (*ws).objectEnd;
             let bytesToAlign =
-                ZSTD_cwksp_bytes_to_align_ptr(alloc, ZSTD_CWKSP_ALIGNMENT_BYTES as size_t);
+                ZSTD_cwksp_bytes_to_align_ptr(alloc, ZSTD_CWKSP_ALIGNMENT_BYTES as usize);
             let objectEnd = (alloc as *mut u8).add(bytesToAlign) as *mut core::ffi::c_void;
             if objectEnd > (*ws).workspaceEnd {
                 return Error::memory_allocation.to_error_code();
@@ -1071,7 +1071,7 @@ unsafe fn ZSTD_cwksp_owns_buffer(
 #[inline]
 unsafe fn ZSTD_cwksp_reserve_internal(
     ws: *mut ZSTD_cwksp,
-    bytes: size_t,
+    bytes: usize,
     phase: ZSTD_cwksp_alloc_phase_e,
 ) -> *mut core::ffi::c_void {
     let mut alloc = core::ptr::null_mut::<core::ffi::c_void>();
@@ -1082,29 +1082,29 @@ unsafe fn ZSTD_cwksp_reserve_internal(
     alloc
 }
 #[inline]
-unsafe fn ZSTD_cwksp_reserve_buffer(ws: *mut ZSTD_cwksp, bytes: size_t) -> *mut u8 {
+unsafe fn ZSTD_cwksp_reserve_buffer(ws: *mut ZSTD_cwksp, bytes: usize) -> *mut u8 {
     ZSTD_cwksp_reserve_internal(ws, bytes, ZSTD_cwksp_alloc_buffers) as *mut u8
 }
 #[inline]
 unsafe fn ZSTD_cwksp_reserve_aligned_init_once(
     ws: *mut ZSTD_cwksp,
-    bytes: size_t,
+    bytes: usize,
 ) -> *mut core::ffi::c_void {
-    let alignedBytes = ZSTD_cwksp_align(bytes, ZSTD_CWKSP_ALIGNMENT_BYTES as size_t);
+    let alignedBytes = ZSTD_cwksp_align(bytes, ZSTD_CWKSP_ALIGNMENT_BYTES as usize);
     let ptr = ZSTD_cwksp_reserve_internal(ws, alignedBytes, ZSTD_cwksp_alloc_aligned_init_once);
     if !ptr.is_null() && ptr < (*ws).initOnceStart {
         ptr::write_bytes(
             ptr as *mut u8,
             0,
             (if (((*ws).initOnceStart as *mut u8).offset_from(ptr as *mut u8) as core::ffi::c_long
-                as size_t)
+                as usize)
                 < alignedBytes
             {
                 ((*ws).initOnceStart as *mut u8).offset_from(ptr as *mut u8) as core::ffi::c_long
-                    as size_t
+                    as usize
             } else {
                 alignedBytes
-            }) as libc::size_t,
+            }) as usize,
         );
         (*ws).initOnceStart = ptr;
     }
@@ -1113,16 +1113,16 @@ unsafe fn ZSTD_cwksp_reserve_aligned_init_once(
 #[inline]
 unsafe fn ZSTD_cwksp_reserve_aligned64(
     ws: *mut ZSTD_cwksp,
-    bytes: size_t,
+    bytes: usize,
 ) -> *mut core::ffi::c_void {
     ZSTD_cwksp_reserve_internal(
         ws,
-        ZSTD_cwksp_align(bytes, ZSTD_CWKSP_ALIGNMENT_BYTES as size_t),
+        ZSTD_cwksp_align(bytes, ZSTD_CWKSP_ALIGNMENT_BYTES as usize),
         ZSTD_cwksp_alloc_aligned,
     )
 }
 #[inline]
-unsafe fn ZSTD_cwksp_reserve_table(ws: *mut ZSTD_cwksp, bytes: size_t) -> *mut core::ffi::c_void {
+unsafe fn ZSTD_cwksp_reserve_table(ws: *mut ZSTD_cwksp, bytes: usize) -> *mut core::ffi::c_void {
     let phase = ZSTD_cwksp_alloc_aligned_init_once;
     let mut alloc = core::ptr::null_mut::<core::ffi::c_void>();
     let mut end = core::ptr::null_mut::<core::ffi::c_void>();
@@ -1144,7 +1144,7 @@ unsafe fn ZSTD_cwksp_reserve_table(ws: *mut ZSTD_cwksp, bytes: size_t) -> *mut c
     alloc
 }
 #[inline]
-unsafe fn ZSTD_cwksp_reserve_object(ws: *mut ZSTD_cwksp, bytes: size_t) -> *mut core::ffi::c_void {
+unsafe fn ZSTD_cwksp_reserve_object(ws: *mut ZSTD_cwksp, bytes: usize) -> *mut core::ffi::c_void {
     let roundedBytes = ZSTD_cwksp_align(bytes, ::core::mem::size_of::<*mut core::ffi::c_void>());
     let alloc = (*ws).objectEnd;
     let end = (alloc as *mut u8).add(roundedBytes) as *mut core::ffi::c_void;
@@ -1202,15 +1202,15 @@ unsafe fn ZSTD_cwksp_clear(ws: *mut ZSTD_cwksp) {
     ZSTD_cwksp_assert_internal_consistency(ws);
 }
 #[inline]
-unsafe fn ZSTD_cwksp_sizeof(ws: *const ZSTD_cwksp) -> size_t {
+unsafe fn ZSTD_cwksp_sizeof(ws: *const ZSTD_cwksp) -> usize {
     ((*ws).workspaceEnd as *mut u8).offset_from((*ws).workspace as *mut u8) as core::ffi::c_long
-        as size_t
+        as usize
 }
 #[inline]
 unsafe fn ZSTD_cwksp_init(
     ws: *mut ZSTD_cwksp,
     start: *mut core::ffi::c_void,
-    size: size_t,
+    size: usize,
     isStatic: ZSTD_cwksp_static_alloc_e,
 ) {
     (*ws).workspace = start;
@@ -1225,11 +1225,7 @@ unsafe fn ZSTD_cwksp_init(
     ZSTD_cwksp_assert_internal_consistency(ws);
 }
 #[inline]
-unsafe fn ZSTD_cwksp_create(
-    ws: *mut ZSTD_cwksp,
-    size: size_t,
-    customMem: ZSTD_customMem,
-) -> size_t {
+unsafe fn ZSTD_cwksp_create(ws: *mut ZSTD_cwksp, size: usize, customMem: ZSTD_customMem) -> usize {
     let workspace = ZSTD_customMalloc(size, customMem);
     if workspace.is_null() {
         return Error::memory_allocation.to_error_code();
@@ -1256,38 +1252,38 @@ unsafe fn ZSTD_cwksp_reserve_failed(ws: *const ZSTD_cwksp) -> core::ffi::c_int {
     (*ws).allocFailed as core::ffi::c_int
 }
 #[inline]
-unsafe fn ZSTD_cwksp_available_space(ws: *mut ZSTD_cwksp) -> size_t {
+unsafe fn ZSTD_cwksp_available_space(ws: *mut ZSTD_cwksp) -> usize {
     ((*ws).allocStart as *mut u8).offset_from((*ws).tableEnd as *mut u8) as core::ffi::c_long
-        as size_t
+        as usize
 }
 #[inline]
 unsafe fn ZSTD_cwksp_check_available(
     ws: *mut ZSTD_cwksp,
-    additionalNeededSpace: size_t,
+    additionalNeededSpace: usize,
 ) -> core::ffi::c_int {
     (ZSTD_cwksp_available_space(ws) >= additionalNeededSpace) as core::ffi::c_int
 }
 #[inline]
 unsafe fn ZSTD_cwksp_check_too_large(
     ws: *mut ZSTD_cwksp,
-    additionalNeededSpace: size_t,
+    additionalNeededSpace: usize,
 ) -> core::ffi::c_int {
     ZSTD_cwksp_check_available(
         ws,
-        additionalNeededSpace * ZSTD_WORKSPACETOOLARGE_FACTOR as size_t,
+        additionalNeededSpace * ZSTD_WORKSPACETOOLARGE_FACTOR as usize,
     )
 }
 #[inline]
 unsafe fn ZSTD_cwksp_check_wasteful(
     ws: *mut ZSTD_cwksp,
-    additionalNeededSpace: size_t,
+    additionalNeededSpace: usize,
 ) -> core::ffi::c_int {
     (ZSTD_cwksp_check_too_large(ws, additionalNeededSpace) != 0
         && (*ws).workspaceOversizedDuration > ZSTD_WORKSPACETOOLARGE_MAXDURATION)
         as core::ffi::c_int
 }
 #[inline]
-unsafe fn ZSTD_cwksp_bump_oversized_duration(ws: *mut ZSTD_cwksp, additionalNeededSpace: size_t) {
+unsafe fn ZSTD_cwksp_bump_oversized_duration(ws: *mut ZSTD_cwksp, additionalNeededSpace: usize) {
     if ZSTD_cwksp_check_too_large(ws, additionalNeededSpace) != 0 {
         (*ws).workspaceOversizedDuration += 1;
     } else {
@@ -1303,22 +1299,22 @@ pub const ZSTD_COMPRESSBLOCK_DOUBLEFAST: unsafe fn(
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_doubleFast;
+    usize,
+) -> usize = ZSTD_compressBlock_doubleFast;
 pub const ZSTD_COMPRESSBLOCK_DOUBLEFAST_DICTMATCHSTATE: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_doubleFast_dictMatchState;
+    usize,
+) -> usize = ZSTD_compressBlock_doubleFast_dictMatchState;
 pub const ZSTD_COMPRESSBLOCK_DOUBLEFAST_EXTDICT: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_doubleFast_extDict;
+    usize,
+) -> usize = ZSTD_compressBlock_doubleFast_extDict;
 pub const ZSTD_LAZY_DDSS_BUCKET_LOG: core::ffi::c_int = 2;
 pub const ZSTD_ROW_HASH_TAG_BITS: core::ffi::c_int = 8;
 pub const ZSTD_COMPRESSBLOCK_GREEDY: unsafe fn(
@@ -1326,245 +1322,245 @@ pub const ZSTD_COMPRESSBLOCK_GREEDY: unsafe fn(
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_greedy;
+    usize,
+) -> usize = ZSTD_compressBlock_greedy;
 pub const ZSTD_COMPRESSBLOCK_GREEDY_ROW: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_greedy_row;
+    usize,
+) -> usize = ZSTD_compressBlock_greedy_row;
 pub const ZSTD_COMPRESSBLOCK_GREEDY_DICTMATCHSTATE: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_greedy_dictMatchState;
+    usize,
+) -> usize = ZSTD_compressBlock_greedy_dictMatchState;
 pub const ZSTD_COMPRESSBLOCK_GREEDY_DICTMATCHSTATE_ROW: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_greedy_dictMatchState_row;
+    usize,
+) -> usize = ZSTD_compressBlock_greedy_dictMatchState_row;
 pub const ZSTD_COMPRESSBLOCK_GREEDY_DEDICATEDDICTSEARCH: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_greedy_dedicatedDictSearch;
+    usize,
+) -> usize = ZSTD_compressBlock_greedy_dedicatedDictSearch;
 pub const ZSTD_COMPRESSBLOCK_GREEDY_DEDICATEDDICTSEARCH_ROW: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_greedy_dedicatedDictSearch_row;
+    usize,
+) -> usize = ZSTD_compressBlock_greedy_dedicatedDictSearch_row;
 pub const ZSTD_COMPRESSBLOCK_GREEDY_EXTDICT: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_greedy_extDict;
+    usize,
+) -> usize = ZSTD_compressBlock_greedy_extDict;
 pub const ZSTD_COMPRESSBLOCK_GREEDY_EXTDICT_ROW: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_greedy_extDict_row;
+    usize,
+) -> usize = ZSTD_compressBlock_greedy_extDict_row;
 pub const ZSTD_COMPRESSBLOCK_LAZY: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_lazy;
+    usize,
+) -> usize = ZSTD_compressBlock_lazy;
 pub const ZSTD_COMPRESSBLOCK_LAZY_ROW: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_lazy_row;
+    usize,
+) -> usize = ZSTD_compressBlock_lazy_row;
 pub const ZSTD_COMPRESSBLOCK_LAZY_DICTMATCHSTATE: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_lazy_dictMatchState;
+    usize,
+) -> usize = ZSTD_compressBlock_lazy_dictMatchState;
 pub const ZSTD_COMPRESSBLOCK_LAZY_DICTMATCHSTATE_ROW: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_lazy_dictMatchState_row;
+    usize,
+) -> usize = ZSTD_compressBlock_lazy_dictMatchState_row;
 pub const ZSTD_COMPRESSBLOCK_LAZY_DEDICATEDDICTSEARCH: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_lazy_dedicatedDictSearch;
+    usize,
+) -> usize = ZSTD_compressBlock_lazy_dedicatedDictSearch;
 pub const ZSTD_COMPRESSBLOCK_LAZY_DEDICATEDDICTSEARCH_ROW: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_lazy_dedicatedDictSearch_row;
+    usize,
+) -> usize = ZSTD_compressBlock_lazy_dedicatedDictSearch_row;
 pub const ZSTD_COMPRESSBLOCK_LAZY_EXTDICT: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_lazy_extDict;
+    usize,
+) -> usize = ZSTD_compressBlock_lazy_extDict;
 pub const ZSTD_COMPRESSBLOCK_LAZY_EXTDICT_ROW: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_lazy_extDict_row;
+    usize,
+) -> usize = ZSTD_compressBlock_lazy_extDict_row;
 pub const ZSTD_COMPRESSBLOCK_LAZY2: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_lazy2;
+    usize,
+) -> usize = ZSTD_compressBlock_lazy2;
 pub const ZSTD_COMPRESSBLOCK_LAZY2_ROW: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_lazy2_row;
+    usize,
+) -> usize = ZSTD_compressBlock_lazy2_row;
 pub const ZSTD_COMPRESSBLOCK_LAZY2_DICTMATCHSTATE: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_lazy2_dictMatchState;
+    usize,
+) -> usize = ZSTD_compressBlock_lazy2_dictMatchState;
 pub const ZSTD_COMPRESSBLOCK_LAZY2_DICTMATCHSTATE_ROW: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_lazy2_dictMatchState_row;
+    usize,
+) -> usize = ZSTD_compressBlock_lazy2_dictMatchState_row;
 pub const ZSTD_COMPRESSBLOCK_LAZY2_DEDICATEDDICTSEARCH: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_lazy2_dedicatedDictSearch;
+    usize,
+) -> usize = ZSTD_compressBlock_lazy2_dedicatedDictSearch;
 pub const ZSTD_COMPRESSBLOCK_LAZY2_DEDICATEDDICTSEARCH_ROW: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_lazy2_dedicatedDictSearch_row;
+    usize,
+) -> usize = ZSTD_compressBlock_lazy2_dedicatedDictSearch_row;
 pub const ZSTD_COMPRESSBLOCK_LAZY2_EXTDICT: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_lazy2_extDict;
+    usize,
+) -> usize = ZSTD_compressBlock_lazy2_extDict;
 pub const ZSTD_COMPRESSBLOCK_LAZY2_EXTDICT_ROW: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_lazy2_extDict_row;
+    usize,
+) -> usize = ZSTD_compressBlock_lazy2_extDict_row;
 pub const ZSTD_COMPRESSBLOCK_BTLAZY2: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_btlazy2;
+    usize,
+) -> usize = ZSTD_compressBlock_btlazy2;
 pub const ZSTD_COMPRESSBLOCK_BTLAZY2_DICTMATCHSTATE: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_btlazy2_dictMatchState;
+    usize,
+) -> usize = ZSTD_compressBlock_btlazy2_dictMatchState;
 pub const ZSTD_COMPRESSBLOCK_BTLAZY2_EXTDICT: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_btlazy2_extDict;
+    usize,
+) -> usize = ZSTD_compressBlock_btlazy2_extDict;
 pub const ZSTD_COMPRESSBLOCK_BTOPT: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_btopt;
+    usize,
+) -> usize = ZSTD_compressBlock_btopt;
 pub const ZSTD_COMPRESSBLOCK_BTOPT_DICTMATCHSTATE: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_btopt_dictMatchState;
+    usize,
+) -> usize = ZSTD_compressBlock_btopt_dictMatchState;
 pub const ZSTD_COMPRESSBLOCK_BTOPT_EXTDICT: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_btopt_extDict;
+    usize,
+) -> usize = ZSTD_compressBlock_btopt_extDict;
 pub const ZSTD_COMPRESSBLOCK_BTULTRA: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_btultra;
+    usize,
+) -> usize = ZSTD_compressBlock_btultra;
 pub const ZSTD_COMPRESSBLOCK_BTULTRA_DICTMATCHSTATE: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_btultra_dictMatchState;
+    usize,
+) -> usize = ZSTD_compressBlock_btultra_dictMatchState;
 pub const ZSTD_COMPRESSBLOCK_BTULTRA_EXTDICT: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_btultra_extDict;
+    usize,
+) -> usize = ZSTD_compressBlock_btultra_extDict;
 pub const ZSTD_COMPRESSBLOCK_BTULTRA2: unsafe fn(
     &mut ZSTD_MatchState_t,
     &mut SeqStore_t,
     *mut u32,
     *const core::ffi::c_void,
-    size_t,
-) -> size_t = ZSTD_compressBlock_btultra2;
+    usize,
+) -> usize = ZSTD_compressBlock_btultra2;
 pub const ZSTD_LDM_DEFAULT_WINDOW_LOG: core::ffi::c_int = 27;
 pub const INT_MAX: core::ffi::c_int = __INT_MAX__;
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_compressBound))]
-pub extern "C" fn ZSTD_compressBound(srcSize: size_t) -> size_t {
+pub extern "C" fn ZSTD_compressBound(srcSize: usize) -> usize {
     let r = if srcSize as core::ffi::c_ulonglong
-        >= (if ::core::mem::size_of::<size_t>() == 8 {
+        >= (if ::core::mem::size_of::<usize>() == 8 {
             0xff00ff00ff00ff00 as core::ffi::c_ulonglong
         } else {
             0xff00ff00 as core::ffi::c_uint as core::ffi::c_ulonglong
@@ -1573,8 +1569,8 @@ pub extern "C" fn ZSTD_compressBound(srcSize: size_t) -> size_t {
     } else {
         srcSize
             .wrapping_add(srcSize >> 8)
-            .wrapping_add(if srcSize < ((128) << 10) as size_t {
-                (((128) << 10) as size_t).wrapping_sub(srcSize) >> 11
+            .wrapping_add(if srcSize < ((128) << 10) as usize {
+                (((128) << 10) as usize).wrapping_sub(srcSize) >> 11
             } else {
                 0
             })
@@ -1606,7 +1602,7 @@ pub unsafe extern "C" fn ZSTD_createCCtx_advanced(customMem: ZSTD_customMem) -> 
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_initStaticCCtx))]
 pub unsafe extern "C" fn ZSTD_initStaticCCtx(
     workspace: *mut core::ffi::c_void,
-    workspaceSize: size_t,
+    workspaceSize: usize,
 ) -> *mut ZSTD_CCtx {
     let mut ws = ZSTD_cwksp {
         workspace: core::ptr::null_mut::<core::ffi::c_void>(),
@@ -1625,7 +1621,7 @@ pub unsafe extern "C" fn ZSTD_initStaticCCtx(
     if workspaceSize <= ::core::mem::size_of::<ZSTD_CCtx>() {
         return core::ptr::null_mut();
     }
-    if workspace as size_t & 7 != 0 {
+    if workspace as usize & 7 != 0 {
         return core::ptr::null_mut();
     }
     ZSTD_cwksp_init(&mut ws, workspace, workspaceSize, ZSTD_cwksp_static_alloc);
@@ -1639,20 +1635,20 @@ pub unsafe extern "C" fn ZSTD_initStaticCCtx(
     (*cctx).staticSize = workspaceSize;
     if ZSTD_cwksp_check_available(
         &mut (*cctx).workspace,
-        (if ((((8) << 10) + 512) as size_t).wrapping_add(
+        (if ((((8) << 10) + 512) as usize).wrapping_add(
             (::core::mem::size_of::<core::ffi::c_uint>())
-                .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
+                .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as usize),
         ) > 8208
         {
-            ((((8) << 10) + 512) as size_t).wrapping_add(
+            ((((8) << 10) + 512) as usize).wrapping_add(
                 (::core::mem::size_of::<core::ffi::c_uint>())
-                    .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
+                    .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as usize),
             )
         } else {
             8208
         })
         .wrapping_add(
-            (2 as size_t).wrapping_mul(::core::mem::size_of::<ZSTD_compressedBlockState_t>()),
+            (2 as usize).wrapping_mul(::core::mem::size_of::<ZSTD_compressedBlockState_t>()),
         ),
     ) == 0
     {
@@ -1668,27 +1664,27 @@ pub unsafe extern "C" fn ZSTD_initStaticCCtx(
     ) as *mut ZSTD_compressedBlockState_t;
     (*cctx).tmpWorkspace = ZSTD_cwksp_reserve_object(
         &mut (*cctx).workspace,
-        if ((((8) << 10) + 512) as size_t).wrapping_add(
+        if ((((8) << 10) + 512) as usize).wrapping_add(
             (::core::mem::size_of::<core::ffi::c_uint>())
-                .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
+                .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as usize),
         ) > 8208
         {
-            ((((8) << 10) + 512) as size_t).wrapping_add(
+            ((((8) << 10) + 512) as usize).wrapping_add(
                 (::core::mem::size_of::<core::ffi::c_uint>())
-                    .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
+                    .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as usize),
             )
         } else {
             8208
         },
     );
-    (*cctx).tmpWkspSize = if ((((8) << 10) + 512) as size_t).wrapping_add(
+    (*cctx).tmpWkspSize = if ((((8) << 10) + 512) as usize).wrapping_add(
         (::core::mem::size_of::<core::ffi::c_uint>())
-            .wrapping_mul(((if 35 > 52 as core::ffi::c_int { 35 } else { 52 }) + 2) as size_t),
-    ) > 8208 as size_t
+            .wrapping_mul(((if 35 > 52 as core::ffi::c_int { 35 } else { 52 }) + 2) as usize),
+    ) > 8208 as usize
     {
-        ((((8) << 10) + 512) as size_t).wrapping_add(
+        ((((8) << 10) + 512) as usize).wrapping_add(
             (::core::mem::size_of::<core::ffi::c_uint>())
-                .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
+                .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as usize),
         )
     } else {
         8208
@@ -1715,7 +1711,7 @@ unsafe fn ZSTD_clearAllDicts(cctx: *mut ZSTD_CCtx) {
     );
     (*cctx).cdict = core::ptr::null();
 }
-unsafe fn ZSTD_sizeof_localDict(dict: ZSTD_localDict) -> size_t {
+unsafe fn ZSTD_sizeof_localDict(dict: ZSTD_localDict) -> usize {
     let bufferSize = if !(dict.dictBuffer).is_null() {
         dict.dictSize
     } else {
@@ -1731,7 +1727,7 @@ unsafe fn ZSTD_freeCCtxContent(cctx: *mut ZSTD_CCtx) {
     ZSTD_cwksp_free(&mut (*cctx).workspace, (*cctx).customMem);
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_freeCCtx))]
-pub unsafe extern "C" fn ZSTD_freeCCtx(cctx: *mut ZSTD_CCtx) -> size_t {
+pub unsafe extern "C" fn ZSTD_freeCCtx(cctx: *mut ZSTD_CCtx) -> usize {
     if cctx.is_null() {
         return 0;
     }
@@ -1750,11 +1746,11 @@ pub unsafe extern "C" fn ZSTD_freeCCtx(cctx: *mut ZSTD_CCtx) -> size_t {
     }
     0
 }
-unsafe fn ZSTD_sizeof_mtctx(cctx: *const ZSTD_CCtx) -> size_t {
+unsafe fn ZSTD_sizeof_mtctx(cctx: *const ZSTD_CCtx) -> usize {
     ZSTDMT_sizeof_CCtx((*cctx).mtctx)
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_sizeof_CCtx))]
-pub unsafe extern "C" fn ZSTD_sizeof_CCtx(cctx: *const ZSTD_CCtx) -> size_t {
+pub unsafe extern "C" fn ZSTD_sizeof_CCtx(cctx: *const ZSTD_CCtx) -> usize {
     if cctx.is_null() {
         return 0;
     }
@@ -1768,7 +1764,7 @@ pub unsafe extern "C" fn ZSTD_sizeof_CCtx(cctx: *const ZSTD_CCtx) -> size_t {
     .wrapping_add(ZSTD_sizeof_mtctx(cctx))
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_sizeof_CStream))]
-pub unsafe extern "C" fn ZSTD_sizeof_CStream(zcs: *const ZSTD_CStream) -> size_t {
+pub unsafe extern "C" fn ZSTD_sizeof_CStream(zcs: *const ZSTD_CStream) -> usize {
     ZSTD_sizeof_CCtx(zcs)
 }
 pub unsafe fn ZSTD_getSeqStore(ctx: *const ZSTD_CCtx) -> *const SeqStore_t {
@@ -1847,9 +1843,9 @@ unsafe fn ZSTD_resolveEnableLdm(
 unsafe fn ZSTD_resolveExternalSequenceValidation(mode: core::ffi::c_int) -> core::ffi::c_int {
     mode
 }
-unsafe fn ZSTD_resolveMaxBlockSize(maxBlockSize: size_t) -> size_t {
+unsafe fn ZSTD_resolveMaxBlockSize(maxBlockSize: usize) -> usize {
     if maxBlockSize == 0 {
-        ZSTD_BLOCKSIZE_MAX as size_t
+        ZSTD_BLOCKSIZE_MAX as usize
     } else {
         maxBlockSize
     }
@@ -1961,7 +1957,7 @@ pub unsafe extern "C" fn ZSTD_createCCtxParams() -> *mut ZSTD_CCtx_params {
     ZSTD_createCCtxParams_advanced(ZSTD_customMem::default())
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_freeCCtxParams))]
-pub unsafe extern "C" fn ZSTD_freeCCtxParams(params: *mut ZSTD_CCtx_params) -> size_t {
+pub unsafe extern "C" fn ZSTD_freeCCtxParams(params: *mut ZSTD_CCtx_params) -> usize {
     if params.is_null() {
         return 0;
     }
@@ -1973,14 +1969,14 @@ pub unsafe extern "C" fn ZSTD_freeCCtxParams(params: *mut ZSTD_CCtx_params) -> s
     0
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_CCtxParams_reset))]
-pub unsafe extern "C" fn ZSTD_CCtxParams_reset(params: *mut ZSTD_CCtx_params) -> size_t {
+pub unsafe extern "C" fn ZSTD_CCtxParams_reset(params: *mut ZSTD_CCtx_params) -> usize {
     ZSTD_CCtxParams_init(params, ZSTD_CLEVEL_DEFAULT)
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_CCtxParams_init))]
 pub unsafe extern "C" fn ZSTD_CCtxParams_init(
     cctxParams: *mut ZSTD_CCtx_params,
     compressionLevel: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     if cctxParams.is_null() {
         return Error::GENERIC.to_error_code();
     }
@@ -2025,7 +2021,7 @@ unsafe fn ZSTD_CCtxParams_init_internal(
 pub unsafe extern "C" fn ZSTD_CCtxParams_init_advanced(
     cctxParams: *mut ZSTD_CCtx_params,
     params: ZSTD_parameters,
-) -> size_t {
+) -> usize {
     if cctxParams.is_null() {
         return Error::GENERIC.to_error_code();
     }
@@ -2061,7 +2057,7 @@ pub unsafe extern "C" fn ZSTD_cParam_getBounds(param: ZSTD_cParameter) -> ZSTD_b
         }
         101 => {
             bounds.lowerBound = ZSTD_WINDOWLOG_MIN;
-            bounds.upperBound = if ::core::mem::size_of::<size_t>() == 4 {
+            bounds.upperBound = if ::core::mem::size_of::<usize>() == 4 {
                 ZSTD_WINDOWLOG_MAX_32
             } else {
                 ZSTD_WINDOWLOG_MAX_64
@@ -2070,13 +2066,13 @@ pub unsafe extern "C" fn ZSTD_cParam_getBounds(param: ZSTD_cParameter) -> ZSTD_b
         }
         102 => {
             bounds.lowerBound = ZSTD_HASHLOG_MIN;
-            bounds.upperBound = if (if ::core::mem::size_of::<size_t>() == 4 {
+            bounds.upperBound = if (if ::core::mem::size_of::<usize>() == 4 {
                 ZSTD_WINDOWLOG_MAX_32
             } else {
                 ZSTD_WINDOWLOG_MAX_64
             }) < 30
             {
-                if ::core::mem::size_of::<size_t>() == 4 {
+                if ::core::mem::size_of::<usize>() == 4 {
                     ZSTD_WINDOWLOG_MAX_32
                 } else {
                     ZSTD_WINDOWLOG_MAX_64
@@ -2088,7 +2084,7 @@ pub unsafe extern "C" fn ZSTD_cParam_getBounds(param: ZSTD_cParameter) -> ZSTD_b
         }
         103 => {
             bounds.lowerBound = ZSTD_CHAINLOG_MIN;
-            bounds.upperBound = if ::core::mem::size_of::<size_t>() == 4 {
+            bounds.upperBound = if ::core::mem::size_of::<usize>() == 4 {
                 ZSTD_CHAINLOG_MAX_32
             } else {
                 ZSTD_CHAINLOG_MAX_64
@@ -2097,7 +2093,7 @@ pub unsafe extern "C" fn ZSTD_cParam_getBounds(param: ZSTD_cParameter) -> ZSTD_b
         }
         104 => {
             bounds.lowerBound = ZSTD_SEARCHLOG_MIN;
-            bounds.upperBound = (if ::core::mem::size_of::<size_t>() == 4 {
+            bounds.upperBound = (if ::core::mem::size_of::<usize>() == 4 {
                 ZSTD_WINDOWLOG_MAX_32
             } else {
                 ZSTD_WINDOWLOG_MAX_64
@@ -2169,13 +2165,13 @@ pub unsafe extern "C" fn ZSTD_cParam_getBounds(param: ZSTD_cParameter) -> ZSTD_b
         }
         161 => {
             bounds.lowerBound = ZSTD_LDM_HASHLOG_MIN;
-            bounds.upperBound = if (if ::core::mem::size_of::<size_t>() == 4 {
+            bounds.upperBound = if (if ::core::mem::size_of::<usize>() == 4 {
                 ZSTD_WINDOWLOG_MAX_32
             } else {
                 ZSTD_WINDOWLOG_MAX_64
             }) < 30
             {
-                if ::core::mem::size_of::<size_t>() == 4 {
+                if ::core::mem::size_of::<usize>() == 4 {
                     ZSTD_WINDOWLOG_MAX_32
                 } else {
                     ZSTD_WINDOWLOG_MAX_64
@@ -2197,7 +2193,7 @@ pub unsafe extern "C" fn ZSTD_cParam_getBounds(param: ZSTD_cParameter) -> ZSTD_b
         }
         164 => {
             bounds.lowerBound = ZSTD_LDM_HASHRATELOG_MIN;
-            bounds.upperBound = (if ::core::mem::size_of::<size_t>() == 4 {
+            bounds.upperBound = (if ::core::mem::size_of::<usize>() == 4 {
                 ZSTD_WINDOWLOG_MAX_32
             } else {
                 ZSTD_WINDOWLOG_MAX_64
@@ -2300,7 +2296,7 @@ pub unsafe extern "C" fn ZSTD_cParam_getBounds(param: ZSTD_cParameter) -> ZSTD_b
         }
     }
 }
-unsafe fn ZSTD_cParam_clampBounds(cParam: ZSTD_cParameter, value: *mut core::ffi::c_int) -> size_t {
+unsafe fn ZSTD_cParam_clampBounds(cParam: ZSTD_cParameter, value: *mut core::ffi::c_int) -> usize {
     let bounds = ZSTD_cParam_getBounds(cParam);
     if ERR_isError(bounds.error) {
         return bounds.error;
@@ -2333,7 +2329,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_setParameter(
     cctx: *mut ZSTD_CCtx,
     param: ZSTD_cParameter,
     value: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     if (*cctx).streamStage != zcss_init {
         if ZSTD_isUpdateAuthorized(param) != 0 {
             (*cctx).cParamsChanged = 1;
@@ -2400,7 +2396,7 @@ pub unsafe extern "C" fn ZSTD_CCtxParams_setParameter(
     CCtxParams: *mut ZSTD_CCtx_params,
     param: ZSTD_cParameter,
     mut value: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     match param.0 {
         10 => {
             let Ok(format) = Format::try_from(value) else {
@@ -2408,7 +2404,7 @@ pub unsafe extern "C" fn ZSTD_CCtxParams_setParameter(
             };
 
             (*CCtxParams).format = format;
-            (*CCtxParams).format as size_t
+            (*CCtxParams).format as usize
         }
         100 => {
             let err_code = ZSTD_cParam_clampBounds(param, &mut value);
@@ -2421,7 +2417,7 @@ pub unsafe extern "C" fn ZSTD_CCtxParams_setParameter(
                 (*CCtxParams).compressionLevel = value;
             }
             if (*CCtxParams).compressionLevel >= 0 {
-                return (*CCtxParams).compressionLevel as size_t;
+                return (*CCtxParams).compressionLevel as usize;
             }
             0
         }
@@ -2431,14 +2427,14 @@ pub unsafe extern "C" fn ZSTD_CCtxParams_setParameter(
                 return Error::parameter_outOfBound.to_error_code();
             }
             (*CCtxParams).cParams.windowLog = value as u32;
-            (*CCtxParams).cParams.windowLog as size_t
+            (*CCtxParams).cParams.windowLog as usize
         }
         102 => {
             if value != 0 && ZSTD_cParam_withinBounds(ZSTD_cParameter::ZSTD_c_hashLog, value) == 0 {
                 return Error::parameter_outOfBound.to_error_code();
             }
             (*CCtxParams).cParams.hashLog = value as u32;
-            (*CCtxParams).cParams.hashLog as size_t
+            (*CCtxParams).cParams.hashLog as usize
         }
         103 => {
             if value != 0 && ZSTD_cParam_withinBounds(ZSTD_cParameter::ZSTD_c_chainLog, value) == 0
@@ -2446,7 +2442,7 @@ pub unsafe extern "C" fn ZSTD_CCtxParams_setParameter(
                 return Error::parameter_outOfBound.to_error_code();
             }
             (*CCtxParams).cParams.chainLog = value as u32;
-            (*CCtxParams).cParams.chainLog as size_t
+            (*CCtxParams).cParams.chainLog as usize
         }
         104 => {
             if value != 0 && ZSTD_cParam_withinBounds(ZSTD_cParameter::ZSTD_c_searchLog, value) == 0
@@ -2454,7 +2450,7 @@ pub unsafe extern "C" fn ZSTD_CCtxParams_setParameter(
                 return Error::parameter_outOfBound.to_error_code();
             }
             (*CCtxParams).cParams.searchLog = value as u32;
-            value as size_t
+            value as usize
         }
         105 => {
             if value != 0 && ZSTD_cParam_withinBounds(ZSTD_cParameter::ZSTD_c_minMatch, value) == 0
@@ -2462,14 +2458,14 @@ pub unsafe extern "C" fn ZSTD_CCtxParams_setParameter(
                 return Error::parameter_outOfBound.to_error_code();
             }
             (*CCtxParams).cParams.minMatch = value as u32;
-            (*CCtxParams).cParams.minMatch as size_t
+            (*CCtxParams).cParams.minMatch as usize
         }
         106 => {
             if ZSTD_cParam_withinBounds(ZSTD_cParameter::ZSTD_c_targetLength, value) == 0 {
                 return Error::parameter_outOfBound.to_error_code();
             }
             (*CCtxParams).cParams.targetLength = value as u32;
-            (*CCtxParams).cParams.targetLength as size_t
+            (*CCtxParams).cParams.targetLength as usize
         }
         107 => {
             if value != 0 && ZSTD_cParam_withinBounds(ZSTD_cParameter::ZSTD_c_strategy, value) == 0
@@ -2477,37 +2473,37 @@ pub unsafe extern "C" fn ZSTD_CCtxParams_setParameter(
                 return Error::parameter_outOfBound.to_error_code();
             }
             (*CCtxParams).cParams.strategy = value as ZSTD_strategy;
-            (*CCtxParams).cParams.strategy as size_t
+            (*CCtxParams).cParams.strategy as usize
         }
         200 => {
             (*CCtxParams).fParams.contentSizeFlag = (value != 0) as core::ffi::c_int;
-            (*CCtxParams).fParams.contentSizeFlag as size_t
+            (*CCtxParams).fParams.contentSizeFlag as usize
         }
         201 => {
             (*CCtxParams).fParams.checksumFlag = (value != 0) as core::ffi::c_int;
-            (*CCtxParams).fParams.checksumFlag as size_t
+            (*CCtxParams).fParams.checksumFlag as usize
         }
         202 => {
             (*CCtxParams).fParams.noDictIDFlag = (value == 0) as core::ffi::c_int;
-            ((*CCtxParams).fParams.noDictIDFlag == 0) as core::ffi::c_int as size_t
+            ((*CCtxParams).fParams.noDictIDFlag == 0) as core::ffi::c_int as usize
         }
         1000 => {
             (*CCtxParams).forceWindow = (value != 0) as core::ffi::c_int;
-            (*CCtxParams).forceWindow as size_t
+            (*CCtxParams).forceWindow as usize
         }
         1001 => {
             let Ok(pref) = ZSTD_dictAttachPref_e::try_from(value) else {
                 return Error::parameter_outOfBound.to_error_code();
             };
             (*CCtxParams).attachDictPref = pref;
-            (*CCtxParams).attachDictPref.0 as size_t
+            (*CCtxParams).attachDictPref.0 as usize
         }
         1002 => {
             let Ok(lcm) = ParamSwitch::try_from(value) else {
                 return Error::parameter_outOfBound.to_error_code();
             };
             (*CCtxParams).literalCompressionMode = lcm;
-            (*CCtxParams).literalCompressionMode as size_t
+            (*CCtxParams).literalCompressionMode as usize
         }
         400 => {
             let err_code_0 = ZSTD_cParam_clampBounds(param, &mut value);
@@ -2515,7 +2511,7 @@ pub unsafe extern "C" fn ZSTD_CCtxParams_setParameter(
                 return err_code_0;
             }
             (*CCtxParams).nbWorkers = value;
-            (*CCtxParams).nbWorkers as size_t
+            (*CCtxParams).nbWorkers as usize
         }
         401 => {
             if value != 0 && value < ZSTDMT_JOBSIZE_MIN {
@@ -2525,7 +2521,7 @@ pub unsafe extern "C" fn ZSTD_CCtxParams_setParameter(
             if ERR_isError(err_code_1) {
                 return err_code_1;
             }
-            (*CCtxParams).jobSize = value as size_t;
+            (*CCtxParams).jobSize = value as usize;
             (*CCtxParams).jobSize
         }
         402 => {
@@ -2535,7 +2531,7 @@ pub unsafe extern "C" fn ZSTD_CCtxParams_setParameter(
                 return err_code_2;
             }
             (*CCtxParams).overlapLog = value;
-            (*CCtxParams).overlapLog as size_t
+            (*CCtxParams).overlapLog as usize
         }
         500 => {
             let err_code_3 =
@@ -2544,18 +2540,18 @@ pub unsafe extern "C" fn ZSTD_CCtxParams_setParameter(
                 return err_code_3;
             }
             (*CCtxParams).rsyncable = value;
-            (*CCtxParams).rsyncable as size_t
+            (*CCtxParams).rsyncable as usize
         }
         1005 => {
             (*CCtxParams).enableDedicatedDictSearch = (value != 0) as core::ffi::c_int;
-            (*CCtxParams).enableDedicatedDictSearch as size_t
+            (*CCtxParams).enableDedicatedDictSearch as usize
         }
         160 => {
             let Ok(value) = ZSTD_ParamSwitch_e::try_from(value) else {
                 return Error::parameter_outOfBound.to_error_code();
             };
             (*CCtxParams).ldmParams.enableLdm = value as ZSTD_ParamSwitch_e;
-            (*CCtxParams).ldmParams.enableLdm as size_t
+            (*CCtxParams).ldmParams.enableLdm as usize
         }
         161 => {
             if value != 0
@@ -2564,7 +2560,7 @@ pub unsafe extern "C" fn ZSTD_CCtxParams_setParameter(
                 return Error::parameter_outOfBound.to_error_code();
             }
             (*CCtxParams).ldmParams.hashLog = value as u32;
-            (*CCtxParams).ldmParams.hashLog as size_t
+            (*CCtxParams).ldmParams.hashLog as usize
         }
         162 => {
             if value != 0
@@ -2573,7 +2569,7 @@ pub unsafe extern "C" fn ZSTD_CCtxParams_setParameter(
                 return Error::parameter_outOfBound.to_error_code();
             }
             (*CCtxParams).ldmParams.minMatchLength = value as u32;
-            (*CCtxParams).ldmParams.minMatchLength as size_t
+            (*CCtxParams).ldmParams.minMatchLength as usize
         }
         163 => {
             if value != 0
@@ -2582,7 +2578,7 @@ pub unsafe extern "C" fn ZSTD_CCtxParams_setParameter(
                 return Error::parameter_outOfBound.to_error_code();
             }
             (*CCtxParams).ldmParams.bucketSizeLog = value as u32;
-            (*CCtxParams).ldmParams.bucketSizeLog as size_t
+            (*CCtxParams).ldmParams.bucketSizeLog as usize
         }
         164 => {
             if value != 0
@@ -2591,7 +2587,7 @@ pub unsafe extern "C" fn ZSTD_CCtxParams_setParameter(
                 return Error::parameter_outOfBound.to_error_code();
             }
             (*CCtxParams).ldmParams.hashRateLog = value as u32;
-            (*CCtxParams).ldmParams.hashRateLog as size_t
+            (*CCtxParams).ldmParams.hashRateLog as usize
         }
         130 => {
             if value != 0 {
@@ -2600,7 +2596,7 @@ pub unsafe extern "C" fn ZSTD_CCtxParams_setParameter(
                     return Error::parameter_outOfBound.to_error_code();
                 }
             }
-            (*CCtxParams).targetCBlockSize = value as u32 as size_t;
+            (*CCtxParams).targetCBlockSize = value as u32 as usize;
             (*CCtxParams).targetCBlockSize
         }
         1004 => {
@@ -2610,77 +2606,77 @@ pub unsafe extern "C" fn ZSTD_CCtxParams_setParameter(
                 return Error::parameter_outOfBound.to_error_code();
             }
             (*CCtxParams).srcSizeHint = value;
-            (*CCtxParams).srcSizeHint as size_t
+            (*CCtxParams).srcSizeHint as usize
         }
         1006 => {
             if ZSTD_cParam_withinBounds(ZSTD_cParameter::ZSTD_c_experimentalParam9, value) == 0 {
                 return Error::parameter_outOfBound.to_error_code();
             }
             (*CCtxParams).inBufferMode = value as ZSTD_bufferMode_e;
-            (*CCtxParams).inBufferMode as size_t
+            (*CCtxParams).inBufferMode as usize
         }
         1007 => {
             if ZSTD_cParam_withinBounds(ZSTD_cParameter::ZSTD_c_experimentalParam10, value) == 0 {
                 return Error::parameter_outOfBound.to_error_code();
             }
             (*CCtxParams).outBufferMode = value as ZSTD_bufferMode_e;
-            (*CCtxParams).outBufferMode as size_t
+            (*CCtxParams).outBufferMode as usize
         }
         1008 => {
             if ZSTD_cParam_withinBounds(ZSTD_cParameter::ZSTD_c_experimentalParam11, value) == 0 {
                 return Error::parameter_outOfBound.to_error_code();
             }
             (*CCtxParams).blockDelimiters = value as ZSTD_SequenceFormat_e;
-            (*CCtxParams).blockDelimiters as size_t
+            (*CCtxParams).blockDelimiters as usize
         }
         1009 => {
             if ZSTD_cParam_withinBounds(ZSTD_cParameter::ZSTD_c_experimentalParam12, value) == 0 {
                 return Error::parameter_outOfBound.to_error_code();
             }
             (*CCtxParams).validateSequences = value;
-            (*CCtxParams).validateSequences as size_t
+            (*CCtxParams).validateSequences as usize
         }
         1010 => {
             let Ok(value) = ZSTD_ParamSwitch_e::try_from(value) else {
                 return Error::parameter_outOfBound.to_error_code();
             };
             (*CCtxParams).postBlockSplitter = value as ZSTD_ParamSwitch_e;
-            (*CCtxParams).postBlockSplitter as size_t
+            (*CCtxParams).postBlockSplitter as usize
         }
         1017 => {
             if ZSTD_cParam_withinBounds(ZSTD_cParameter::ZSTD_c_experimentalParam20, value) == 0 {
                 return Error::parameter_outOfBound.to_error_code();
             }
             (*CCtxParams).preBlockSplitter_level = value;
-            (*CCtxParams).preBlockSplitter_level as size_t
+            (*CCtxParams).preBlockSplitter_level as usize
         }
         1011 => {
             let Ok(value) = ZSTD_ParamSwitch_e::try_from(value) else {
                 return Error::parameter_outOfBound.to_error_code();
             };
             (*CCtxParams).useRowMatchFinder = value as ZSTD_ParamSwitch_e;
-            (*CCtxParams).useRowMatchFinder as size_t
+            (*CCtxParams).useRowMatchFinder as usize
         }
         1012 => {
             if ZSTD_cParam_withinBounds(ZSTD_cParameter::ZSTD_c_experimentalParam15, value) == 0 {
                 return Error::parameter_outOfBound.to_error_code();
             }
             (*CCtxParams).deterministicRefPrefix = (value != 0) as core::ffi::c_int;
-            (*CCtxParams).deterministicRefPrefix as size_t
+            (*CCtxParams).deterministicRefPrefix as usize
         }
         1013 => {
             let Ok(value) = ZSTD_ParamSwitch_e::try_from(value) else {
                 return Error::parameter_outOfBound.to_error_code();
             };
             (*CCtxParams).prefetchCDictTables = value as ZSTD_ParamSwitch_e;
-            (*CCtxParams).prefetchCDictTables as size_t
+            (*CCtxParams).prefetchCDictTables as usize
         }
         1014 => {
             if ZSTD_cParam_withinBounds(ZSTD_cParameter::ZSTD_c_experimentalParam17, value) == 0 {
                 return Error::parameter_outOfBound.to_error_code();
             }
             (*CCtxParams).enableMatchFinderFallback = value;
-            (*CCtxParams).enableMatchFinderFallback as size_t
+            (*CCtxParams).enableMatchFinderFallback as usize
         }
         1015 => {
             if value != 0
@@ -2688,7 +2684,7 @@ pub unsafe extern "C" fn ZSTD_CCtxParams_setParameter(
             {
                 return Error::parameter_outOfBound.to_error_code();
             }
-            (*CCtxParams).maxBlockSize = value as size_t;
+            (*CCtxParams).maxBlockSize = value as usize;
             (*CCtxParams).maxBlockSize
         }
         1016 => {
@@ -2696,7 +2692,7 @@ pub unsafe extern "C" fn ZSTD_CCtxParams_setParameter(
                 return Error::parameter_outOfBound.to_error_code();
             };
             (*CCtxParams).searchForExternalRepcodes = value;
-            (*CCtxParams).searchForExternalRepcodes as size_t
+            (*CCtxParams).searchForExternalRepcodes as usize
         }
         _ => Error::parameter_unsupported.to_error_code(),
     }
@@ -2706,7 +2702,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_getParameter(
     cctx: *const ZSTD_CCtx,
     param: ZSTD_cParameter,
     value: *mut core::ffi::c_int,
-) -> size_t {
+) -> usize {
     ZSTD_CCtxParams_getParameter(&(*cctx).requestedParams, param, value)
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_CCtxParams_getParameter))]
@@ -2714,7 +2710,7 @@ pub unsafe extern "C" fn ZSTD_CCtxParams_getParameter(
     CCtxParams: *const ZSTD_CCtx_params,
     param: ZSTD_cParameter,
     value: *mut core::ffi::c_int,
-) -> size_t {
+) -> usize {
     match param.0 {
         10 => {
             *value = (*CCtxParams).format as core::ffi::c_int;
@@ -2841,7 +2837,7 @@ pub unsafe extern "C" fn ZSTD_CCtxParams_getParameter(
 pub unsafe extern "C" fn ZSTD_CCtx_setParametersUsingCCtxParams(
     cctx: *mut ZSTD_CCtx,
     params: *const ZSTD_CCtx_params,
-) -> size_t {
+) -> usize {
     if (*cctx).streamStage as core::ffi::c_uint
         != zcss_init as core::ffi::c_int as core::ffi::c_uint
     {
@@ -2857,7 +2853,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_setParametersUsingCCtxParams(
 pub unsafe extern "C" fn ZSTD_CCtx_setCParams(
     cctx: *mut ZSTD_CCtx,
     cparams: ZSTD_compressionParameters,
-) -> size_t {
+) -> usize {
     let err_code = ZSTD_checkCParams(cparams);
     if ERR_isError(err_code) {
         return err_code;
@@ -2924,7 +2920,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_setCParams(
 pub unsafe extern "C" fn ZSTD_CCtx_setFParams(
     cctx: *mut ZSTD_CCtx,
     fparams: ZSTD_frameParameters,
-) -> size_t {
+) -> usize {
     let err_code = ZSTD_CCtx_setParameter(
         cctx,
         ZSTD_cParameter::ZSTD_c_contentSizeFlag,
@@ -2955,7 +2951,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_setFParams(
 pub unsafe extern "C" fn ZSTD_CCtx_setParams(
     cctx: *mut ZSTD_CCtx,
     params: ZSTD_parameters,
-) -> size_t {
+) -> usize {
     let err_code = ZSTD_checkCParams(params.cParams);
     if ERR_isError(err_code) {
         return err_code;
@@ -2974,7 +2970,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_setParams(
 pub unsafe extern "C" fn ZSTD_CCtx_setPledgedSrcSize(
     cctx: *mut ZSTD_CCtx,
     pledgedSrcSize: core::ffi::c_ulonglong,
-) -> size_t {
+) -> usize {
     if (*cctx).streamStage as core::ffi::c_uint
         != zcss_init as core::ffi::c_int as core::ffi::c_uint
     {
@@ -2983,7 +2979,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_setPledgedSrcSize(
     (*cctx).pledgedSrcSizePlusOne = pledgedSrcSize.wrapping_add(1);
     0
 }
-unsafe fn ZSTD_initLocalDict(cctx: *mut ZSTD_CCtx) -> size_t {
+unsafe fn ZSTD_initLocalDict(cctx: *mut ZSTD_CCtx) -> usize {
     let dl: *mut ZSTD_localDict = &mut (*cctx).localDict;
     if ((*dl).dict).is_null() {
         return 0;
@@ -3009,10 +3005,10 @@ unsafe fn ZSTD_initLocalDict(cctx: *mut ZSTD_CCtx) -> size_t {
 pub unsafe extern "C" fn ZSTD_CCtx_loadDictionary_advanced(
     cctx: *mut ZSTD_CCtx,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     dictLoadMethod: ZSTD_dictLoadMethod_e,
     dictContentType: ZSTD_dictContentType_e,
-) -> size_t {
+) -> usize {
     if (*cctx).streamStage as core::ffi::c_uint
         != zcss_init as core::ffi::c_int as core::ffi::c_uint
     {
@@ -3035,7 +3031,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_loadDictionary_advanced(
         if dictBuffer.is_null() {
             return Error::memory_allocation.to_error_code();
         }
-        libc::memcpy(dictBuffer, dict, dictSize as libc::size_t);
+        libc::memcpy(dictBuffer, dict, dictSize as usize);
         (*cctx).localDict.dictBuffer = dictBuffer;
         (*cctx).localDict.dict = dictBuffer;
     }
@@ -3047,23 +3043,23 @@ pub unsafe extern "C" fn ZSTD_CCtx_loadDictionary_advanced(
 pub unsafe extern "C" fn ZSTD_CCtx_loadDictionary_byReference(
     cctx: *mut ZSTD_CCtx,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
-) -> size_t {
+    dictSize: usize,
+) -> usize {
     ZSTD_CCtx_loadDictionary_advanced(cctx, dict, dictSize, ZSTD_dlm_byRef, ZSTD_dct_auto)
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_CCtx_loadDictionary))]
 pub unsafe extern "C" fn ZSTD_CCtx_loadDictionary(
     cctx: *mut ZSTD_CCtx,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
-) -> size_t {
+    dictSize: usize,
+) -> usize {
     ZSTD_CCtx_loadDictionary_advanced(cctx, dict, dictSize, ZSTD_dlm_byCopy, ZSTD_dct_auto)
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_CCtx_refCDict))]
 pub unsafe extern "C" fn ZSTD_CCtx_refCDict(
     cctx: *mut ZSTD_CCtx,
     cdict: *const ZSTD_CDict,
-) -> size_t {
+) -> usize {
     if (*cctx).streamStage as core::ffi::c_uint
         != zcss_init as core::ffi::c_int as core::ffi::c_uint
     {
@@ -3077,7 +3073,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_refCDict(
 pub unsafe extern "C" fn ZSTD_CCtx_refThreadPool(
     cctx: *mut ZSTD_CCtx,
     pool: *mut ZSTD_threadPool,
-) -> size_t {
+) -> usize {
     if (*cctx).streamStage as core::ffi::c_uint
         != zcss_init as core::ffi::c_int as core::ffi::c_uint
     {
@@ -3090,17 +3086,17 @@ pub unsafe extern "C" fn ZSTD_CCtx_refThreadPool(
 pub unsafe extern "C" fn ZSTD_CCtx_refPrefix(
     cctx: *mut ZSTD_CCtx,
     prefix: *const core::ffi::c_void,
-    prefixSize: size_t,
-) -> size_t {
+    prefixSize: usize,
+) -> usize {
     ZSTD_CCtx_refPrefix_advanced(cctx, prefix, prefixSize, ZSTD_dct_rawContent)
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_CCtx_refPrefix_advanced))]
 pub unsafe extern "C" fn ZSTD_CCtx_refPrefix_advanced(
     cctx: *mut ZSTD_CCtx,
     prefix: *const core::ffi::c_void,
-    prefixSize: size_t,
+    prefixSize: usize,
     dictContentType: ZSTD_dictContentType_e,
-) -> size_t {
+) -> usize {
     if (*cctx).streamStage as core::ffi::c_uint
         != zcss_init as core::ffi::c_int as core::ffi::c_uint
     {
@@ -3118,7 +3114,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_refPrefix_advanced(
 pub unsafe extern "C" fn ZSTD_CCtx_reset(
     cctx: *mut ZSTD_CCtx,
     reset: ZSTD_ResetDirective,
-) -> size_t {
+) -> usize {
     if matches!(
         reset,
         ZSTD_ResetDirective::ZSTD_reset_session_only
@@ -3145,7 +3141,7 @@ pub unsafe extern "C" fn ZSTD_CCtx_reset(
     0
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_checkCParams))]
-pub unsafe extern "C" fn ZSTD_checkCParams(cParams: ZSTD_compressionParameters) -> size_t {
+pub unsafe extern "C" fn ZSTD_checkCParams(cParams: ZSTD_compressionParameters) -> usize {
     if ZSTD_cParam_withinBounds(
         ZSTD_cParameter::ZSTD_c_windowLog,
         cParams.windowLog as core::ffi::c_int,
@@ -3257,7 +3253,7 @@ unsafe fn ZSTD_dictAndWindowLog(windowLog: u32, srcSize: u64, dictSize: u64) -> 
     if windowSize >= dictSize.wrapping_add(srcSize) {
         windowLog
     } else if dictAndWindowSize >= maxWindowSize {
-        (if ::core::mem::size_of::<size_t>() == 4 {
+        (if ::core::mem::size_of::<usize>() == 4 {
             ZSTD_WINDOWLOG_MAX_32
         } else {
             ZSTD_WINDOWLOG_MAX_64
@@ -3269,13 +3265,13 @@ unsafe fn ZSTD_dictAndWindowLog(windowLog: u32, srcSize: u64, dictSize: u64) -> 
 unsafe fn ZSTD_adjustCParams_internal(
     mut cPar: ZSTD_compressionParameters,
     mut srcSize: core::ffi::c_ulonglong,
-    mut dictSize: size_t,
+    mut dictSize: usize,
     mode: ZSTD_CParamMode_e,
     mut useRowMatchFinder: ZSTD_ParamSwitch_e,
 ) -> ZSTD_compressionParameters {
     let minSrcSize = 513;
     let maxWindowResize = ((1)
-        << ((if ::core::mem::size_of::<size_t>() == 4 {
+        << ((if ::core::mem::size_of::<usize>() == 4 {
             ZSTD_WINDOWLOG_MAX_32
         } else {
             ZSTD_WINDOWLOG_MAX_64
@@ -3355,7 +3351,7 @@ unsafe fn ZSTD_adjustCParams_internal(
 pub unsafe extern "C" fn ZSTD_adjustCParams(
     mut cPar: ZSTD_compressionParameters,
     mut srcSize: core::ffi::c_ulonglong,
-    dictSize: size_t,
+    dictSize: usize,
 ) -> ZSTD_compressionParameters {
     cPar = ZSTD_clampCParams(cPar);
     if srcSize == 0 {
@@ -3399,7 +3395,7 @@ unsafe fn ZSTD_overrideCParams(
 pub unsafe extern "C" fn ZSTD_getCParamsFromCCtxParams(
     CCtxParams: *const ZSTD_CCtx_params,
     mut srcSizeHint: u64,
-    dictSize: size_t,
+    dictSize: usize,
     mode: ZSTD_CParamMode_e,
 ) -> ZSTD_compressionParameters {
     let mut cParams = ZSTD_compressionParameters {
@@ -3439,18 +3435,18 @@ unsafe fn ZSTD_sizeof_matchState(
     useRowMatchFinder: ZSTD_ParamSwitch_e,
     enableDedicatedDictSearch: core::ffi::c_int,
     forCCtx: u32,
-) -> size_t {
+) -> usize {
     let chainSize = if ZSTD_allocateChainTable(
         (*cParams).strategy,
         useRowMatchFinder,
         (enableDedicatedDictSearch != 0 && forCCtx == 0) as core::ffi::c_int as u32,
     ) != 0
     {
-        (1 as size_t) << (*cParams).chainLog
+        (1 as usize) << (*cParams).chainLog
     } else {
-        0 as size_t
+        0 as usize
     };
-    let hSize = (1 as size_t) << (*cParams).hashLog;
+    let hSize = (1 as usize) << (*cParams).hashLog;
     let hashLog3 = if forCCtx != 0 && (*cParams).minMatch == 3 {
         if (17) < (*cParams).windowLog {
             17
@@ -3461,31 +3457,31 @@ unsafe fn ZSTD_sizeof_matchState(
         0
     };
     let h3Size = if hashLog3 != 0 {
-        (1 as size_t) << hashLog3
+        (1 as usize) << hashLog3
     } else {
-        0 as size_t
+        0 as usize
     };
     let tableSpace = chainSize
         .wrapping_mul(::core::mem::size_of::<u32>())
         .wrapping_add(hSize.wrapping_mul(::core::mem::size_of::<u32>()))
         .wrapping_add(h3Size.wrapping_mul(::core::mem::size_of::<u32>()));
     let optPotentialSpace = (ZSTD_cwksp_aligned64_alloc_size(
-        ((MaxML + 1) as size_t).wrapping_mul(::core::mem::size_of::<u32>()),
+        ((MaxML + 1) as usize).wrapping_mul(::core::mem::size_of::<u32>()),
     ))
     .wrapping_add(ZSTD_cwksp_aligned64_alloc_size(
-        ((MaxLL + 1) as size_t).wrapping_mul(::core::mem::size_of::<u32>()),
+        ((MaxLL + 1) as usize).wrapping_mul(::core::mem::size_of::<u32>()),
     ))
     .wrapping_add(ZSTD_cwksp_aligned64_alloc_size(
-        ((MaxOff + 1) as size_t).wrapping_mul(::core::mem::size_of::<u32>()),
+        ((MaxOff + 1) as usize).wrapping_mul(::core::mem::size_of::<u32>()),
     ))
     .wrapping_add(ZSTD_cwksp_aligned64_alloc_size(
-        (((1) << Litbits) as size_t).wrapping_mul(::core::mem::size_of::<u32>()),
+        (((1) << Litbits) as usize).wrapping_mul(::core::mem::size_of::<u32>()),
     ))
     .wrapping_add(ZSTD_cwksp_aligned64_alloc_size(
-        (ZSTD_OPT_SIZE as size_t).wrapping_mul(::core::mem::size_of::<ZSTD_match_t>()),
+        (ZSTD_OPT_SIZE as usize).wrapping_mul(::core::mem::size_of::<ZSTD_match_t>()),
     ))
     .wrapping_add(ZSTD_cwksp_aligned64_alloc_size(
-        (ZSTD_OPT_SIZE as size_t).wrapping_mul(::core::mem::size_of::<ZSTD_optimal_t>()),
+        (ZSTD_OPT_SIZE as usize).wrapping_mul(::core::mem::size_of::<ZSTD_optimal_t>()),
     ));
     let lazyAdditionalSpace =
         if ZSTD_rowMatchFinderUsed((*cParams).strategy, useRowMatchFinder) != 0 {
@@ -3508,28 +3504,28 @@ unsafe fn ZSTD_sizeof_matchState(
         .wrapping_add(lazyAdditionalSpace)
 }
 unsafe fn ZSTD_maxNbSeq(
-    blockSize: size_t,
+    blockSize: usize,
     minMatch: core::ffi::c_uint,
     useSequenceProducer: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let divider = (if minMatch == 3 || useSequenceProducer != 0 {
         3
     } else {
         4
     }) as u32;
-    blockSize / divider as size_t
+    blockSize / divider as usize
 }
 unsafe fn ZSTD_estimateCCtxSize_usingCCtxParams_internal(
     cParams: *const ZSTD_compressionParameters,
     ldmParams: *const ldmParams_t,
     isStatic: core::ffi::c_int,
     useRowMatchFinder: ZSTD_ParamSwitch_e,
-    buffInSize: size_t,
-    buffOutSize: size_t,
+    buffInSize: usize,
+    buffOutSize: usize,
     pledgedSrcSize: u64,
     useSequenceProducer: core::ffi::c_int,
-    maxBlockSize: size_t,
-) -> size_t {
+    maxBlockSize: usize,
+) -> usize {
     let windowSize = (if 1
         > (if (1) << (*cParams).windowLog < pledgedSrcSize as core::ffi::c_ulonglong {
             (1) << (*cParams).windowLog
@@ -3541,7 +3537,7 @@ unsafe fn ZSTD_estimateCCtxSize_usingCCtxParams_internal(
         (1) << (*cParams).windowLog
     } else {
         pledgedSrcSize as core::ffi::c_ulonglong
-    }) as size_t;
+    }) as usize;
     let blockSize = if ZSTD_resolveMaxBlockSize(maxBlockSize) < windowSize {
         ZSTD_resolveMaxBlockSize(maxBlockSize)
     } else {
@@ -3556,14 +3552,14 @@ unsafe fn ZSTD_estimateCCtxSize_usingCCtxParams_internal(
             3 * ZSTD_cwksp_alloc_size(maxNbSeq.wrapping_mul(::core::mem::size_of::<u8>())),
         );
     let tmpWorkSpace = ZSTD_cwksp_alloc_size(
-        if ((((8) << 10) + 512) as size_t).wrapping_add(
+        if ((((8) << 10) + 512) as usize).wrapping_add(
             (::core::mem::size_of::<core::ffi::c_uint>())
-                .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
+                .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as usize),
         ) > 8208
         {
-            ((((8) << 10) + 512) as size_t).wrapping_add(
+            ((((8) << 10) + 512) as usize).wrapping_add(
                 (::core::mem::size_of::<core::ffi::c_uint>())
-                    .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
+                    .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as usize),
             )
         } else {
             8208
@@ -3608,7 +3604,7 @@ unsafe fn ZSTD_estimateCCtxSize_usingCCtxParams_internal(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_estimateCCtxSize_usingCCtxParams))]
 pub unsafe extern "C" fn ZSTD_estimateCCtxSize_usingCCtxParams(
     params: *const ZSTD_CCtx_params,
-) -> size_t {
+) -> usize {
     let cParams =
         ZSTD_getCParamsFromCCtxParams(params, ZSTD_CONTENTSIZE_UNKNOWN, 0, ZSTD_cpm_noAttachDict);
     let useRowMatchFinder = ZSTD_resolveRowMatchFinderMode((*params).useRowMatchFinder, &cParams);
@@ -3630,11 +3626,11 @@ pub unsafe extern "C" fn ZSTD_estimateCCtxSize_usingCCtxParams(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_estimateCCtxSize_usingCParams))]
 pub unsafe extern "C" fn ZSTD_estimateCCtxSize_usingCParams(
     cParams: ZSTD_compressionParameters,
-) -> size_t {
+) -> usize {
     let mut initialParams = ZSTD_makeCCtxParamsFromCParams(cParams);
     if ZSTD_rowMatchFinderSupported(cParams.strategy) != 0 {
-        let mut noRowCCtxSize: size_t = 0;
-        let mut rowCCtxSize: size_t = 0;
+        let mut noRowCCtxSize: usize = 0;
+        let mut rowCCtxSize: usize = 0;
         initialParams.useRowMatchFinder = ZSTD_ParamSwitch_e::ZSTD_ps_disable;
         noRowCCtxSize = ZSTD_estimateCCtxSize_usingCCtxParams(&initialParams);
         initialParams.useRowMatchFinder = ZSTD_ParamSwitch_e::ZSTD_ps_enable;
@@ -3654,7 +3650,7 @@ static srcSizeTiers: [core::ffi::c_ulonglong; 4] = [
     256 * (1 << 10),
     ZSTD_CONTENTSIZE_UNKNOWN,
 ];
-unsafe extern "C" fn ZSTD_estimateCCtxSize_internal(compressionLevel: core::ffi::c_int) -> size_t {
+unsafe extern "C" fn ZSTD_estimateCCtxSize_internal(compressionLevel: core::ffi::c_int) -> usize {
     let mut tier = 0;
     let mut largestSize = 0;
     while tier < 4 {
@@ -3674,7 +3670,7 @@ unsafe extern "C" fn ZSTD_estimateCCtxSize_internal(compressionLevel: core::ffi:
     largestSize
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_estimateCCtxSize))]
-pub unsafe extern "C" fn ZSTD_estimateCCtxSize(compressionLevel: core::ffi::c_int) -> size_t {
+pub unsafe extern "C" fn ZSTD_estimateCCtxSize(compressionLevel: core::ffi::c_int) -> usize {
     let mut level: core::ffi::c_int = 0;
     let mut memBudget = 0;
     level = if compressionLevel < 1 {
@@ -3694,7 +3690,7 @@ pub unsafe extern "C" fn ZSTD_estimateCCtxSize(compressionLevel: core::ffi::c_in
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_estimateCStreamSize_usingCCtxParams))]
 pub unsafe extern "C" fn ZSTD_estimateCStreamSize_usingCCtxParams(
     params: *const ZSTD_CCtx_params,
-) -> size_t {
+) -> usize {
     if (*params).nbWorkers > 0 {
         return Error::GENERIC.to_error_code();
     }
@@ -3708,7 +3704,7 @@ pub unsafe extern "C" fn ZSTD_estimateCStreamSize_usingCCtxParams(
     let inBuffSize = if (*params).inBufferMode as core::ffi::c_uint
         == ZSTD_bm_buffered as core::ffi::c_int as core::ffi::c_uint
     {
-        ((1 as size_t) << cParams.windowLog).wrapping_add(blockSize)
+        ((1 as usize) << cParams.windowLog).wrapping_add(blockSize)
     } else {
         0
     };
@@ -3736,11 +3732,11 @@ pub unsafe extern "C" fn ZSTD_estimateCStreamSize_usingCCtxParams(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_estimateCStreamSize_usingCParams))]
 pub unsafe extern "C" fn ZSTD_estimateCStreamSize_usingCParams(
     cParams: ZSTD_compressionParameters,
-) -> size_t {
+) -> usize {
     let mut initialParams = ZSTD_makeCCtxParamsFromCParams(cParams);
     if ZSTD_rowMatchFinderSupported(cParams.strategy) != 0 {
-        let mut noRowCCtxSize: size_t = 0;
-        let mut rowCCtxSize: size_t = 0;
+        let mut noRowCCtxSize: usize = 0;
+        let mut rowCCtxSize: usize = 0;
         initialParams.useRowMatchFinder = ZSTD_ParamSwitch_e::ZSTD_ps_disable;
         noRowCCtxSize = ZSTD_estimateCStreamSize_usingCCtxParams(&initialParams);
         initialParams.useRowMatchFinder = ZSTD_ParamSwitch_e::ZSTD_ps_enable;
@@ -3754,7 +3750,7 @@ pub unsafe extern "C" fn ZSTD_estimateCStreamSize_usingCParams(
         ZSTD_estimateCStreamSize_usingCCtxParams(&initialParams)
     }
 }
-unsafe fn ZSTD_estimateCStreamSize_internal(compressionLevel: core::ffi::c_int) -> size_t {
+unsafe fn ZSTD_estimateCStreamSize_internal(compressionLevel: core::ffi::c_int) -> usize {
     let cParams = ZSTD_getCParams_internal(
         compressionLevel,
         ZSTD_CONTENTSIZE_UNKNOWN,
@@ -3764,7 +3760,7 @@ unsafe fn ZSTD_estimateCStreamSize_internal(compressionLevel: core::ffi::c_int) 
     ZSTD_estimateCStreamSize_usingCParams(cParams)
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_estimateCStreamSize))]
-pub unsafe extern "C" fn ZSTD_estimateCStreamSize(compressionLevel: core::ffi::c_int) -> size_t {
+pub unsafe extern "C" fn ZSTD_estimateCStreamSize(compressionLevel: core::ffi::c_int) -> usize {
     let mut level: core::ffi::c_int = 0;
     let mut memBudget = 0;
     level = if compressionLevel < 1 {
@@ -3814,7 +3810,7 @@ pub unsafe extern "C" fn ZSTD_getFrameProgression(cctx: *const ZSTD_CCtx) -> ZST
     fp
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_toFlushNow))]
-pub unsafe extern "C" fn ZSTD_toFlushNow(cctx: *mut ZSTD_CCtx) -> size_t {
+pub unsafe extern "C" fn ZSTD_toFlushNow(cctx: *mut ZSTD_CCtx) -> usize {
     if (*cctx).appliedParams.nbWorkers > 0 {
         return ZSTDMT_toFlushNow((*cctx).mtctx);
     }
@@ -3869,7 +3865,7 @@ unsafe fn ZSTD_reset_matchState(
     crp: ZSTD_compResetPolicy_e,
     forceResetIndex: ZSTD_indexResetPolicy_e,
     forWho: ZSTD_resetTarget_e,
-) -> size_t {
+) -> usize {
     let chainSize = if ZSTD_allocateChainTable(
         (*cParams).strategy,
         useRowMatchFinder,
@@ -3879,11 +3875,11 @@ unsafe fn ZSTD_reset_matchState(
             as core::ffi::c_int as u32,
     ) != 0
     {
-        (1 as size_t) << (*cParams).chainLog
+        (1 as usize) << (*cParams).chainLog
     } else {
-        0 as size_t
+        0 as usize
     };
-    let hSize = (1 as size_t) << (*cParams).hashLog;
+    let hSize = (1 as usize) << (*cParams).hashLog;
     let hashLog3 = if forWho as core::ffi::c_uint
         == ZSTD_resetTarget_CCtx as core::ffi::c_int as core::ffi::c_uint
         && (*cParams).minMatch == 3
@@ -3897,9 +3893,9 @@ unsafe fn ZSTD_reset_matchState(
         0
     };
     let h3Size = if hashLog3 != 0 {
-        (1 as size_t) << hashLog3
+        (1 as usize) << hashLog3
     } else {
-        0 as size_t
+        0 as usize
     };
     if forceResetIndex as core::ffi::c_uint
         == ZSTDirp_reset as core::ffi::c_int as core::ffi::c_uint
@@ -3956,27 +3952,27 @@ unsafe fn ZSTD_reset_matchState(
     {
         ms.opt.litFreq = ZSTD_cwksp_reserve_aligned64(
             ws,
-            (((1) << Litbits) as size_t).wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>()),
+            (((1) << Litbits) as usize).wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>()),
         ) as *mut core::ffi::c_uint;
         ms.opt.litLengthFreq = ZSTD_cwksp_reserve_aligned64(
             ws,
-            ((MaxLL + 1) as size_t).wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>()),
+            ((MaxLL + 1) as usize).wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>()),
         ) as *mut core::ffi::c_uint;
         ms.opt.matchLengthFreq = ZSTD_cwksp_reserve_aligned64(
             ws,
-            ((MaxML + 1) as size_t).wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>()),
+            ((MaxML + 1) as usize).wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>()),
         ) as *mut core::ffi::c_uint;
         ms.opt.offCodeFreq = ZSTD_cwksp_reserve_aligned64(
             ws,
-            ((MaxOff + 1) as size_t).wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>()),
+            ((MaxOff + 1) as usize).wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>()),
         ) as *mut core::ffi::c_uint;
         ms.opt.matchTable = ZSTD_cwksp_reserve_aligned64(
             ws,
-            (ZSTD_OPT_SIZE as size_t).wrapping_mul(::core::mem::size_of::<ZSTD_match_t>()),
+            (ZSTD_OPT_SIZE as usize).wrapping_mul(::core::mem::size_of::<ZSTD_match_t>()),
         ) as *mut ZSTD_match_t;
         ms.opt.priceTable = ZSTD_cwksp_reserve_aligned64(
             ws,
-            (ZSTD_OPT_SIZE as size_t).wrapping_mul(::core::mem::size_of::<ZSTD_optimal_t>()),
+            (ZSTD_OPT_SIZE as usize).wrapping_mul(::core::mem::size_of::<ZSTD_optimal_t>()),
         ) as *mut ZSTD_optimal_t;
     }
     ms.cParams = *cParams;
@@ -3987,7 +3983,7 @@ unsafe fn ZSTD_reset_matchState(
 }
 pub const ZSTD_INDEXOVERFLOW_MARGIN: core::ffi::c_int = 16 * ((1) << 20);
 unsafe fn ZSTD_indexTooCloseToMax(w: ZSTD_window_t) -> core::ffi::c_int {
-    ((w.nextSrc).wrapping_offset_from(w.base) as size_t
+    ((w.nextSrc).wrapping_offset_from(w.base) as usize
         > (if MEM_64bits() {
             (3500 as core::ffi::c_uint)
                 .wrapping_mul(((1 as core::ffi::c_int) << 20) as core::ffi::c_uint)
@@ -3995,10 +3991,10 @@ unsafe fn ZSTD_indexTooCloseToMax(w: ZSTD_window_t) -> core::ffi::c_int {
             (2000 as core::ffi::c_uint)
                 .wrapping_mul(((1 as core::ffi::c_int) << 20) as core::ffi::c_uint)
         })
-        .wrapping_sub(ZSTD_INDEXOVERFLOW_MARGIN as core::ffi::c_uint) as size_t)
+        .wrapping_sub(ZSTD_INDEXOVERFLOW_MARGIN as core::ffi::c_uint) as usize)
         as core::ffi::c_int
 }
-unsafe fn ZSTD_dictTooBig(loadedDictSize: size_t) -> core::ffi::c_int {
+unsafe fn ZSTD_dictTooBig(loadedDictSize: usize) -> core::ffi::c_int {
     (loadedDictSize
         > (-(1 as core::ffi::c_int) as u32).wrapping_sub(if MEM_64bits() {
             (3500 as core::ffi::c_uint)
@@ -4006,16 +4002,16 @@ unsafe fn ZSTD_dictTooBig(loadedDictSize: size_t) -> core::ffi::c_int {
         } else {
             (2000 as core::ffi::c_uint)
                 .wrapping_mul(((1 as core::ffi::c_int) << 20) as core::ffi::c_uint)
-        }) as size_t) as core::ffi::c_int
+        }) as usize) as core::ffi::c_int
 }
 unsafe fn ZSTD_resetCCtx_internal(
     zc: *mut ZSTD_CCtx,
     mut params: *const ZSTD_CCtx_params,
     pledgedSrcSize: u64,
-    loadedDictSize: size_t,
+    loadedDictSize: usize,
     crp: ZSTD_compResetPolicy_e,
     zbuff: ZSTD_buffered_policy_e,
-) -> size_t {
+) -> usize {
     let ws: *mut ZSTD_cwksp = &mut (*zc).workspace;
     (*zc).isFirstBlock = 1;
     (*zc).appliedParams = *params;
@@ -4024,16 +4020,16 @@ unsafe fn ZSTD_resetCCtx_internal(
         ZSTD_ldm_adjustParameters(&mut (*zc).appliedParams.ldmParams, &(*params).cParams);
     }
     let windowSize = if 1
-        > (if (1 as size_t) << (*params).cParams.windowLog < pledgedSrcSize as size_t {
-            (1 as size_t) << (*params).cParams.windowLog
+        > (if (1 as usize) << (*params).cParams.windowLog < pledgedSrcSize as usize {
+            (1 as usize) << (*params).cParams.windowLog
         } else {
-            pledgedSrcSize as size_t
+            pledgedSrcSize as usize
         }) {
         1
-    } else if (1 as size_t) << (*params).cParams.windowLog < pledgedSrcSize as size_t {
-        (1 as size_t) << (*params).cParams.windowLog
+    } else if (1 as usize) << (*params).cParams.windowLog < pledgedSrcSize as usize {
+        (1 as usize) << (*params).cParams.windowLog
     } else {
-        pledgedSrcSize as size_t
+        pledgedSrcSize as usize
     };
     let blockSize = if (*params).maxBlockSize < windowSize {
         (*params).maxBlockSize
@@ -4116,14 +4112,14 @@ unsafe fn ZSTD_resetCCtx_internal(
         }
         (*zc).tmpWorkspace = ZSTD_cwksp_reserve_object(
             ws,
-            if ((((8) << 10) + 512) as size_t).wrapping_add(
+            if ((((8) << 10) + 512) as usize).wrapping_add(
                 (::core::mem::size_of::<core::ffi::c_uint>())
-                    .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
+                    .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as usize),
             ) > 8208
             {
-                ((((8) << 10) + 512) as size_t).wrapping_add(
+                ((((8) << 10) + 512) as usize).wrapping_add(
                     (::core::mem::size_of::<core::ffi::c_uint>())
-                        .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
+                        .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as usize),
                 )
             } else {
                 8208
@@ -4132,14 +4128,14 @@ unsafe fn ZSTD_resetCCtx_internal(
         if ((*zc).tmpWorkspace).is_null() {
             return Error::memory_allocation.to_error_code();
         }
-        (*zc).tmpWkspSize = if ((((8) << 10) + 512) as size_t).wrapping_add(
+        (*zc).tmpWkspSize = if ((((8) << 10) + 512) as usize).wrapping_add(
             (::core::mem::size_of::<core::ffi::c_uint>())
-                .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
+                .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as usize),
         ) > 8208
         {
-            ((((8) << 10) + 512) as size_t).wrapping_add(
+            ((((8) << 10) + 512) as usize).wrapping_add(
                 (::core::mem::size_of::<core::ffi::c_uint>())
-                    .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
+                    .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as usize),
             )
         } else {
             8208
@@ -4177,7 +4173,7 @@ unsafe fn ZSTD_resetCCtx_internal(
         ZSTD_cwksp_reserve_aligned64(ws, maxNbSeq.wrapping_mul(::core::mem::size_of::<SeqDef>()))
             as *mut SeqDef;
     if (*params).ldmParams.enableLdm == ZSTD_ParamSwitch_e::ZSTD_ps_enable {
-        let ldmHSize = (1 as size_t) << (*params).ldmParams.hashLog;
+        let ldmHSize = (1 as usize) << (*params).ldmParams.hashLog;
         (*zc).ldmState.hashTable = ZSTD_cwksp_reserve_aligned64(
             ws,
             ldmHSize.wrapping_mul(::core::mem::size_of::<ldmEntry_t>()),
@@ -4238,17 +4234,17 @@ pub unsafe fn ZSTD_invalidateRepCodes(cctx: *mut ZSTD_CCtx) {
         i += 1;
     }
 }
-static attachDictSizeCutoffs: [size_t; 10] = [
-    (8 * ((1) << 10)) as size_t,
-    (8 * ((1) << 10)) as size_t,
-    (16 * ((1) << 10)) as size_t,
-    (32 * ((1) << 10)) as size_t,
-    (32 * ((1) << 10)) as size_t,
-    (32 * ((1) << 10)) as size_t,
-    (32 * ((1) << 10)) as size_t,
-    (32 * ((1) << 10)) as size_t,
-    (8 * ((1) << 10)) as size_t,
-    (8 * ((1) << 10)) as size_t,
+static attachDictSizeCutoffs: [usize; 10] = [
+    (8 * ((1) << 10)) as usize,
+    (8 * ((1) << 10)) as usize,
+    (16 * ((1) << 10)) as usize,
+    (32 * ((1) << 10)) as usize,
+    (32 * ((1) << 10)) as usize,
+    (32 * ((1) << 10)) as usize,
+    (32 * ((1) << 10)) as usize,
+    (32 * ((1) << 10)) as usize,
+    (8 * ((1) << 10)) as usize,
+    (8 * ((1) << 10)) as usize,
 ];
 unsafe fn ZSTD_shouldAttachDict(
     cdict: *const ZSTD_CDict,
@@ -4272,7 +4268,7 @@ unsafe fn ZSTD_resetCCtx_byAttachingCDict(
     mut params: ZSTD_CCtx_params,
     pledgedSrcSize: u64,
     zbuff: ZSTD_buffered_policy_e,
-) -> size_t {
+) -> usize {
     let mut adjusted_cdict_cParams = (*cdict).matchState.cParams;
     let windowLog = params.cParams.windowLog;
     if (*cdict).matchState.dedicatedDictSearch != 0 {
@@ -4317,11 +4313,11 @@ unsafe fn ZSTD_resetCCtx_byAttachingCDict(
 unsafe fn ZSTD_copyCDictTableIntoCCtx(
     dst: *mut u32,
     src: *const u32,
-    tableSize: size_t,
+    tableSize: usize,
     cParams: *const ZSTD_compressionParameters,
 ) {
     if ZSTD_CDictIndicesAreTagged(cParams) != 0 {
-        let mut i: size_t = 0;
+        let mut i: usize = 0;
         i = 0;
         while i < tableSize {
             let taggedIndex = *src.add(i);
@@ -4343,7 +4339,7 @@ unsafe fn ZSTD_resetCCtx_byCopyingCDict(
     mut params: ZSTD_CCtx_params,
     pledgedSrcSize: u64,
     zbuff: ZSTD_buffered_policy_e,
-) -> size_t {
+) -> usize {
     let cdict_cParams: *const ZSTD_compressionParameters = &(*cdict).matchState.cParams;
     let windowLog = params.cParams.windowLog;
     params.cParams = *cdict_cParams;
@@ -4386,15 +4382,15 @@ unsafe fn ZSTD_resetCCtx_byCopyingCDict(
         libc::memcpy(
             (*cctx).blockState.matchState.tagTable as *mut core::ffi::c_void,
             (*cdict).matchState.tagTable as *const core::ffi::c_void,
-            tagTableSize as libc::size_t,
+            tagTableSize as usize,
         );
         (*cctx).blockState.matchState.hashSalt = (*cdict).matchState.hashSalt;
     }
     let h3log = (*cctx).blockState.matchState.hashLog3;
     let h3Size = if h3log != 0 {
-        (1 as size_t) << h3log
+        (1 as usize) << h3log
     } else {
-        0 as size_t
+        0 as usize
     };
     ptr::write_bytes(
         (*cctx).blockState.matchState.hashTable3 as *mut u8,
@@ -4422,7 +4418,7 @@ unsafe fn ZSTD_resetCCtx_usingCDict(
     params: *const ZSTD_CCtx_params,
     pledgedSrcSize: u64,
     zbuff: ZSTD_buffered_policy_e,
-) -> size_t {
+) -> usize {
     if ZSTD_shouldAttachDict(cdict, params, pledgedSrcSize) != 0 {
         ZSTD_resetCCtx_byAttachingCDict(cctx, cdict, *params, pledgedSrcSize, zbuff)
     } else {
@@ -4435,7 +4431,7 @@ unsafe fn ZSTD_copyCCtx_internal(
     fParams: ZSTD_frameParameters,
     pledgedSrcSize: u64,
     zbuff: ZSTD_buffered_policy_e,
-) -> size_t {
+) -> usize {
     if (*srcCCtx).stage as core::ffi::c_uint != ZSTDcs_init as core::ffi::c_int as core::ffi::c_uint
     {
         return Error::stage_wrong.to_error_code();
@@ -4467,31 +4463,31 @@ unsafe fn ZSTD_copyCCtx_internal(
         0,
     ) != 0
     {
-        (1 as size_t) << (*srcCCtx).appliedParams.cParams.chainLog
+        (1 as usize) << (*srcCCtx).appliedParams.cParams.chainLog
     } else {
-        0 as size_t
+        0 as usize
     };
-    let hSize = (1 as size_t) << (*srcCCtx).appliedParams.cParams.hashLog;
+    let hSize = (1 as usize) << (*srcCCtx).appliedParams.cParams.hashLog;
     let h3log = (*srcCCtx).blockState.matchState.hashLog3;
     let h3Size = if h3log != 0 {
-        (1 as size_t) << h3log
+        (1 as usize) << h3log
     } else {
-        0 as size_t
+        0 as usize
     };
     libc::memcpy(
         (*dstCCtx).blockState.matchState.hashTable as *mut core::ffi::c_void,
         (*srcCCtx).blockState.matchState.hashTable as *const core::ffi::c_void,
-        hSize.wrapping_mul(::core::mem::size_of::<u32>()) as libc::size_t,
+        hSize.wrapping_mul(::core::mem::size_of::<u32>()) as usize,
     );
     libc::memcpy(
         (*dstCCtx).blockState.matchState.chainTable as *mut core::ffi::c_void,
         (*srcCCtx).blockState.matchState.chainTable as *const core::ffi::c_void,
-        chainSize.wrapping_mul(::core::mem::size_of::<u32>()) as libc::size_t,
+        chainSize.wrapping_mul(::core::mem::size_of::<u32>()) as usize,
     );
     libc::memcpy(
         (*dstCCtx).blockState.matchState.hashTable3 as *mut core::ffi::c_void,
         (*srcCCtx).blockState.matchState.hashTable3 as *const core::ffi::c_void,
-        h3Size.wrapping_mul(::core::mem::size_of::<u32>()) as libc::size_t,
+        h3Size.wrapping_mul(::core::mem::size_of::<u32>()) as usize,
     );
     ZSTD_cwksp_mark_tables_clean(&mut (*dstCCtx).workspace);
     let srcMatchState: *const ZSTD_MatchState_t = &(*srcCCtx).blockState.matchState;
@@ -4504,7 +4500,7 @@ unsafe fn ZSTD_copyCCtx_internal(
     libc::memcpy(
         (*dstCCtx).blockState.prevCBlock as *mut core::ffi::c_void,
         (*srcCCtx).blockState.prevCBlock as *const core::ffi::c_void,
-        ::core::mem::size_of::<ZSTD_compressedBlockState_t>() as libc::size_t,
+        ::core::mem::size_of::<ZSTD_compressedBlockState_t>() as usize,
     );
     0
 }
@@ -4513,7 +4509,7 @@ pub unsafe extern "C" fn ZSTD_copyCCtx(
     dstCCtx: *mut ZSTD_CCtx,
     srcCCtx: *const ZSTD_CCtx,
     mut pledgedSrcSize: core::ffi::c_ulonglong,
-) -> size_t {
+) -> usize {
     let mut fParams = {
         ZSTD_frameParameters {
             contentSizeFlag: 1,
@@ -4639,7 +4635,7 @@ unsafe fn ZSTD_blockSplitterEnabled(cctxParams: *mut ZSTD_CCtx_params) -> core::
 }
 unsafe fn ZSTD_buildSequencesStatistics(
     seqStorePtr: *const SeqStore_t,
-    nbSeq: size_t,
+    nbSeq: usize,
     prevEntropy: *const ZSTD_fseCTables_t,
     nextEntropy: *mut ZSTD_fseCTables_t,
     dst: *mut u8,
@@ -4647,7 +4643,7 @@ unsafe fn ZSTD_buildSequencesStatistics(
     strategy: ZSTD_strategy,
     countWorkspace: *mut core::ffi::c_uint,
     entropyWorkspace: *mut core::ffi::c_void,
-    entropyWkspSize: size_t,
+    entropyWkspSize: usize,
 ) -> ZSTD_symbolEncodingTypeStats_t {
     let ostart = dst;
     let oend = dstEnd;
@@ -4827,42 +4823,42 @@ pub const SUSPECT_UNCOMPRESSIBLE_LITERAL_RATIO: core::ffi::c_int = 20;
 #[inline]
 unsafe fn ZSTD_entropyCompressSeqStore_internal(
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     literals: *const core::ffi::c_void,
-    litSize: size_t,
+    litSize: usize,
     seqStorePtr: *const SeqStore_t,
     prevEntropy: *const ZSTD_entropyCTables_t,
     nextEntropy: *mut ZSTD_entropyCTables_t,
     cctxParams: *const ZSTD_CCtx_params,
     mut entropyWorkspace: *mut core::ffi::c_void,
-    mut entropyWkspSize: size_t,
+    mut entropyWkspSize: usize,
     bmi2: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let strategy = (*cctxParams).cParams.strategy;
     let count = entropyWorkspace as *mut core::ffi::c_uint;
     let CTable_LitLength = (&raw const ((*nextEntropy).fse.litlengthCTable)).cast::<u32>();
     let CTable_OffsetBits = (&raw const ((*nextEntropy).fse.offcodeCTable)).cast::<u32>();
     let CTable_MatchLength = (&raw const ((*nextEntropy).fse.matchlengthCTable)).cast::<u32>();
     let sequences: *const SeqDef = (*seqStorePtr).sequencesStart;
-    let nbSeq = ((*seqStorePtr).sequences).offset_from((*seqStorePtr).sequencesStart) as size_t;
+    let nbSeq = ((*seqStorePtr).sequences).offset_from((*seqStorePtr).sequencesStart) as usize;
     let ofCodeTable: *const u8 = (*seqStorePtr).ofCode;
     let llCodeTable: *const u8 = (*seqStorePtr).llCode;
     let mlCodeTable: *const u8 = (*seqStorePtr).mlCode;
     let ostart = dst as *mut u8;
     let oend = ostart.add(dstCapacity);
     let mut op = ostart;
-    let mut lastCountSize: size_t = 0;
+    let mut lastCountSize: usize = 0;
     let mut longOffsets = 0;
     entropyWorkspace =
         count.offset(((if 35 > 52 { 35 } else { 52 }) + 1) as isize) as *mut core::ffi::c_void;
-    entropyWkspSize = (entropyWkspSize as size_t).wrapping_sub(
-        ((if 35 > 52 { 35 as size_t } else { 52 }) + 1)
+    entropyWkspSize = (entropyWkspSize as usize).wrapping_sub(
+        ((if 35 > 52 { 35 as usize } else { 52 }) + 1)
             .wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>()),
     );
     let numSequences =
-        ((*seqStorePtr).sequences).offset_from((*seqStorePtr).sequencesStart) as size_t;
+        ((*seqStorePtr).sequences).offset_from((*seqStorePtr).sequencesStart) as usize;
     let suspectUncompressible = (numSequences == 0
-        || litSize / numSequences >= SUSPECT_UNCOMPRESSIBLE_LITERAL_RATIO as size_t)
+        || litSize / numSequences >= SUSPECT_UNCOMPRESSIBLE_LITERAL_RATIO as usize)
         as core::ffi::c_int;
     let cSize = ZSTD_compressLiterals(
         op as *mut core::ffi::c_void,
@@ -4890,15 +4886,15 @@ unsafe fn ZSTD_entropyCompressSeqStore_internal(
         let fresh2 = op;
         op = op.add(1);
         *fresh2 = nbSeq as u8;
-    } else if nbSeq < LONGNBSEQ as size_t {
-        *op = (nbSeq >> 8).wrapping_add(0x80 as core::ffi::c_int as size_t) as u8;
+    } else if nbSeq < LONGNBSEQ as usize {
+        *op = (nbSeq >> 8).wrapping_add(0x80 as core::ffi::c_int as usize) as u8;
         *op.add(1) = nbSeq as u8;
         op = op.add(2);
     } else {
         *op = 0xff as core::ffi::c_int as u8;
         MEM_writeLE16(
             op.add(1) as *mut core::ffi::c_void,
-            nbSeq.wrapping_sub(LONGNBSEQ as size_t) as u16,
+            nbSeq.wrapping_sub(LONGNBSEQ as usize) as u16,
         );
         op = op.add(3);
     }
@@ -4961,18 +4957,18 @@ unsafe fn ZSTD_entropyCompressSeqStore_internal(
 }
 unsafe fn ZSTD_entropyCompressSeqStore_wExtLitBuffer(
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     literals: *const core::ffi::c_void,
-    litSize: size_t,
-    blockSize: size_t,
+    litSize: usize,
+    blockSize: usize,
     seqStorePtr: *const SeqStore_t,
     prevEntropy: *const ZSTD_entropyCTables_t,
     nextEntropy: *mut ZSTD_entropyCTables_t,
     cctxParams: *const ZSTD_CCtx_params,
     entropyWorkspace: *mut core::ffi::c_void,
-    entropyWkspSize: size_t,
+    entropyWkspSize: usize,
     bmi2: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let cSize = ZSTD_entropyCompressSeqStore_internal(
         dst,
         dstCapacity,
@@ -5011,17 +5007,17 @@ unsafe fn ZSTD_entropyCompressSeqStore(
     nextEntropy: *mut ZSTD_entropyCTables_t,
     cctxParams: *const ZSTD_CCtx_params,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
-    srcSize: size_t,
+    dstCapacity: usize,
+    srcSize: usize,
     entropyWorkspace: *mut core::ffi::c_void,
-    entropyWkspSize: size_t,
+    entropyWkspSize: usize,
     bmi2: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     ZSTD_entropyCompressSeqStore_wExtLitBuffer(
         dst,
         dstCapacity,
         (*seqStorePtr).litStart as *const core::ffi::c_void,
-        ((*seqStorePtr).lit).offset_from((*seqStorePtr).litStart) as size_t,
+        ((*seqStorePtr).lit).offset_from((*seqStorePtr).litStart) as usize,
         srcSize,
         seqStorePtr,
         prevEntropy,
@@ -5046,8 +5042,8 @@ pub unsafe fn ZSTD_selectBlockCompressor(
                         &mut SeqStore_t,
                         *mut u32,
                         *const core::ffi::c_void,
-                        size_t,
-                    ) -> size_t,
+                        usize,
+                    ) -> usize,
             ),
             Some(
                 ZSTD_compressBlock_fast
@@ -5056,8 +5052,8 @@ pub unsafe fn ZSTD_selectBlockCompressor(
                         &mut SeqStore_t,
                         *mut u32,
                         *const core::ffi::c_void,
-                        size_t,
-                    ) -> size_t,
+                        usize,
+                    ) -> usize,
             ),
             Some(ZSTD_COMPRESSBLOCK_DOUBLEFAST),
             Some(ZSTD_COMPRESSBLOCK_GREEDY),
@@ -5076,8 +5072,8 @@ pub unsafe fn ZSTD_selectBlockCompressor(
                         &mut SeqStore_t,
                         *mut u32,
                         *const core::ffi::c_void,
-                        size_t,
-                    ) -> size_t,
+                        usize,
+                    ) -> usize,
             ),
             Some(
                 ZSTD_compressBlock_fast_extDict
@@ -5086,8 +5082,8 @@ pub unsafe fn ZSTD_selectBlockCompressor(
                         &mut SeqStore_t,
                         *mut u32,
                         *const core::ffi::c_void,
-                        size_t,
-                    ) -> size_t,
+                        usize,
+                    ) -> usize,
             ),
             Some(ZSTD_COMPRESSBLOCK_DOUBLEFAST_EXTDICT),
             Some(ZSTD_COMPRESSBLOCK_GREEDY_EXTDICT),
@@ -5106,8 +5102,8 @@ pub unsafe fn ZSTD_selectBlockCompressor(
                         &mut SeqStore_t,
                         *mut u32,
                         *const core::ffi::c_void,
-                        size_t,
-                    ) -> size_t,
+                        usize,
+                    ) -> usize,
             ),
             Some(
                 ZSTD_compressBlock_fast_dictMatchState
@@ -5116,8 +5112,8 @@ pub unsafe fn ZSTD_selectBlockCompressor(
                         &mut SeqStore_t,
                         *mut u32,
                         *const core::ffi::c_void,
-                        size_t,
-                    ) -> size_t,
+                        usize,
+                    ) -> usize,
             ),
             Some(ZSTD_COMPRESSBLOCK_DOUBLEFAST_DICTMATCHSTATE),
             Some(ZSTD_COMPRESSBLOCK_GREEDY_DICTMATCHSTATE),
@@ -5182,12 +5178,12 @@ pub unsafe fn ZSTD_selectBlockCompressor(
 unsafe fn ZSTD_storeLastLiterals(
     seqStorePtr: &mut SeqStore_t,
     anchor: *const u8,
-    lastLLSize: size_t,
+    lastLLSize: usize,
 ) {
     libc::memcpy(
         seqStorePtr.lit as *mut core::ffi::c_void,
         anchor as *const core::ffi::c_void,
-        lastLLSize as libc::size_t,
+        lastLLSize as usize,
     );
     seqStorePtr.lit = (seqStorePtr.lit).add(lastLLSize);
 }
@@ -5198,10 +5194,10 @@ pub unsafe fn ZSTD_resetSeqStore(ssPtr: &mut SeqStore_t) {
 }
 unsafe fn ZSTD_postProcessSequenceProducerResult(
     outSeqs: *mut ZSTD_Sequence,
-    nbExternalSeqs: size_t,
-    outSeqsCapacity: size_t,
-    srcSize: size_t,
-) -> size_t {
+    nbExternalSeqs: usize,
+    outSeqsCapacity: usize,
+    srcSize: usize,
+) -> usize {
     if nbExternalSeqs > outSeqsCapacity {
         return Error::sequenceProducer_failed.to_error_code();
     }
@@ -5230,16 +5226,16 @@ unsafe fn ZSTD_postProcessSequenceProducerResult(
     );
     nbExternalSeqs.wrapping_add(1)
 }
-unsafe fn ZSTD_fastSequenceLengthSum(seqBuf: *const ZSTD_Sequence, seqBufSize: size_t) -> size_t {
-    let mut matchLenSum: size_t = 0;
-    let mut litLenSum: size_t = 0;
-    let mut i: size_t = 0;
+unsafe fn ZSTD_fastSequenceLengthSum(seqBuf: *const ZSTD_Sequence, seqBufSize: usize) -> usize {
+    let mut matchLenSum: usize = 0;
+    let mut litLenSum: usize = 0;
+    let mut i: usize = 0;
     matchLenSum = 0;
     litLenSum = 0;
     i = 0;
     while i < seqBufSize {
-        litLenSum = litLenSum.wrapping_add((*seqBuf.add(i)).litLength as size_t);
-        matchLenSum = matchLenSum.wrapping_add((*seqBuf.add(i)).matchLength as size_t);
+        litLenSum = litLenSum.wrapping_add((*seqBuf.add(i)).litLength as usize);
+        matchLenSum = matchLenSum.wrapping_add((*seqBuf.add(i)).matchLength as usize);
         i = i.wrapping_add(1);
     }
     litLenSum.wrapping_add(matchLenSum)
@@ -5267,12 +5263,12 @@ unsafe fn ZSTD_validateSeqStore(
 unsafe fn ZSTD_buildSeqStore(
     zc: *mut ZSTD_CCtx,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let ms: &mut ZSTD_MatchState_t = &mut (*zc).blockState.matchState;
     ZSTD_assertEqualCParams((*zc).appliedParams.cParams, ms.cParams);
     if srcSize
-        < (MIN_CBLOCK_SIZE as size_t)
+        < (MIN_CBLOCK_SIZE as usize)
             .wrapping_add(ZSTD_blockHeaderSize)
             .wrapping_add(1)
             .wrapping_add(1)
@@ -5288,7 +5284,7 @@ unsafe fn ZSTD_buildSeqStore(
                 (*zc).appliedParams.cParams.minMatch,
             );
         }
-        return ZSTDbss_noCompress as core::ffi::c_int as size_t;
+        return ZSTDbss_noCompress as core::ffi::c_int as usize;
     }
     ZSTD_resetSeqStore(&mut (*zc).seqStore);
     ms.opt.symbolCosts = &mut (*(*zc).blockState.prevCBlock).entropy;
@@ -5310,7 +5306,7 @@ unsafe fn ZSTD_buildSeqStore(
 
     /* select and store sequences */
     let dictMode = ZSTD_matchState_dictMode(ms);
-    let mut lastLLSize: size_t = 0;
+    let mut lastLLSize: usize = 0;
     let mut i: core::ffi::c_int = 0;
     i = 0;
     while i < ZSTD_REP_NUM {
@@ -5371,7 +5367,7 @@ unsafe fn ZSTD_buildSeqStore(
             core::ptr::null(),
             0,
             (*zc).appliedParams.compressionLevel,
-            windowSize as size_t,
+            windowSize as usize,
         );
         let nbPostProcessedSeqs = ZSTD_postProcessSequenceProducerResult(
             (*zc).extSeqBuf,
@@ -5404,7 +5400,7 @@ unsafe fn ZSTD_buildSeqStore(
                 return err_code_0;
             }
             ms.ldmSeqStore = core::ptr::null();
-            return ZSTDbss_compress as core::ffi::c_int as size_t;
+            return ZSTDbss_compress as core::ffi::c_int as usize;
         }
         if (*zc).appliedParams.enableMatchFinderFallback == 0 {
             return nbPostProcessedSeqs;
@@ -5442,25 +5438,25 @@ unsafe fn ZSTD_buildSeqStore(
         .offset(-(lastLLSize as isize));
     ZSTD_storeLastLiterals(&mut (*zc).seqStore, lastLiterals, lastLLSize);
     ZSTD_validateSeqStore(&(*zc).seqStore, &(*zc).appliedParams.cParams);
-    ZSTDbss_compress as core::ffi::c_int as size_t
+    ZSTDbss_compress as core::ffi::c_int as usize
 }
 unsafe fn ZSTD_copyBlockSequences(
     seqCollector: *mut SeqCollector,
     seqStore: *const SeqStore_t,
     prevRepcodes: *const u32,
-) -> size_t {
+) -> usize {
     let inSeqs: *const SeqDef = (*seqStore).sequencesStart;
     let nbInSequences = ((*seqStore).sequences).offset_from_unsigned(inSeqs);
-    let nbInLiterals = ((*seqStore).lit).offset_from((*seqStore).litStart) as size_t;
+    let nbInLiterals = ((*seqStore).lit).offset_from((*seqStore).litStart) as usize;
     let outSeqs = if (*seqCollector).seqIndex == 0 {
         (*seqCollector).seqStart
     } else {
         ((*seqCollector).seqStart).add((*seqCollector).seqIndex)
     };
     let nbOutSequences = nbInSequences.wrapping_add(1);
-    let mut nbOutLiterals = 0 as size_t;
+    let mut nbOutLiterals = 0 as usize;
     let mut repcodes = repcodes_s { rep: [0; 3] };
-    let mut i: size_t = 0;
+    let mut i: usize = 0;
     if nbOutSequences > ((*seqCollector).maxSequences).wrapping_sub((*seqCollector).seqIndex) {
         return Error::dstSize_tooSmall.to_error_code();
     }
@@ -5476,7 +5472,7 @@ unsafe fn ZSTD_copyBlockSequences(
         (*outSeqs.add(i)).matchLength =
             ((*inSeqs.add(i)).mlBase as core::ffi::c_int + MINMATCH) as core::ffi::c_uint;
         (*outSeqs.add(i)).rep = 0;
-        if i == (*seqStore).longLengthPos as size_t {
+        if i == (*seqStore).longLengthPos as usize {
             if (*seqStore).longLengthType == ZSTD_llt_literalLength {
                 let fresh4 = &mut (*outSeqs.add(i)).litLength;
                 *fresh4 = (*fresh4).wrapping_add(0x10000 as core::ffi::c_int as core::ffi::c_uint);
@@ -5506,7 +5502,7 @@ unsafe fn ZSTD_copyBlockSequences(
             (*inSeqs.add(i)).offBase,
             ((*inSeqs.add(i)).litLength as core::ffi::c_int == 0) as core::ffi::c_int as u32,
         );
-        nbOutLiterals = nbOutLiterals.wrapping_add((*outSeqs.add(i)).litLength as size_t);
+        nbOutLiterals = nbOutLiterals.wrapping_add((*outSeqs.add(i)).litLength as usize);
         i = i.wrapping_add(1);
     }
     let lastLLSize = nbInLiterals.wrapping_sub(nbOutLiterals);
@@ -5517,19 +5513,19 @@ unsafe fn ZSTD_copyBlockSequences(
     0
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_sequenceBound))]
-pub unsafe extern "C" fn ZSTD_sequenceBound(srcSize: size_t) -> size_t {
-    let maxNbSeq = (srcSize / ZSTD_MINMATCH_MIN as size_t).wrapping_add(1);
-    let maxNbDelims = (srcSize / ZSTD_BLOCKSIZE_MAX_MIN as size_t).wrapping_add(1);
+pub unsafe extern "C" fn ZSTD_sequenceBound(srcSize: usize) -> usize {
+    let maxNbSeq = (srcSize / ZSTD_MINMATCH_MIN as usize).wrapping_add(1);
+    let maxNbDelims = (srcSize / ZSTD_BLOCKSIZE_MAX_MIN as usize).wrapping_add(1);
     maxNbSeq.wrapping_add(maxNbDelims)
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_generateSequences))]
 pub unsafe extern "C" fn ZSTD_generateSequences(
     zc: *mut ZSTD_CCtx,
     outSeqs: *mut ZSTD_Sequence,
-    outSeqsSize: size_t,
+    outSeqsSize: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let dstCapacity = ZSTD_compressBound(srcSize);
     let mut dst = core::ptr::null_mut::<core::ffi::c_void>();
     let mut seqCollector = SeqCollector {
@@ -5578,10 +5574,10 @@ pub unsafe extern "C" fn ZSTD_generateSequences(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_mergeBlockDelimiters))]
 pub unsafe extern "C" fn ZSTD_mergeBlockDelimiters(
     sequences: *mut ZSTD_Sequence,
-    seqsSize: size_t,
-) -> size_t {
+    seqsSize: usize,
+) -> usize {
     let mut in_0 = 0;
-    let mut out = 0 as size_t;
+    let mut out = 0 as usize;
     while in_0 < seqsSize {
         if (*sequences.add(in_0)).offset == 0 && (*sequences.add(in_0)).matchLength == 0 {
             if in_0 != seqsSize.wrapping_sub(1) {
@@ -5596,15 +5592,15 @@ pub unsafe extern "C" fn ZSTD_mergeBlockDelimiters(
     }
     out
 }
-unsafe fn ZSTD_isRLE(src: *const u8, length: size_t) -> core::ffi::c_int {
+unsafe fn ZSTD_isRLE(src: *const u8, length: usize) -> core::ffi::c_int {
     let ip = src;
     let value = *ip;
     let valueST = (value as u64 as core::ffi::c_ulonglong)
-        .wrapping_mul(0x101010101010101 as core::ffi::c_ulonglong) as size_t;
-    let unrollSize = ::core::mem::size_of::<size_t>().wrapping_mul(4);
+        .wrapping_mul(0x101010101010101 as core::ffi::c_ulonglong) as usize;
+    let unrollSize = ::core::mem::size_of::<usize>().wrapping_mul(4);
     let unrollMask = unrollSize.wrapping_sub(1);
     let prefixLength = length & unrollMask;
-    let mut i: size_t = 0;
+    let mut i: usize = 0;
     if length == 1 {
         return 1;
     }
@@ -5615,21 +5611,21 @@ unsafe fn ZSTD_isRLE(src: *const u8, length: size_t) -> core::ffi::c_int {
     }
     i = prefixLength;
     while i != length {
-        let mut u: size_t = 0;
+        let mut u: usize = 0;
         u = 0;
         while u < unrollSize {
             if MEM_readST(ip.add(i).add(u) as *const core::ffi::c_void) != valueST {
                 return 0;
             }
-            u = (u as size_t).wrapping_add(::core::mem::size_of::<size_t>());
+            u = (u as usize).wrapping_add(::core::mem::size_of::<usize>());
         }
         i = i.wrapping_add(unrollSize);
     }
     1
 }
 unsafe fn ZSTD_maybeRLE(seqStore: *const SeqStore_t) -> core::ffi::c_int {
-    let nbSeqs = ((*seqStore).sequences).offset_from((*seqStore).sequencesStart) as size_t;
-    let nbLits = ((*seqStore).lit).offset_from((*seqStore).litStart) as size_t;
+    let nbSeqs = ((*seqStore).sequences).offset_from((*seqStore).sequencesStart) as usize;
+    let nbLits = ((*seqStore).lit).offset_from((*seqStore).litStart) as usize;
     (nbSeqs < 4 && nbLits < 10) as core::ffi::c_int
 }
 unsafe fn ZSTD_blockState_confirmRepcodesAndEntropyTables(bs: *mut ZSTD_blockState_t) {
@@ -5637,8 +5633,8 @@ unsafe fn ZSTD_blockState_confirmRepcodesAndEntropyTables(bs: *mut ZSTD_blockSta
 }
 unsafe fn writeBlockHeader(
     op: *mut core::ffi::c_void,
-    cSize: size_t,
-    blockSize: size_t,
+    cSize: usize,
+    blockSize: usize,
     lastBlock: u32,
 ) {
     let cBlockHeader = if cSize == 1 {
@@ -5654,20 +5650,20 @@ unsafe fn writeBlockHeader(
 }
 unsafe fn ZSTD_buildBlockEntropyStats_literals(
     src: *mut core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     prevHuf: *const ZSTD_hufCTables_t,
     nextHuf: *mut ZSTD_hufCTables_t,
     hufMetadata: *mut ZSTD_hufCTablesMetadata_t,
     literalsCompressionIsDisabled: core::ffi::c_int,
     workspace: *mut core::ffi::c_void,
-    wkspSize: size_t,
+    wkspSize: usize,
     hufFlags: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let wkspStart = workspace as *mut u8;
     let wkspEnd = wkspStart.add(wkspSize);
     let countWkspStart = wkspStart;
     let countWksp = workspace as *mut core::ffi::c_uint;
-    let countWkspSize = ((HUF_SYMBOLVALUE_MAX + 1) as size_t)
+    let countWkspSize = ((HUF_SYMBOLVALUE_MAX + 1) as usize)
         .wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>());
     let nodeWksp = countWkspStart.add(countWkspSize);
     let nodeWkspSize = wkspEnd.offset_from_unsigned(nodeWksp);
@@ -5689,7 +5685,7 @@ unsafe fn ZSTD_buildBlockEntropyStats_literals(
         6
     } else {
         COMPRESS_LITERALS_SIZE_MIN
-    }) as size_t;
+    }) as usize;
     if srcSize <= minLitSize {
         (*hufMetadata).hType = set_basic;
         return 0;
@@ -5812,17 +5808,17 @@ unsafe fn ZSTD_buildBlockEntropyStats_sequences(
     cctxParams: *const ZSTD_CCtx_params,
     fseMetadata: *mut ZSTD_fseCTablesMetadata_t,
     workspace: *mut core::ffi::c_void,
-    wkspSize: size_t,
-) -> size_t {
+    wkspSize: usize,
+) -> usize {
     let strategy = (*cctxParams).cParams.strategy;
-    let nbSeq = ((*seqStorePtr).sequences).offset_from((*seqStorePtr).sequencesStart) as size_t;
+    let nbSeq = ((*seqStorePtr).sequences).offset_from((*seqStorePtr).sequencesStart) as usize;
     let ostart = ((*fseMetadata).fseTablesBuffer).as_mut_ptr();
     let oend = ostart.add(::core::mem::size_of::<[u8; 133]>());
     let op = ostart;
     let countWorkspace = workspace as *mut core::ffi::c_uint;
     let entropyWorkspace = countWorkspace.offset(((if 35 > 52 { 35 } else { 52 }) + 1) as isize);
     let entropyWorkspaceSize = wkspSize.wrapping_sub(
-        ((if 35 > 52 { 35 as size_t } else { 52 }) + 1)
+        ((if 35 > 52 { 35 as usize } else { 52 }) + 1)
             .wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>()),
     );
     let mut stats = ZSTD_symbolEncodingTypeStats_t {
@@ -5866,9 +5862,9 @@ pub unsafe fn ZSTD_buildBlockEntropyStats(
     cctxParams: *const ZSTD_CCtx_params,
     entropyMetadata: *mut ZSTD_entropyCTablesMetadata_t,
     workspace: *mut core::ffi::c_void,
-    wkspSize: size_t,
-) -> size_t {
-    let litSize = ((*seqStorePtr).lit).offset_from((*seqStorePtr).litStart) as size_t;
+    wkspSize: usize,
+) -> usize {
+    let litSize = ((*seqStorePtr).lit).offset_from((*seqStorePtr).litStart) as usize;
     let huf_useOptDepth = ((*cctxParams).cParams.strategy as core::ffi::c_uint
         >= HUF_OPTIMAL_DEPTH_THRESHOLD as core::ffi::c_uint)
         as core::ffi::c_int;
@@ -5909,18 +5905,18 @@ pub unsafe fn ZSTD_buildBlockEntropyStats(
 }
 unsafe fn ZSTD_estimateBlockSize_literal(
     literals: *const u8,
-    litSize: size_t,
+    litSize: usize,
     huf: *const ZSTD_hufCTables_t,
     hufMetadata: *const ZSTD_hufCTablesMetadata_t,
     workspace: *mut core::ffi::c_void,
-    wkspSize: size_t,
+    wkspSize: usize,
     writeEntropy: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let countWksp = workspace as *mut core::ffi::c_uint;
     let mut maxSymbolValue = HUF_SYMBOLVALUE_MAX;
     let literalSectionHeaderSize =
-        (3 + (litSize >= ((1) << 10) as size_t) as core::ffi::c_int
-            + (litSize >= (16 * ((1) << 10)) as size_t) as core::ffi::c_int) as size_t;
+        (3 + (litSize >= ((1) << 10) as usize) as core::ffi::c_int
+            + (litSize >= (16 * ((1) << 10)) as usize) as core::ffi::c_int) as usize;
     let singleStream = (litSize < 256) as core::ffi::c_int as u32;
     if (*hufMetadata).hType as core::ffi::c_uint
         == set_basic as core::ffi::c_int as core::ffi::c_uint
@@ -5961,7 +5957,7 @@ unsafe fn ZSTD_estimateBlockSize_literal(
 unsafe fn ZSTD_estimateBlockSize_symbolType(
     type_0: SymbolEncodingType_e,
     codeTable: *const u8,
-    nbSeq: size_t,
+    nbSeq: usize,
     maxCode: core::ffi::c_uint,
     fseCTable: *const FSE_CTable,
     additionalBits: *const u8,
@@ -5969,8 +5965,8 @@ unsafe fn ZSTD_estimateBlockSize_symbolType(
     defaultNormLog: u32,
     defaultMax: u32,
     workspace: *mut core::ffi::c_void,
-    wkspSize: size_t,
-) -> size_t {
+    wkspSize: usize,
+) -> usize {
     let countWksp = workspace as *mut core::ffi::c_uint;
     let mut ctp = codeTable;
     let ctStart = ctp;
@@ -6004,10 +6000,10 @@ unsafe fn ZSTD_estimateBlockSize_symbolType(
     while ctp < ctEnd {
         if !additionalBits.is_null() {
             cSymbolTypeSizeEstimateInBits = cSymbolTypeSizeEstimateInBits
-                .wrapping_add(*additionalBits.offset(*ctp as isize) as size_t);
+                .wrapping_add(*additionalBits.offset(*ctp as isize) as usize);
         } else {
             cSymbolTypeSizeEstimateInBits =
-                cSymbolTypeSizeEstimateInBits.wrapping_add(*ctp as size_t);
+                cSymbolTypeSizeEstimateInBits.wrapping_add(*ctp as usize);
         }
         ctp = ctp.add(1);
     }
@@ -6017,18 +6013,18 @@ unsafe fn ZSTD_estimateBlockSize_sequences(
     ofCodeTable: *const u8,
     llCodeTable: *const u8,
     mlCodeTable: *const u8,
-    nbSeq: size_t,
+    nbSeq: usize,
     fseTables: *const ZSTD_fseCTables_t,
     fseMetadata: *const ZSTD_fseCTablesMetadata_t,
     workspace: *mut core::ffi::c_void,
-    wkspSize: size_t,
+    wkspSize: usize,
     writeEntropy: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let sequencesSectionHeaderSize =
         (1 + 1
             + (nbSeq >= 128) as core::ffi::c_int
-            + (nbSeq >= LONGNBSEQ as size_t) as core::ffi::c_int) as size_t;
-    let mut cSeqSizeEstimate = 0 as size_t;
+            + (nbSeq >= LONGNBSEQ as usize) as core::ffi::c_int) as usize;
+    let mut cSeqSizeEstimate = 0 as usize;
     cSeqSizeEstimate = cSeqSizeEstimate.wrapping_add(ZSTD_estimateBlockSize_symbolType(
         (*fseMetadata).ofType,
         ofCodeTable,
@@ -6075,18 +6071,18 @@ unsafe fn ZSTD_estimateBlockSize_sequences(
 }
 unsafe fn ZSTD_estimateBlockSize(
     literals: *const u8,
-    litSize: size_t,
+    litSize: usize,
     ofCodeTable: *const u8,
     llCodeTable: *const u8,
     mlCodeTable: *const u8,
-    nbSeq: size_t,
+    nbSeq: usize,
     entropy: *const ZSTD_entropyCTables_t,
     entropyMetadata: *const ZSTD_entropyCTablesMetadata_t,
     workspace: *mut core::ffi::c_void,
-    wkspSize: size_t,
+    wkspSize: usize,
     writeLitEntropy: core::ffi::c_int,
     writeSeqEntropy: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let literalsSize = ZSTD_estimateBlockSize_literal(
         literals,
         litSize,
@@ -6114,7 +6110,7 @@ unsafe fn ZSTD_estimateBlockSize(
 unsafe fn ZSTD_buildEntropyStatisticsAndEstimateSubBlockSize(
     seqStore: &mut SeqStore_t,
     zc: *mut ZSTD_CCtx,
-) -> size_t {
+) -> usize {
     let entropyMetadata: *mut ZSTD_entropyCTablesMetadata_t =
         &mut (*zc).blockSplitCtx.entropyMetadata;
     let err_code = ZSTD_buildBlockEntropyStats(
@@ -6135,7 +6131,7 @@ unsafe fn ZSTD_buildEntropyStatisticsAndEstimateSubBlockSize(
         seqStore.ofCode,
         seqStore.llCode,
         seqStore.mlCode,
-        (seqStore.sequences).offset_from(seqStore.sequencesStart) as core::ffi::c_long as size_t,
+        (seqStore.sequences).offset_from(seqStore.sequencesStart) as core::ffi::c_long as usize,
         &(*(*zc).blockState.nextCBlock).entropy,
         entropyMetadata,
         (*zc).tmpWorkspace,
@@ -6145,35 +6141,35 @@ unsafe fn ZSTD_buildEntropyStatisticsAndEstimateSubBlockSize(
         1,
     )
 }
-unsafe fn ZSTD_countSeqStoreLiteralsBytes(seqStore: *const SeqStore_t) -> size_t {
-    let mut literalsBytes = 0 as size_t;
-    let nbSeqs = ((*seqStore).sequences).offset_from((*seqStore).sequencesStart) as size_t;
-    let mut i: size_t = 0;
+unsafe fn ZSTD_countSeqStoreLiteralsBytes(seqStore: *const SeqStore_t) -> usize {
+    let mut literalsBytes = 0 as usize;
+    let nbSeqs = ((*seqStore).sequences).offset_from((*seqStore).sequencesStart) as usize;
+    let mut i: usize = 0;
     i = 0;
     while i < nbSeqs {
         let seq = *((*seqStore).sequencesStart).add(i);
-        literalsBytes = literalsBytes.wrapping_add(seq.litLength as size_t);
-        if i == (*seqStore).longLengthPos as size_t
+        literalsBytes = literalsBytes.wrapping_add(seq.litLength as usize);
+        if i == (*seqStore).longLengthPos as usize
             && (*seqStore).longLengthType == ZSTD_llt_literalLength
         {
-            literalsBytes = literalsBytes.wrapping_add(0x10000 as core::ffi::c_int as size_t);
+            literalsBytes = literalsBytes.wrapping_add(0x10000 as core::ffi::c_int as usize);
         }
         i = i.wrapping_add(1);
     }
     literalsBytes
 }
-unsafe fn ZSTD_countSeqStoreMatchBytes(seqStore: *const SeqStore_t) -> size_t {
-    let mut matchBytes = 0 as size_t;
-    let nbSeqs = ((*seqStore).sequences).offset_from((*seqStore).sequencesStart) as size_t;
-    let mut i: size_t = 0;
+unsafe fn ZSTD_countSeqStoreMatchBytes(seqStore: *const SeqStore_t) -> usize {
+    let mut matchBytes = 0 as usize;
+    let nbSeqs = ((*seqStore).sequences).offset_from((*seqStore).sequencesStart) as usize;
+    let mut i: usize = 0;
     i = 0;
     while i < nbSeqs {
         let seq = *((*seqStore).sequencesStart).add(i);
-        matchBytes = matchBytes.wrapping_add((seq.mlBase as core::ffi::c_int + MINMATCH) as size_t);
-        if i == (*seqStore).longLengthPos as size_t
+        matchBytes = matchBytes.wrapping_add((seq.mlBase as core::ffi::c_int + MINMATCH) as usize);
+        if i == (*seqStore).longLengthPos as usize
             && (*seqStore).longLengthType == ZSTD_llt_matchLength
         {
-            matchBytes = matchBytes.wrapping_add(0x10000 as core::ffi::c_int as size_t);
+            matchBytes = matchBytes.wrapping_add(0x10000 as core::ffi::c_int as usize);
         }
         i = i.wrapping_add(1);
     }
@@ -6182,8 +6178,8 @@ unsafe fn ZSTD_countSeqStoreMatchBytes(seqStore: *const SeqStore_t) -> size_t {
 unsafe fn ZSTD_deriveSeqStoreChunk(
     resultSeqStore: &mut SeqStore_t,
     originalSeqStore: *const SeqStore_t,
-    startIdx: size_t,
-    endIdx: size_t,
+    startIdx: usize,
+    endIdx: usize,
 ) {
     *resultSeqStore = *originalSeqStore;
     if startIdx > 0 {
@@ -6192,8 +6188,8 @@ unsafe fn ZSTD_deriveSeqStoreChunk(
             (resultSeqStore.litStart).add(ZSTD_countSeqStoreLiteralsBytes(resultSeqStore));
     }
     if (*originalSeqStore).longLengthType != ZSTD_llt_none {
-        if ((*originalSeqStore).longLengthPos as size_t) < startIdx
-            || (*originalSeqStore).longLengthPos as size_t > endIdx
+        if ((*originalSeqStore).longLengthPos as usize) < startIdx
+            || (*originalSeqStore).longLengthPos as usize > endIdx
         {
             resultSeqStore.longLengthType = ZSTD_llt_none;
         } else {
@@ -6204,7 +6200,7 @@ unsafe fn ZSTD_deriveSeqStoreChunk(
     resultSeqStore.sequencesStart = ((*originalSeqStore).sequencesStart).add(startIdx);
     resultSeqStore.sequences = ((*originalSeqStore).sequencesStart).add(endIdx);
     if endIdx
-        != ((*originalSeqStore).sequences).offset_from((*originalSeqStore).sequencesStart) as size_t
+        != ((*originalSeqStore).sequences).offset_from((*originalSeqStore).sequencesStart) as usize
     {
         let literalsBytes = ZSTD_countSeqStoreLiteralsBytes(resultSeqStore);
         resultSeqStore.lit = (resultSeqStore.litStart).add(literalsBytes);
@@ -6263,17 +6259,17 @@ unsafe fn ZSTD_compressSeqStore_singleBlock(
     dRep: *mut Repcodes_t,
     cRep: *mut Repcodes_t,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     lastBlock: u32,
     isPartition: u32,
-) -> size_t {
+) -> usize {
     let rleMaxLength = 25;
     let op = dst as *mut u8;
     let ip = src as *const u8;
-    let mut cSize: size_t = 0;
-    let mut cSeqsSize: size_t = 0;
+    let mut cSize: usize = 0;
+    let mut cSeqsSize: usize = 0;
     let dRepOriginal = *dRep;
     if isPartition != 0 {
         ZSTD_seqStore_resolveOffCodes(
@@ -6304,7 +6300,7 @@ unsafe fn ZSTD_compressSeqStore_singleBlock(
         return err_code;
     }
     if (*zc).isFirstBlock == 0
-        && cSeqsSize < rleMaxLength as size_t
+        && cSeqsSize < rleMaxLength as usize
         && ZSTD_isRLE(src as *const u8, srcSize) != 0
     {
         cSeqsSize = 1;
@@ -6368,20 +6364,20 @@ unsafe fn ZSTD_compressSeqStore_singleBlock(
 pub const MIN_SEQUENCES_BLOCK_SPLITTING: core::ffi::c_int = 300;
 unsafe fn ZSTD_deriveBlockSplitsHelper(
     splits: *mut seqStoreSplits,
-    startIdx: size_t,
-    endIdx: size_t,
+    startIdx: usize,
+    endIdx: usize,
     zc: *mut ZSTD_CCtx,
     origSeqStore: *const SeqStore_t,
 ) {
     let fullSeqStoreChunk: &mut SeqStore_t = &mut (*zc).blockSplitCtx.fullSeqStoreChunk;
     let firstHalfSeqStore: &mut SeqStore_t = &mut (*zc).blockSplitCtx.firstHalfSeqStore;
     let secondHalfSeqStore: &mut SeqStore_t = &mut (*zc).blockSplitCtx.secondHalfSeqStore;
-    let mut estimatedOriginalSize: size_t = 0;
-    let mut estimatedFirstHalfSize: size_t = 0;
-    let mut estimatedSecondHalfSize: size_t = 0;
+    let mut estimatedOriginalSize: usize = 0;
+    let mut estimatedFirstHalfSize: usize = 0;
+    let mut estimatedSecondHalfSize: usize = 0;
     let midIdx = startIdx.wrapping_add(endIdx) / 2;
-    if endIdx.wrapping_sub(startIdx) < MIN_SEQUENCES_BLOCK_SPLITTING as size_t
-        || (*splits).idx >= ZSTD_MAX_NB_BLOCK_SPLITS as size_t
+    if endIdx.wrapping_sub(startIdx) < MIN_SEQUENCES_BLOCK_SPLITTING as usize
+        || (*splits).idx >= ZSTD_MAX_NB_BLOCK_SPLITS as usize
     {
         return;
     }
@@ -6407,7 +6403,7 @@ unsafe fn ZSTD_deriveBlockSplitsHelper(
         ZSTD_deriveBlockSplitsHelper(splits, midIdx, endIdx, zc, origSeqStore);
     }
 }
-unsafe fn ZSTD_deriveBlockSplits(zc: *mut ZSTD_CCtx, partitions: *mut u32, nbSeq: u32) -> size_t {
+unsafe fn ZSTD_deriveBlockSplits(zc: *mut ZSTD_CCtx, partitions: *mut u32, nbSeq: u32) -> usize {
     let mut splits = seqStoreSplits {
         splitLocations: core::ptr::null_mut::<u32>(),
         idx: 0,
@@ -6417,24 +6413,24 @@ unsafe fn ZSTD_deriveBlockSplits(zc: *mut ZSTD_CCtx, partitions: *mut u32, nbSeq
     if nbSeq <= 4 {
         return 0;
     }
-    ZSTD_deriveBlockSplitsHelper(&mut splits, 0, nbSeq as size_t, zc, &(*zc).seqStore);
+    ZSTD_deriveBlockSplitsHelper(&mut splits, 0, nbSeq as usize, zc, &(*zc).seqStore);
     *(splits.splitLocations).add(splits.idx) = nbSeq;
     splits.idx
 }
 unsafe fn ZSTD_compressBlock_splitBlock_internal(
     zc: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    mut dstCapacity: size_t,
+    mut dstCapacity: usize,
     src: *const core::ffi::c_void,
-    blockSize: size_t,
+    blockSize: usize,
     lastBlock: u32,
     nbSeq: u32,
-) -> size_t {
-    let mut cSize = 0 as size_t;
+) -> usize {
+    let mut cSize = 0 as usize;
     let mut ip = src as *const u8;
     let mut op = dst as *mut u8;
     let mut i = 0;
-    let mut srcBytesTotal = 0 as size_t;
+    let mut srcBytesTotal = 0 as usize;
     let partitions = ((*zc).blockSplitCtx.partitions).as_mut_ptr();
     let nextSeqStore: &mut SeqStore_t = &mut (*zc).blockSplitCtx.nextSeqStore;
     let currSeqStore: &mut SeqStore_t = &mut (*zc).blockSplitCtx.currSeqStore;
@@ -6475,10 +6471,10 @@ unsafe fn ZSTD_compressBlock_splitBlock_internal(
         }
         return cSizeSingleBlock;
     }
-    ZSTD_deriveSeqStoreChunk(currSeqStore, &(*zc).seqStore, 0, *partitions as size_t);
+    ZSTD_deriveSeqStoreChunk(currSeqStore, &(*zc).seqStore, 0, *partitions as usize);
     i = 0;
     while i <= numSplits {
-        let mut cSizeChunk: size_t = 0;
+        let mut cSizeChunk: usize = 0;
         let lastPartition = (i == numSplits) as core::ffi::c_int as u32;
         let mut lastBlockEntireSrc = 0;
         let mut srcBytes = (ZSTD_countSeqStoreLiteralsBytes(currSeqStore))
@@ -6491,8 +6487,8 @@ unsafe fn ZSTD_compressBlock_splitBlock_internal(
             ZSTD_deriveSeqStoreChunk(
                 nextSeqStore,
                 &(*zc).seqStore,
-                *partitions.add(i) as size_t,
-                *partitions.add(i.wrapping_add(1)) as size_t,
+                *partitions.add(i) as usize,
+                *partitions.add(i.wrapping_add(1)) as usize,
             );
         }
         cSizeChunk = ZSTD_compressSeqStore_singleBlock(
@@ -6528,19 +6524,19 @@ unsafe fn ZSTD_compressBlock_splitBlock_internal(
 unsafe fn ZSTD_compressBlock_splitBlock(
     zc: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     lastBlock: u32,
-) -> size_t {
+) -> usize {
     let mut nbSeq: u32 = 0;
-    let mut cSize: size_t = 0;
+    let mut cSize: usize = 0;
     let bss = ZSTD_buildSeqStore(zc, src, srcSize);
     let err_code = bss;
     if ERR_isError(err_code) {
         return err_code;
     }
-    if bss == ZSTDbss_noCompress as core::ffi::c_int as size_t {
+    if bss == ZSTDbss_noCompress as core::ffi::c_int as usize {
         if (*(*zc).blockState.prevCBlock)
             .entropy
             .fse
@@ -6582,13 +6578,13 @@ unsafe fn ZSTD_compressBlock_splitBlock(
 unsafe fn ZSTD_compressBlock_internal(
     zc: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     frame: u32,
-) -> size_t {
+) -> usize {
     let rleMaxLength = 25;
-    let mut cSize: size_t = 0;
+    let mut cSize: usize = 0;
     let ip = src as *const u8;
     let op = dst as *mut u8;
     let bss = ZSTD_buildSeqStore(zc, src, srcSize);
@@ -6596,7 +6592,7 @@ unsafe fn ZSTD_compressBlock_internal(
     if ERR_isError(err_code) {
         return err_code;
     }
-    if bss == ZSTDbss_noCompress as core::ffi::c_int as size_t {
+    if bss == ZSTDbss_noCompress as core::ffi::c_int as usize {
         if (*zc).seqCollector.collectSequences != 0 {
             return Error::sequenceProducer_failed.to_error_code();
         }
@@ -6628,7 +6624,7 @@ unsafe fn ZSTD_compressBlock_internal(
         );
         if frame != 0
             && (*zc).isFirstBlock == 0
-            && cSize < rleMaxLength as size_t
+            && cSize < rleMaxLength as usize
             && ZSTD_isRLE(ip, srcSize) != 0
         {
             cSize = 1;
@@ -6654,13 +6650,13 @@ unsafe fn ZSTD_compressBlock_internal(
 unsafe fn ZSTD_compressBlock_targetCBlockSize_body(
     zc: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-    bss: size_t,
+    srcSize: usize,
+    bss: usize,
     lastBlock: u32,
-) -> size_t {
-    if bss == ZSTDbss_compress as core::ffi::c_int as size_t {
+) -> usize {
+    if bss == ZSTDbss_compress as core::ffi::c_int as usize {
         if (*zc).isFirstBlock == 0
             && ZSTD_maybeRLE(&(*zc).seqStore) != 0
             && ZSTD_isRLE(src as *const u8, srcSize) != 0
@@ -6692,11 +6688,11 @@ unsafe fn ZSTD_compressBlock_targetCBlockSize_body(
 unsafe fn ZSTD_compressBlock_targetCBlockSize(
     zc: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     lastBlock: u32,
-) -> size_t {
+) -> usize {
     let mut cSize = 0;
     let bss = ZSTD_buildSeqStore(zc, src, srcSize);
     let err_code = bss;
@@ -6756,14 +6752,14 @@ unsafe fn ZSTD_overflowCorrectIfNeeded(
 unsafe fn ZSTD_optimalBlockSize(
     cctx: *mut ZSTD_CCtx,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-    blockSizeMax: size_t,
+    srcSize: usize,
+    blockSizeMax: usize,
     mut splitLevel: core::ffi::c_int,
     strat: ZSTD_strategy,
     savings: S64,
-) -> size_t {
+) -> usize {
     static splitLevels: [core::ffi::c_int; 10] = [0, 0, 1, 2, 2, 3, 3, 4, 4, 4];
-    if srcSize < (128 * ((1) << 10)) as size_t || blockSizeMax < (128 * ((1) << 10)) as size_t {
+    if srcSize < (128 * ((1) << 10)) as usize || blockSizeMax < (128 * ((1) << 10)) as usize {
         return if srcSize < blockSizeMax {
             srcSize
         } else {
@@ -6771,10 +6767,10 @@ unsafe fn ZSTD_optimalBlockSize(
         };
     }
     if savings < 3 {
-        return (128 * ((1) << 10)) as size_t;
+        return (128 * ((1) << 10)) as usize;
     }
     if splitLevel == 1 {
-        return (128 * ((1) << 10)) as size_t;
+        return (128 * ((1) << 10)) as usize;
     }
     if splitLevel == 0 {
         splitLevel = *splitLevels.as_ptr().offset(strat as isize);
@@ -6792,11 +6788,11 @@ unsafe fn ZSTD_optimalBlockSize(
 unsafe fn ZSTD_compress_frameChunk(
     cctx: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    mut dstCapacity: size_t,
+    mut dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     lastFrameChunk: u32,
-) -> size_t {
+) -> usize {
     let blockSizeMax = (*cctx).blockSizeMax;
     let mut remaining = srcSize;
     let mut ip = src as *const u8;
@@ -6824,7 +6820,7 @@ unsafe fn ZSTD_compress_frameChunk(
         let lastBlock = lastFrameChunk & (blockSize == remaining) as core::ffi::c_int as u32;
         if dstCapacity
             < ZSTD_blockHeaderSize
-                .wrapping_add((1 + 1) as size_t)
+                .wrapping_add((1 + 1) as usize)
                 .wrapping_add(1)
         {
             return Error::dstSize_tooSmall.to_error_code();
@@ -6853,7 +6849,7 @@ unsafe fn ZSTD_compress_frameChunk(
         if ms.nextToUpdate < ms.window.lowLimit {
             ms.nextToUpdate = ms.window.lowLimit;
         }
-        let mut cSize: size_t = 0;
+        let mut cSize: usize = 0;
         if ZSTD_useTargetCBlockSize(&(*cctx).appliedParams) != 0 {
             cSize = ZSTD_compressBlock_targetCBlockSize(
                 cctx,
@@ -6933,11 +6929,11 @@ unsafe fn ZSTD_compress_frameChunk(
 }
 unsafe fn ZSTD_writeFrameHeader(
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     params: *const ZSTD_CCtx_params,
     pledgedSrcSize: u64,
     dictID: u32,
-) -> size_t {
+) -> usize {
     let op = dst as *mut u8;
     let dictIDSizeCodeLength = ((dictID > 0) as core::ffi::c_int
         + (dictID >= 256) as core::ffi::c_int
@@ -6965,7 +6961,7 @@ unsafe fn ZSTD_writeFrameHeader(
         .wrapping_add(checksumFlag << 2)
         .wrapping_add(singleSegment << 5)
         .wrapping_add(fcsCode << 6) as u8;
-    let mut pos = 0 as size_t;
+    let mut pos = 0 as usize;
     if dstCapacity < 18 {
         return Error::dstSize_tooSmall.to_error_code();
     }
@@ -7025,16 +7021,16 @@ unsafe fn ZSTD_writeFrameHeader(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_writeSkippableFrame))]
 pub unsafe extern "C" fn ZSTD_writeSkippableFrame(
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     magicVariant: core::ffi::c_uint,
-) -> size_t {
+) -> usize {
     let op = dst as *mut u8;
     if dstCapacity < srcSize.wrapping_add(8) {
         return Error::dstSize_tooSmall.to_error_code();
     }
-    if srcSize > 0xffffffff as core::ffi::c_uint as size_t {
+    if srcSize > 0xffffffff as core::ffi::c_uint as usize {
         return Error::srcSize_wrong.to_error_code();
     }
     if magicVariant > 15 {
@@ -7045,14 +7041,10 @@ pub unsafe extern "C" fn ZSTD_writeSkippableFrame(
         ZSTD_MAGIC_SKIPPABLE_START.wrapping_add(magicVariant),
     );
     MEM_writeLE32(op.add(4) as *mut core::ffi::c_void, srcSize as u32);
-    libc::memcpy(
-        op.add(8) as *mut core::ffi::c_void,
-        src,
-        srcSize as libc::size_t,
-    );
-    srcSize.wrapping_add(ZSTD_SKIPPABLEHEADERSIZE as size_t)
+    libc::memcpy(op.add(8) as *mut core::ffi::c_void, src, srcSize as usize);
+    srcSize.wrapping_add(ZSTD_SKIPPABLEHEADERSIZE as usize)
 }
-pub unsafe fn ZSTD_writeLastEmptyBlock(dst: *mut core::ffi::c_void, dstCapacity: size_t) -> size_t {
+pub unsafe fn ZSTD_writeLastEmptyBlock(dst: *mut core::ffi::c_void, dstCapacity: usize) -> usize {
     if dstCapacity < ZSTD_blockHeaderSize {
         return Error::dstSize_tooSmall.to_error_code();
     }
@@ -7063,7 +7055,7 @@ pub unsafe fn ZSTD_writeLastEmptyBlock(dst: *mut core::ffi::c_void, dstCapacity:
 pub unsafe fn ZSTD_referenceExternalSequences(
     cctx: *mut ZSTD_CCtx,
     seq: *mut rawSeq,
-    nbSeq: size_t,
+    nbSeq: usize,
 ) {
     (*cctx).externSeqStore.seq = seq;
     (*cctx).externSeqStore.size = nbSeq;
@@ -7074,12 +7066,12 @@ pub unsafe fn ZSTD_referenceExternalSequences(
 unsafe extern "C" fn ZSTD_compressContinue_internal(
     cctx: *mut ZSTD_CCtx,
     mut dst: *mut core::ffi::c_void,
-    mut dstCapacity: size_t,
+    mut dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     frame: u32,
     lastFrameChunk: u32,
-) -> size_t {
+) -> usize {
     let ms: &mut ZSTD_MatchState_t = &mut (*cctx).blockState.matchState;
     let mut fhSize = 0;
     if (*cctx).stage as core::ffi::c_uint == ZSTDcs_created as core::ffi::c_int as core::ffi::c_uint
@@ -7148,23 +7140,23 @@ unsafe extern "C" fn ZSTD_compressContinue_internal(
 pub unsafe extern "C" fn ZSTD_compressContinue_public(
     cctx: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressContinue_internal(cctx, dst, dstCapacity, src, srcSize, 1, 0)
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_compressContinue))]
 pub unsafe extern "C" fn ZSTD_compressContinue(
     cctx: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressContinue_public(cctx, dst, dstCapacity, src, srcSize)
 }
-unsafe fn ZSTD_getBlockSize_deprecated(cctx: *const ZSTD_CCtx) -> size_t {
+unsafe fn ZSTD_getBlockSize_deprecated(cctx: *const ZSTD_CCtx) -> usize {
     let cParams = (*cctx).appliedParams.cParams;
     if (*cctx).appliedParams.maxBlockSize < (1) << cParams.windowLog {
         (*cctx).appliedParams.maxBlockSize
@@ -7173,17 +7165,17 @@ unsafe fn ZSTD_getBlockSize_deprecated(cctx: *const ZSTD_CCtx) -> size_t {
     }
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_getBlockSize))]
-pub unsafe extern "C" fn ZSTD_getBlockSize(cctx: *const ZSTD_CCtx) -> size_t {
+pub unsafe extern "C" fn ZSTD_getBlockSize(cctx: *const ZSTD_CCtx) -> usize {
     ZSTD_getBlockSize_deprecated(cctx)
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_compressBlock_deprecated))]
 pub unsafe extern "C" fn ZSTD_compressBlock_deprecated(
     cctx: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let blockSizeMax = ZSTD_getBlockSize_deprecated(cctx);
     if srcSize > blockSizeMax {
         return Error::srcSize_wrong.to_error_code();
@@ -7194,10 +7186,10 @@ pub unsafe extern "C" fn ZSTD_compressBlock_deprecated(
 pub unsafe extern "C" fn ZSTD_compressBlock(
     cctx: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_deprecated(cctx, dst, dstCapacity, src, srcSize)
 }
 unsafe fn ZSTD_loadDictionaryContent(
@@ -7206,10 +7198,10 @@ unsafe fn ZSTD_loadDictionaryContent(
     ws: *mut ZSTD_cwksp,
     params: *const ZSTD_CCtx_params,
     mut src: *const core::ffi::c_void,
-    mut srcSize: size_t,
+    mut srcSize: usize,
     dtlm: ZSTD_dictTableLoadMethod_e,
     tfp: ZSTD_tableFillPurpose_e,
-) -> size_t {
+) -> usize {
     let mut ip = src as *const u8;
     let iend = ip.add(srcSize);
     let loadLdmDict = ((*params).ldmParams.enableLdm == ZSTD_ParamSwitch_e::ZSTD_ps_enable
@@ -7235,10 +7227,10 @@ unsafe fn ZSTD_loadDictionaryContent(
             shortCacheMaxDictSize
         };
     }
-    if srcSize > maxDictSize as size_t {
+    if srcSize > maxDictSize as usize {
         ip = iend.offset(-(maxDictSize as isize));
         src = ip as *const core::ffi::c_void;
-        srcSize = maxDictSize as size_t;
+        srcSize = maxDictSize as usize;
     }
     if srcSize
         > (-(1 as core::ffi::c_int) as u32).wrapping_sub(if MEM_64bits() {
@@ -7247,7 +7239,7 @@ unsafe fn ZSTD_loadDictionaryContent(
         } else {
             (2000 as core::ffi::c_uint)
                 .wrapping_mul(((1 as core::ffi::c_int) << 20) as core::ffi::c_uint)
-        }) as size_t
+        }) as usize
     {
         assert!(loadLdmDict != 0);
     }
@@ -7280,10 +7272,10 @@ unsafe fn ZSTD_loadDictionaryContent(
         } else {
             31
         });
-    if srcSize > maxDictSize_0 as size_t {
+    if srcSize > maxDictSize_0 as usize {
         ip = iend.offset(-(maxDictSize_0 as isize));
         src = ip as *const core::ffi::c_void;
-        srcSize = maxDictSize_0 as size_t;
+        srcSize = maxDictSize_0 as usize;
     }
     ms.nextToUpdate = ip.offset_from(ms.window.base) as core::ffi::c_long as u32;
     ms.loadedDictEnd = if (*params).forceWindow != 0 {
@@ -7292,7 +7284,7 @@ unsafe fn ZSTD_loadDictionaryContent(
         iend.offset_from(ms.window.base) as core::ffi::c_long as u32
     };
     ms.forceNonContiguous = (*params).deterministicRefPrefix;
-    if srcSize <= HASH_READ_SIZE as size_t {
+    if srcSize <= HASH_READ_SIZE as usize {
         return 0;
     }
     ZSTD_overflowCorrectIfNeeded(
@@ -7353,8 +7345,8 @@ pub unsafe fn ZSTD_loadCEntropy(
     bs: *mut ZSTD_compressedBlockState_t,
     workspace: *mut core::ffi::c_void,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
-) -> size_t {
+    dictSize: usize,
+) -> usize {
     let mut offcodeNCount: [core::ffi::c_short; 32] = [0; 32];
     let mut offcodeMaxValue = MaxOff;
     let mut dictPtr = dict as *const u8;
@@ -7397,7 +7389,7 @@ pub unsafe fn ZSTD_loadCEntropy(
         31,
         offcodeLog,
         workspace,
-        (((8) << 10) + 512) as size_t,
+        (((8) << 10) + 512) as usize,
     )) {
         return Error::dictionary_corrupted.to_error_code();
     }
@@ -7424,7 +7416,7 @@ pub unsafe fn ZSTD_loadCEntropy(
         matchlengthMaxValue,
         matchlengthLog,
         workspace,
-        (((8) << 10) + 512) as size_t,
+        (((8) << 10) + 512) as usize,
     )) {
         return Error::dictionary_corrupted.to_error_code();
     }
@@ -7453,7 +7445,7 @@ pub unsafe fn ZSTD_loadCEntropy(
         litlengthMaxValue,
         litlengthLog,
         workspace,
-        (((8) << 10) + 512) as size_t,
+        (((8) << 10) + 512) as usize,
     )) {
         return Error::dictionary_corrupted.to_error_code();
     }
@@ -7472,7 +7464,7 @@ pub unsafe fn ZSTD_loadCEntropy(
     if dictContentSize
         <= (-(1 as core::ffi::c_int) as u32)
             .wrapping_sub((128 as core::ffi::c_int * ((1 as core::ffi::c_int) << 10)) as u32)
-            as size_t
+            as usize
     {
         let maxOffset = (dictContentSize as u32).wrapping_add((128 * ((1) << 10)) as u32);
         offcodeMax = ZSTD_highbit32(maxOffset);
@@ -7488,7 +7480,7 @@ pub unsafe fn ZSTD_loadCEntropy(
         if *((*bs).rep).as_mut_ptr().offset(u as isize) == 0 {
             return Error::dictionary_corrupted.to_error_code();
         }
-        if *((*bs).rep).as_mut_ptr().offset(u as isize) as size_t > dictContentSize {
+        if *((*bs).rep).as_mut_ptr().offset(u as isize) as usize > dictContentSize {
             return Error::dictionary_corrupted.to_error_code();
         }
         u = u.wrapping_add(1);
@@ -7501,20 +7493,20 @@ unsafe fn ZSTD_loadZstdDictionary(
     ws: *mut ZSTD_cwksp,
     params: *const ZSTD_CCtx_params,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     dtlm: ZSTD_dictTableLoadMethod_e,
     tfp: ZSTD_tableFillPurpose_e,
     workspace: *mut core::ffi::c_void,
-) -> size_t {
+) -> usize {
     let mut dictPtr = dict as *const u8;
     let dictEnd = dictPtr.add(dictSize);
-    let mut dictID: size_t = 0;
-    let mut eSize: size_t = 0;
+    let mut dictID: usize = 0;
+    let mut eSize: usize = 0;
     dictID = (if (*params).fParams.noDictIDFlag != 0 {
         0
     } else {
         MEM_readLE32(dictPtr.add(4) as *const core::ffi::c_void)
-    }) as size_t;
+    }) as usize;
     eSize = ZSTD_loadCEntropy(bs, workspace, dict, dictSize);
     let err_code = eSize;
     if ERR_isError(err_code) {
@@ -7545,12 +7537,12 @@ unsafe fn ZSTD_compress_insertDictionary(
     ws: *mut ZSTD_cwksp,
     params: *const ZSTD_CCtx_params,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     dictContentType: ZSTD_dictContentType_e,
     dtlm: ZSTD_dictTableLoadMethod_e,
     tfp: ZSTD_tableFillPurpose_e,
     workspace: *mut core::ffi::c_void,
-) -> size_t {
+) -> usize {
     if dict.is_null() || dictSize < 8 {
         if dictContentType as core::ffi::c_uint
             == ZSTD_dct_fullDict as core::ffi::c_int as core::ffi::c_uint
@@ -7584,14 +7576,14 @@ pub const ZSTD_USE_CDICT_PARAMS_DICTSIZE_MULTIPLIER: core::ffi::c_ulonglong = 6;
 unsafe fn ZSTD_compressBegin_internal(
     cctx: *mut ZSTD_CCtx,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     dictContentType: ZSTD_dictContentType_e,
     dtlm: ZSTD_dictTableLoadMethod_e,
     cdict: *const ZSTD_CDict,
     params: *const ZSTD_CCtx_params,
     pledgedSrcSize: u64,
     zbuff: ZSTD_buffered_policy_e,
-) -> size_t {
+) -> usize {
     let dictContentSize = if !cdict.is_null() {
         (*cdict).dictContentSize
     } else {
@@ -7661,13 +7653,13 @@ unsafe fn ZSTD_compressBegin_internal(
 pub unsafe fn ZSTD_compressBegin_advanced_internal(
     cctx: *mut ZSTD_CCtx,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     dictContentType: ZSTD_dictContentType_e,
     dtlm: ZSTD_dictTableLoadMethod_e,
     cdict: *const ZSTD_CDict,
     params: *const ZSTD_CCtx_params,
     pledgedSrcSize: core::ffi::c_ulonglong,
-) -> size_t {
+) -> usize {
     let err_code = ZSTD_checkCParams((*params).cParams);
     if ERR_isError(err_code) {
         return err_code;
@@ -7688,10 +7680,10 @@ pub unsafe fn ZSTD_compressBegin_advanced_internal(
 pub unsafe extern "C" fn ZSTD_compressBegin_advanced(
     cctx: *mut ZSTD_CCtx,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     params: ZSTD_parameters,
     pledgedSrcSize: core::ffi::c_ulonglong,
-) -> size_t {
+) -> usize {
     let mut cctxParams = ZSTD_CCtx_params_s {
         format: Format::ZSTD_f_zstd1,
         cParams: ZSTD_compressionParameters {
@@ -7758,9 +7750,9 @@ pub unsafe extern "C" fn ZSTD_compressBegin_advanced(
 unsafe fn ZSTD_compressBegin_usingDict_deprecated(
     cctx: *mut ZSTD_CCtx,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     compressionLevel: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let mut cctxParams = ZSTD_CCtx_params_s {
         format: Format::ZSTD_f_zstd1,
         cParams: ZSTD_compressionParameters {
@@ -7843,23 +7835,23 @@ unsafe fn ZSTD_compressBegin_usingDict_deprecated(
 pub unsafe extern "C" fn ZSTD_compressBegin_usingDict(
     cctx: *mut ZSTD_CCtx,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     compressionLevel: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     ZSTD_compressBegin_usingDict_deprecated(cctx, dict, dictSize, compressionLevel)
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_compressBegin))]
 pub unsafe extern "C" fn ZSTD_compressBegin(
     cctx: *mut ZSTD_CCtx,
     compressionLevel: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     ZSTD_compressBegin_usingDict_deprecated(cctx, core::ptr::null(), 0, compressionLevel)
 }
 unsafe fn ZSTD_writeEpilogue(
     cctx: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    mut dstCapacity: size_t,
-) -> size_t {
+    mut dstCapacity: usize,
+) -> usize {
     let ostart = dst as *mut u8;
     let mut op = ostart;
     if (*cctx).stage as core::ffi::c_uint == ZSTDcs_created as core::ffi::c_int as core::ffi::c_uint
@@ -7881,7 +7873,7 @@ unsafe fn ZSTD_writeEpilogue(
         let cBlockHeader24 = 1u32
             .wrapping_add((bt_raw as core::ffi::c_int as u32) << 1)
             .wrapping_add(0);
-        if dstCapacity < 3 as size_t {
+        if dstCapacity < 3 as usize {
             return Error::dstSize_tooSmall.to_error_code();
         }
         MEM_writeLE24(op as *mut core::ffi::c_void, cBlockHeader24);
@@ -7899,7 +7891,7 @@ unsafe fn ZSTD_writeEpilogue(
     (*cctx).stage = ZSTDcs_created;
     op.offset_from_unsigned(ostart)
 }
-pub unsafe fn ZSTD_CCtx_trace(cctx: *mut ZSTD_CCtx, extraCSize: size_t) {
+pub unsafe fn ZSTD_CCtx_trace(cctx: *mut ZSTD_CCtx, extraCSize: usize) {
     if (*cctx).traceCtx != 0 {
         let streaming = ((*cctx).inBuffSize > 0
             || (*cctx).outBuffSize > 0
@@ -7909,9 +7901,9 @@ pub unsafe fn ZSTD_CCtx_trace(cctx: *mut ZSTD_CCtx, extraCSize: size_t) {
         trace.streaming = streaming;
         trace.dictionaryID = (*cctx).dictID;
         trace.dictionarySize = (*cctx).dictContentSize;
-        trace.uncompressedSize = (*cctx).consumedSrcSize as size_t;
+        trace.uncompressedSize = (*cctx).consumedSrcSize as usize;
         trace.compressedSize =
-            ((*cctx).producedCSize).wrapping_add(extraCSize as core::ffi::c_ulonglong) as size_t;
+            ((*cctx).producedCSize).wrapping_add(extraCSize as core::ffi::c_ulonglong) as usize;
         trace.params = &mut (*cctx).appliedParams;
         trace.cctx = cctx;
         ZSTD_trace_compress_end((*cctx).traceCtx, &trace);
@@ -7922,11 +7914,11 @@ pub unsafe fn ZSTD_CCtx_trace(cctx: *mut ZSTD_CCtx, extraCSize: size_t) {
 pub unsafe extern "C" fn ZSTD_compressEnd_public(
     cctx: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
-    let mut endResult: size_t = 0;
+    srcSize: usize,
+) -> usize {
+    let mut endResult: usize = 0;
     let cSize = ZSTD_compressContinue_internal(cctx, dst, dstCapacity, src, srcSize, 1, 1);
     let err_code = cSize;
     if ERR_isError(err_code) {
@@ -7953,23 +7945,23 @@ pub unsafe extern "C" fn ZSTD_compressEnd_public(
 pub unsafe extern "C" fn ZSTD_compressEnd(
     cctx: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressEnd_public(cctx, dst, dstCapacity, src, srcSize)
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_compress_advanced))]
 pub unsafe extern "C" fn ZSTD_compress_advanced(
     cctx: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     params: ZSTD_parameters,
-) -> size_t {
+) -> usize {
     let err_code = ZSTD_checkCParams(params.cParams);
     if ERR_isError(err_code) {
         return err_code;
@@ -7989,13 +7981,13 @@ pub unsafe extern "C" fn ZSTD_compress_advanced(
 pub unsafe fn ZSTD_compress_advanced_internal(
     cctx: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     params: *const ZSTD_CCtx_params,
-) -> size_t {
+) -> usize {
     let err_code = ZSTD_compressBegin_internal(
         cctx,
         dict,
@@ -8016,13 +8008,13 @@ pub unsafe fn ZSTD_compress_advanced_internal(
 pub unsafe extern "C" fn ZSTD_compress_usingDict(
     cctx: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     compressionLevel: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let params = ZSTD_getParams_internal(
         compressionLevel,
         srcSize as core::ffi::c_ulonglong,
@@ -8053,11 +8045,11 @@ pub unsafe extern "C" fn ZSTD_compress_usingDict(
 pub unsafe extern "C" fn ZSTD_compressCCtx(
     cctx: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     compressionLevel: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     ZSTD_compress_usingDict(
         cctx,
         dst,
@@ -8072,12 +8064,12 @@ pub unsafe extern "C" fn ZSTD_compressCCtx(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_compress))]
 pub unsafe extern "C" fn ZSTD_compress(
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     compressionLevel: core::ffi::c_int,
-) -> size_t {
-    let mut result: size_t = 0;
+) -> usize {
+    let mut result: usize = 0;
     let mut ctxBody = ZSTD_CCtx_s {
         stage: ZSTDcs_created,
         cParamsChanged: 0,
@@ -8503,10 +8495,10 @@ pub unsafe extern "C" fn ZSTD_compress(
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_estimateCDictSize_advanced))]
 pub unsafe extern "C" fn ZSTD_estimateCDictSize_advanced(
-    dictSize: size_t,
+    dictSize: usize,
     cParams: ZSTD_compressionParameters,
     dictLoadMethod: ZSTD_dictLoadMethod_e,
-) -> size_t {
+) -> usize {
     (ZSTD_cwksp_alloc_size(::core::mem::size_of::<ZSTD_CDict>()))
         .wrapping_add(ZSTD_cwksp_alloc_size(HUF_WORKSPACE_SIZE))
         .wrapping_add(ZSTD_sizeof_matchState(
@@ -8530,9 +8522,9 @@ pub unsafe extern "C" fn ZSTD_estimateCDictSize_advanced(
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_estimateCDictSize))]
 pub unsafe extern "C" fn ZSTD_estimateCDictSize(
-    dictSize: size_t,
+    dictSize: usize,
     compressionLevel: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let cParams = ZSTD_getCParams_internal(
         compressionLevel,
         ZSTD_CONTENTSIZE_UNKNOWN,
@@ -8542,7 +8534,7 @@ pub unsafe extern "C" fn ZSTD_estimateCDictSize(
     ZSTD_estimateCDictSize_advanced(dictSize, cParams, ZSTD_dlm_byCopy)
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_sizeof_CDict))]
-pub unsafe extern "C" fn ZSTD_sizeof_CDict(cdict: *const ZSTD_CDict) -> size_t {
+pub unsafe extern "C" fn ZSTD_sizeof_CDict(cdict: *const ZSTD_CDict) -> usize {
     if cdict.is_null() {
         return 0;
     }
@@ -8556,11 +8548,11 @@ pub unsafe extern "C" fn ZSTD_sizeof_CDict(cdict: *const ZSTD_CDict) -> size_t {
 unsafe fn ZSTD_initCDict_internal(
     cdict: *mut ZSTD_CDict,
     dictBuffer: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     dictLoadMethod: ZSTD_dictLoadMethod_e,
     dictContentType: ZSTD_dictContentType_e,
     mut params: ZSTD_CCtx_params,
-) -> size_t {
+) -> usize {
     (*cdict).matchState.cParams = params.cParams;
     (*cdict).matchState.dedicatedDictSearch = params.enableDedicatedDictSearch;
     if dictLoadMethod as core::ffi::c_uint
@@ -8578,7 +8570,7 @@ unsafe fn ZSTD_initCDict_internal(
             return Error::memory_allocation.to_error_code();
         }
         (*cdict).dictContent = internalBuffer;
-        libc::memcpy(internalBuffer, dictBuffer, dictSize as libc::size_t);
+        libc::memcpy(internalBuffer, dictBuffer, dictSize as usize);
     }
     (*cdict).dictContentSize = dictSize;
     (*cdict).dictContentType = dictContentType;
@@ -8620,7 +8612,7 @@ unsafe fn ZSTD_initCDict_internal(
     0
 }
 unsafe fn ZSTD_createCDict_advanced_internal(
-    dictSize: size_t,
+    dictSize: usize,
     dictLoadMethod: ZSTD_dictLoadMethod_e,
     cParams: ZSTD_compressionParameters,
     useRowMatchFinder: ZSTD_ParamSwitch_e,
@@ -8672,7 +8664,7 @@ unsafe fn ZSTD_createCDict_advanced_internal(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_createCDict_advanced))]
 pub unsafe extern "C" fn ZSTD_createCDict_advanced(
     dictBuffer: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     dictLoadMethod: ZSTD_dictLoadMethod_e,
     dictContentType: ZSTD_dictContentType_e,
     cParams: ZSTD_compressionParameters,
@@ -8749,7 +8741,7 @@ pub unsafe extern "C" fn ZSTD_createCDict_advanced(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_createCDict_advanced2))]
 pub unsafe extern "C" fn ZSTD_createCDict_advanced2(
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     dictLoadMethod: ZSTD_dictLoadMethod_e,
     dictContentType: ZSTD_dictContentType_e,
     originalCctxParams: *const ZSTD_CCtx_params,
@@ -8814,7 +8806,7 @@ pub unsafe extern "C" fn ZSTD_createCDict_advanced2(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_createCDict))]
 pub unsafe extern "C" fn ZSTD_createCDict(
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     compressionLevel: core::ffi::c_int,
 ) -> *mut ZSTD_CDict {
     let cParams = ZSTD_getCParams_internal(
@@ -8843,7 +8835,7 @@ pub unsafe extern "C" fn ZSTD_createCDict(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_createCDict_byReference))]
 pub unsafe extern "C" fn ZSTD_createCDict_byReference(
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     compressionLevel: core::ffi::c_int,
 ) -> *mut ZSTD_CDict {
     let cParams = ZSTD_getCParams_internal(
@@ -8870,7 +8862,7 @@ pub unsafe extern "C" fn ZSTD_createCDict_byReference(
     cdict
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_freeCDict))]
-pub unsafe extern "C" fn ZSTD_freeCDict(cdict: *mut ZSTD_CDict) -> size_t {
+pub unsafe extern "C" fn ZSTD_freeCDict(cdict: *mut ZSTD_CDict) -> usize {
     if cdict.is_null() {
         return 0;
     }
@@ -8890,9 +8882,9 @@ pub unsafe extern "C" fn ZSTD_freeCDict(cdict: *mut ZSTD_CDict) -> size_t {
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_initStaticCDict))]
 pub unsafe extern "C" fn ZSTD_initStaticCDict(
     workspace: *mut core::ffi::c_void,
-    workspaceSize: size_t,
+    workspaceSize: usize,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     dictLoadMethod: ZSTD_dictLoadMethod_e,
     dictContentType: ZSTD_dictContentType_e,
     cParams: ZSTD_compressionParameters,
@@ -8963,7 +8955,7 @@ pub unsafe extern "C" fn ZSTD_initStaticCDict(
         extSeqProdFunc: None,
         searchForExternalRepcodes: ZSTD_ParamSwitch_e::ZSTD_ps_auto,
     };
-    if workspace as size_t & 7 != 0 {
+    if workspace as usize & 7 != 0 {
         return core::ptr::null();
     }
     let mut ws = ZSTD_cwksp {
@@ -9024,7 +9016,7 @@ unsafe fn ZSTD_compressBegin_usingCDict_internal(
     cdict: *const ZSTD_CDict,
     fParams: ZSTD_frameParameters,
     pledgedSrcSize: core::ffi::c_ulonglong,
-) -> size_t {
+) -> usize {
     let mut cctxParams = ZSTD_CCtx_params_s {
         format: Format::ZSTD_f_zstd1,
         cParams: ZSTD_compressionParameters {
@@ -9148,14 +9140,14 @@ pub unsafe extern "C" fn ZSTD_compressBegin_usingCDict_advanced(
     cdict: *const ZSTD_CDict,
     fParams: ZSTD_frameParameters,
     pledgedSrcSize: core::ffi::c_ulonglong,
-) -> size_t {
+) -> usize {
     ZSTD_compressBegin_usingCDict_internal(cctx, cdict, fParams, pledgedSrcSize)
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_compressBegin_usingCDict_deprecated))]
 pub unsafe extern "C" fn ZSTD_compressBegin_usingCDict_deprecated(
     cctx: *mut ZSTD_CCtx,
     cdict: *const ZSTD_CDict,
-) -> size_t {
+) -> usize {
     let fParams = {
         ZSTD_frameParameters {
             contentSizeFlag: 0,
@@ -9169,18 +9161,18 @@ pub unsafe extern "C" fn ZSTD_compressBegin_usingCDict_deprecated(
 pub unsafe extern "C" fn ZSTD_compressBegin_usingCDict(
     cctx: *mut ZSTD_CCtx,
     cdict: *const ZSTD_CDict,
-) -> size_t {
+) -> usize {
     ZSTD_compressBegin_usingCDict_deprecated(cctx, cdict)
 }
 unsafe fn ZSTD_compress_usingCDict_internal(
     cctx: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     cdict: *const ZSTD_CDict,
     fParams: ZSTD_frameParameters,
-) -> size_t {
+) -> usize {
     let err_code = ZSTD_compressBegin_usingCDict_internal(
         cctx,
         cdict,
@@ -9196,23 +9188,23 @@ unsafe fn ZSTD_compress_usingCDict_internal(
 pub unsafe extern "C" fn ZSTD_compress_usingCDict_advanced(
     cctx: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     cdict: *const ZSTD_CDict,
     fParams: ZSTD_frameParameters,
-) -> size_t {
+) -> usize {
     ZSTD_compress_usingCDict_internal(cctx, dst, dstCapacity, src, srcSize, cdict, fParams)
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_compress_usingCDict))]
 pub unsafe extern "C" fn ZSTD_compress_usingCDict(
     cctx: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     cdict: *const ZSTD_CDict,
-) -> size_t {
+) -> usize {
     let fParams = {
         ZSTD_frameParameters {
             contentSizeFlag: 1,
@@ -9229,7 +9221,7 @@ pub unsafe extern "C" fn ZSTD_createCStream() -> *mut ZSTD_CStream {
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_initStaticCStream))]
 pub unsafe extern "C" fn ZSTD_initStaticCStream(
     workspace: *mut core::ffi::c_void,
-    workspaceSize: size_t,
+    workspaceSize: usize,
 ) -> *mut ZSTD_CStream {
     ZSTD_initStaticCCtx(workspace, workspaceSize)
 }
@@ -9240,16 +9232,16 @@ pub unsafe extern "C" fn ZSTD_createCStream_advanced(
     ZSTD_createCCtx_advanced(customMem)
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_freeCStream))]
-pub unsafe extern "C" fn ZSTD_freeCStream(zcs: *mut ZSTD_CStream) -> size_t {
+pub unsafe extern "C" fn ZSTD_freeCStream(zcs: *mut ZSTD_CStream) -> usize {
     ZSTD_freeCCtx(zcs)
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_CStreamInSize))]
-pub unsafe extern "C" fn ZSTD_CStreamInSize() -> size_t {
-    ZSTD_BLOCKSIZE_MAX as size_t
+pub unsafe extern "C" fn ZSTD_CStreamInSize() -> usize {
+    ZSTD_BLOCKSIZE_MAX as usize
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_CStreamOutSize))]
-pub unsafe extern "C" fn ZSTD_CStreamOutSize() -> size_t {
-    (ZSTD_compressBound(ZSTD_BLOCKSIZE_MAX as size_t))
+pub unsafe extern "C" fn ZSTD_CStreamOutSize() -> usize {
+    (ZSTD_compressBound(ZSTD_BLOCKSIZE_MAX as usize))
         .wrapping_add(ZSTD_blockHeaderSize)
         .wrapping_add(4)
 }
@@ -9268,7 +9260,7 @@ unsafe fn ZSTD_getCParamMode(
 pub unsafe extern "C" fn ZSTD_resetCStream(
     zcs: *mut ZSTD_CStream,
     pss: core::ffi::c_ulonglong,
-) -> size_t {
+) -> usize {
     let pledgedSrcSize = if pss == 0 {
         ZSTD_CONTENTSIZE_UNKNOWN
     } else {
@@ -9287,11 +9279,11 @@ pub unsafe extern "C" fn ZSTD_resetCStream(
 pub unsafe fn ZSTD_initCStream_internal(
     zcs: *mut ZSTD_CStream,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     cdict: *const ZSTD_CDict,
     params: *const ZSTD_CCtx_params,
     pledgedSrcSize: core::ffi::c_ulonglong,
-) -> size_t {
+) -> usize {
     let err_code = ZSTD_CCtx_reset(zcs, ZSTD_ResetDirective::ZSTD_reset_session_only);
     if ERR_isError(err_code) {
         return err_code;
@@ -9320,7 +9312,7 @@ pub unsafe extern "C" fn ZSTD_initCStream_usingCDict_advanced(
     cdict: *const ZSTD_CDict,
     fParams: ZSTD_frameParameters,
     pledgedSrcSize: core::ffi::c_ulonglong,
-) -> size_t {
+) -> usize {
     let err_code = ZSTD_CCtx_reset(zcs, ZSTD_ResetDirective::ZSTD_reset_session_only);
     if ERR_isError(err_code) {
         return err_code;
@@ -9340,7 +9332,7 @@ pub unsafe extern "C" fn ZSTD_initCStream_usingCDict_advanced(
 pub unsafe extern "C" fn ZSTD_initCStream_usingCDict(
     zcs: *mut ZSTD_CStream,
     cdict: *const ZSTD_CDict,
-) -> size_t {
+) -> usize {
     let err_code = ZSTD_CCtx_reset(zcs, ZSTD_ResetDirective::ZSTD_reset_session_only);
     if ERR_isError(err_code) {
         return err_code;
@@ -9355,10 +9347,10 @@ pub unsafe extern "C" fn ZSTD_initCStream_usingCDict(
 pub unsafe extern "C" fn ZSTD_initCStream_advanced(
     zcs: *mut ZSTD_CStream,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     params: ZSTD_parameters,
     pss: core::ffi::c_ulonglong,
-) -> size_t {
+) -> usize {
     let pledgedSrcSize = if pss == 0 && params.fParams.contentSizeFlag == 0 {
         ZSTD_CONTENTSIZE_UNKNOWN
     } else {
@@ -9387,9 +9379,9 @@ pub unsafe extern "C" fn ZSTD_initCStream_advanced(
 pub unsafe extern "C" fn ZSTD_initCStream_usingDict(
     zcs: *mut ZSTD_CStream,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     compressionLevel: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let err_code = ZSTD_CCtx_reset(zcs, ZSTD_ResetDirective::ZSTD_reset_session_only);
     if ERR_isError(err_code) {
         return err_code;
@@ -9413,7 +9405,7 @@ pub unsafe extern "C" fn ZSTD_initCStream_srcSize(
     zcs: *mut ZSTD_CStream,
     compressionLevel: core::ffi::c_int,
     pss: core::ffi::c_ulonglong,
-) -> size_t {
+) -> usize {
     let pledgedSrcSize = if pss == 0 {
         ZSTD_CONTENTSIZE_UNKNOWN
     } else {
@@ -9445,7 +9437,7 @@ pub unsafe extern "C" fn ZSTD_initCStream_srcSize(
 pub unsafe extern "C" fn ZSTD_initCStream(
     zcs: *mut ZSTD_CStream,
     compressionLevel: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let err_code = ZSTD_CCtx_reset(zcs, ZSTD_ResetDirective::ZSTD_reset_session_only);
     if ERR_isError(err_code) {
         return err_code;
@@ -9464,7 +9456,7 @@ pub unsafe extern "C" fn ZSTD_initCStream(
     }
     0
 }
-unsafe fn ZSTD_nextInputSizeHint(cctx: *const ZSTD_CCtx) -> size_t {
+unsafe fn ZSTD_nextInputSizeHint(cctx: *const ZSTD_CCtx) -> usize {
     if (*cctx).appliedParams.inBufferMode as core::ffi::c_uint
         == ZSTD_bm_stable as core::ffi::c_int as core::ffi::c_uint
     {
@@ -9481,7 +9473,7 @@ unsafe fn ZSTD_compressStream_generic(
     output: *mut ZSTD_outBuffer,
     input: *mut ZSTD_inBuffer,
     flushMode: ZSTD_EndDirective,
-) -> size_t {
+) -> usize {
     let istart = (*input).src as *const u8;
     let iend = if !istart.is_null() {
         istart.add((*input).size)
@@ -9609,7 +9601,7 @@ unsafe fn ZSTD_compressStream_generic(
                                 == ZSTD_bm_buffered as core::ffi::c_int as core::ffi::c_uint)
                                 as core::ffi::c_int;
                             let mut cDst = core::ptr::null_mut::<core::ffi::c_void>();
-                            let mut cSize_0: size_t = 0;
+                            let mut cSize_0: usize = 0;
                             let mut oSize = oend.offset_from_unsigned(op);
                             let iSize = if inputBuffered != 0 {
                                 ((*zcs).inBuffPos).wrapping_sub((*zcs).inToCompress)
@@ -9762,7 +9754,7 @@ unsafe fn ZSTD_compressStream_generic(
     }
     ZSTD_nextInputSizeHint(zcs)
 }
-unsafe fn ZSTD_nextInputSizeHint_MTorST(cctx: *const ZSTD_CCtx) -> size_t {
+unsafe fn ZSTD_nextInputSizeHint_MTorST(cctx: *const ZSTD_CCtx) -> usize {
     if (*cctx).appliedParams.nbWorkers >= 1 {
         return ZSTDMT_nextInputSizeHint((*cctx).mtctx);
     }
@@ -9773,7 +9765,7 @@ pub unsafe extern "C" fn ZSTD_compressStream(
     zcs: *mut ZSTD_CStream,
     output: *mut ZSTD_outBuffer,
     input: *mut ZSTD_inBuffer,
-) -> size_t {
+) -> usize {
     let err_code = ZSTD_compressStream2(zcs, output, input, ZSTD_e_continue);
     if ERR_isError(err_code) {
         return err_code;
@@ -9801,7 +9793,7 @@ unsafe fn ZSTD_checkBufferStability(
     output: *const ZSTD_outBuffer,
     input: *const ZSTD_inBuffer,
     _endOp: ZSTD_EndDirective,
-) -> size_t {
+) -> usize {
     if (*cctx).appliedParams.inBufferMode as core::ffi::c_uint
         == ZSTD_bm_stable as core::ffi::c_int as core::ffi::c_uint
     {
@@ -9823,8 +9815,8 @@ unsafe fn ZSTD_checkBufferStability(
 unsafe fn ZSTD_CCtx_init_compressStream2(
     cctx: *mut ZSTD_CCtx,
     endOp: ZSTD_EndDirective,
-    inSize: size_t,
-) -> size_t {
+    inSize: usize,
+) -> usize {
     let mut params = (*cctx).requestedParams;
     let prefixDict = (*cctx).prefixDict;
     let err_code = ZSTD_initLocalDict(cctx);
@@ -9939,7 +9931,7 @@ unsafe fn ZSTD_CCtx_init_compressStream2(
             == ZSTD_bm_buffered as core::ffi::c_int as core::ffi::c_uint
         {
             (*cctx).inBuffTarget = ((*cctx).blockSizeMax).wrapping_add(
-                ((*cctx).blockSizeMax as u64 == pledgedSrcSize) as core::ffi::c_int as size_t,
+                ((*cctx).blockSizeMax as u64 == pledgedSrcSize) as core::ffi::c_int as usize,
             );
         } else {
             (*cctx).inBuffTarget = 0;
@@ -9957,7 +9949,7 @@ pub unsafe extern "C" fn ZSTD_compressStream2(
     output: *mut ZSTD_outBuffer,
     input: *mut ZSTD_inBuffer,
     endOp: ZSTD_EndDirective,
-) -> size_t {
+) -> usize {
     if (*output).pos > (*output).size {
         return Error::dstSize_tooSmall.to_error_code();
     }
@@ -9976,16 +9968,16 @@ pub unsafe extern "C" fn ZSTD_compressStream2(
             == ZSTD_bm_stable as core::ffi::c_int as core::ffi::c_uint
             && endOp as core::ffi::c_uint
                 == ZSTD_e_continue as core::ffi::c_int as core::ffi::c_uint
-            && totalInputSize < ZSTD_BLOCKSIZE_MAX as size_t
+            && totalInputSize < ZSTD_BLOCKSIZE_MAX as usize
         {
             if (*cctx).stableIn_notConsumed != 0 {
                 if (*input).src != (*cctx).expectedInBuffer.src {
                     return -(ZSTD_error_stabilityCondition_notRespected as core::ffi::c_int)
-                        as size_t;
+                        as usize;
                 }
                 if (*input).pos != (*cctx).expectedInBuffer.size {
                     return -(ZSTD_error_stabilityCondition_notRespected as core::ffi::c_int)
-                        as size_t;
+                        as usize;
                 }
             }
             (*input).pos = (*input).size;
@@ -9995,7 +9987,7 @@ pub unsafe extern "C" fn ZSTD_compressStream2(
                 6
             } else {
                 2
-            }) as size_t;
+            }) as usize;
         }
         let err_code = ZSTD_CCtx_init_compressStream2(cctx, endOp, totalInputSize);
         if ERR_isError(err_code) {
@@ -10008,7 +10000,7 @@ pub unsafe extern "C" fn ZSTD_compressStream2(
         return err_code_0;
     }
     if (*cctx).appliedParams.nbWorkers > 0 {
-        let mut flushMin: size_t = 0;
+        let mut flushMin: usize = 0;
         if (*cctx).cParamsChanged != 0 {
             ZSTDMT_updateCParams_whileCompressing((*cctx).mtctx, &(*cctx).requestedParams);
             (*cctx).cParamsChanged = 0;
@@ -10066,13 +10058,13 @@ pub unsafe extern "C" fn ZSTD_compressStream2(
 pub unsafe extern "C" fn ZSTD_compressStream2_simpleArgs(
     cctx: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
-    dstPos: *mut size_t,
+    dstCapacity: usize,
+    dstPos: *mut usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-    srcPos: *mut size_t,
+    srcSize: usize,
+    srcPos: *mut usize,
     endOp: ZSTD_EndDirective,
-) -> size_t {
+) -> usize {
     let mut output = ZSTD_outBuffer_s {
         dst: core::ptr::null_mut::<core::ffi::c_void>(),
         size: 0,
@@ -10098,10 +10090,10 @@ pub unsafe extern "C" fn ZSTD_compressStream2_simpleArgs(
 pub unsafe extern "C" fn ZSTD_compress2(
     cctx: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let originalInBufferMode = (*cctx).requestedParams.inBufferMode;
     let originalOutBufferMode = (*cctx).requestedParams.outBufferMode;
     ZSTD_CCtx_reset(cctx, ZSTD_ResetDirective::ZSTD_reset_session_only);
@@ -10134,14 +10126,14 @@ unsafe fn ZSTD_validateSequence(
     offBase: u32,
     matchLength: u32,
     minMatch: u32,
-    posInSrc: size_t,
+    posInSrc: usize,
     windowLog: u32,
-    dictSize: size_t,
+    dictSize: usize,
     useSequenceProducer: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let windowSize = (1) << windowLog;
-    let offsetBound = if posInSrc > windowSize as size_t {
-        windowSize as size_t
+    let offsetBound = if posInSrc > windowSize as usize {
+        windowSize as usize
     } else {
         posInSrc.wrapping_add(dictSize)
     };
@@ -10149,11 +10141,11 @@ unsafe fn ZSTD_validateSequence(
         3
     } else {
         4
-    }) as size_t;
-    if offBase as size_t > offsetBound.wrapping_add(3) {
+    }) as usize;
+    if offBase as usize > offsetBound.wrapping_add(3) {
         return Error::externalSequences_invalid.to_error_code();
     }
-    if (matchLength as size_t) < matchLenLowerBound {
+    if (matchLength as usize) < matchLenLowerBound {
         return Error::externalSequences_invalid.to_error_code();
     }
     0
@@ -10175,11 +10167,11 @@ unsafe fn ZSTD_transferSequences_wBlockDelim(
     cctx: *mut ZSTD_CCtx,
     seqPos: *mut ZSTD_SequencePosition,
     inSeqs: *const ZSTD_Sequence,
-    inSeqsSize: size_t,
+    inSeqsSize: usize,
     src: *const core::ffi::c_void,
-    blockSize: size_t,
+    blockSize: usize,
     externalRepSearch: ZSTD_ParamSwitch_e,
-) -> size_t {
+) -> usize {
     let mut idx = (*seqPos).idx;
     let startIdx = idx;
     let mut ip = src as *const u8;
@@ -10198,7 +10190,7 @@ unsafe fn ZSTD_transferSequences_wBlockDelim(
         ((*(*cctx).blockState.prevCBlock).rep).as_mut_ptr() as *const core::ffi::c_void,
         ::core::mem::size_of::<Repcodes_t>(),
     );
-    while (idx as size_t) < inSeqsSize
+    while (idx as usize) < inSeqsSize
         && ((*inSeqs.offset(idx as isize)).matchLength != 0
             || (*inSeqs.offset(idx as isize)).offset != 0)
     {
@@ -10219,35 +10211,35 @@ unsafe fn ZSTD_transferSequences_wBlockDelim(
         }
         if (*cctx).appliedParams.validateSequences != 0 {
             (*seqPos).posInSrc =
-                ((*seqPos).posInSrc).wrapping_add(litLength.wrapping_add(matchLength) as size_t);
+                ((*seqPos).posInSrc).wrapping_add(litLength.wrapping_add(matchLength) as usize);
             let err_code = ZSTD_validateSequence(
                 offBase,
                 matchLength,
                 (*cctx).appliedParams.cParams.minMatch,
                 (*seqPos).posInSrc,
                 (*cctx).appliedParams.cParams.windowLog,
-                dictSize as size_t,
+                dictSize as usize,
                 ZSTD_hasExtSeqProd(&(*cctx).appliedParams),
             );
             if ERR_isError(err_code) {
                 return err_code;
             }
         }
-        if idx.wrapping_sub((*seqPos).idx) as size_t >= (*cctx).seqStore.maxNbSeq {
+        if idx.wrapping_sub((*seqPos).idx) as usize >= (*cctx).seqStore.maxNbSeq {
             return Error::externalSequences_invalid.to_error_code();
         }
         ZSTD_storeSeq(
             &mut (*cctx).seqStore,
-            litLength as size_t,
+            litLength as usize,
             ip,
             iend,
             offBase,
-            matchLength as size_t,
+            matchLength as usize,
         );
         ip = ip.offset(matchLength.wrapping_add(litLength) as isize);
         idx = idx.wrapping_add(1);
     }
-    if idx as size_t == inSeqsSize {
+    if idx as usize == inSeqsSize {
         return Error::externalSequences_invalid.to_error_code();
     }
     if externalRepSearch == ZSTD_ParamSwitch_e::ZSTD_ps_disable && idx != startIdx {
@@ -10276,11 +10268,11 @@ unsafe fn ZSTD_transferSequences_wBlockDelim(
         ZSTD_storeLastLiterals(
             &mut (*cctx).seqStore,
             ip,
-            (*inSeqs.offset(idx as isize)).litLength as size_t,
+            (*inSeqs.offset(idx as isize)).litLength as usize,
         );
         ip = ip.offset((*inSeqs.offset(idx as isize)).litLength as isize);
         (*seqPos).posInSrc =
-            ((*seqPos).posInSrc).wrapping_add((*inSeqs.offset(idx as isize)).litLength as size_t);
+            ((*seqPos).posInSrc).wrapping_add((*inSeqs.offset(idx as isize)).litLength as usize);
     }
     if ip != iend {
         return Error::externalSequences_invalid.to_error_code();
@@ -10292,15 +10284,15 @@ unsafe fn ZSTD_transferSequences_noDelim(
     cctx: *mut ZSTD_CCtx,
     seqPos: *mut ZSTD_SequencePosition,
     inSeqs: *const ZSTD_Sequence,
-    inSeqsSize: size_t,
+    inSeqsSize: usize,
     src: *const core::ffi::c_void,
-    blockSize: size_t,
+    blockSize: usize,
     externalRepSearch: ZSTD_ParamSwitch_e,
-) -> size_t {
+) -> usize {
     let mut idx = (*seqPos).idx;
     let mut startPosInSequence = (*seqPos).posInSequence;
     let mut endPosInSequence = ((*seqPos).posInSequence).wrapping_add(blockSize as u32);
-    let mut dictSize: size_t = 0;
+    let mut dictSize: usize = 0;
     let istart = src as *const u8;
     let mut ip = istart;
     let mut iend = istart.add(blockSize);
@@ -10323,7 +10315,7 @@ unsafe fn ZSTD_transferSequences_noDelim(
         ((*(*cctx).blockState.prevCBlock).rep).as_mut_ptr() as *const core::ffi::c_void,
         ::core::mem::size_of::<Repcodes_t>(),
     );
-    while endPosInSequence != 0 && (idx as size_t) < inSeqsSize && finalMatchSplit == 0 {
+    while endPosInSequence != 0 && (idx as usize) < inSeqsSize && finalMatchSplit == 0 {
         let currSeq = *inSeqs.offset(idx as isize);
         let mut litLength = currSeq.litLength;
         let mut matchLength = currSeq.matchLength;
@@ -10353,7 +10345,7 @@ unsafe fn ZSTD_transferSequences_noDelim(
             firstHalfMatchLength = endPosInSequence
                 .wrapping_sub(startPosInSequence)
                 .wrapping_sub(litLength);
-            if matchLength as size_t > blockSize
+            if matchLength as usize > blockSize
                 && firstHalfMatchLength >= (*cctx).appliedParams.cParams.minMatch
             {
                 let secondHalfMatchLength = (currSeq.matchLength)
@@ -10385,7 +10377,7 @@ unsafe fn ZSTD_transferSequences_noDelim(
         ZSTD_updateRep((updatedRepcodes.rep).as_mut_ptr(), offBase, ll0);
         if (*cctx).appliedParams.validateSequences != 0 {
             (*seqPos).posInSrc =
-                ((*seqPos).posInSrc).wrapping_add(litLength.wrapping_add(matchLength) as size_t);
+                ((*seqPos).posInSrc).wrapping_add(litLength.wrapping_add(matchLength) as usize);
             let err_code = ZSTD_validateSequence(
                 offBase,
                 matchLength,
@@ -10399,16 +10391,16 @@ unsafe fn ZSTD_transferSequences_noDelim(
                 return err_code;
             }
         }
-        if idx.wrapping_sub((*seqPos).idx) as size_t >= (*cctx).seqStore.maxNbSeq {
+        if idx.wrapping_sub((*seqPos).idx) as usize >= (*cctx).seqStore.maxNbSeq {
             return Error::externalSequences_invalid.to_error_code();
         }
         ZSTD_storeSeq(
             &mut (*cctx).seqStore,
-            litLength as size_t,
+            litLength as usize,
             ip,
             iend,
             offBase,
-            matchLength as size_t,
+            matchLength as usize,
         );
         ip = ip.offset(matchLength.wrapping_add(litLength) as isize);
         if finalMatchSplit == 0 {
@@ -10425,8 +10417,8 @@ unsafe fn ZSTD_transferSequences_noDelim(
     iend = iend.offset(-(bytesAdjustment as isize));
     if ip != iend {
         let lastLLSize = iend.offset_from(ip) as core::ffi::c_long as u32;
-        ZSTD_storeLastLiterals(&mut (*cctx).seqStore, ip, lastLLSize as size_t);
-        (*seqPos).posInSrc = ((*seqPos).posInSrc).wrapping_add(lastLLSize as size_t);
+        ZSTD_storeLastLiterals(&mut (*cctx).seqStore, ip, lastLLSize as usize);
+        (*seqPos).posInSrc = ((*seqPos).posInSrc).wrapping_add(lastLLSize as usize);
     }
     iend.offset_from_unsigned(istart)
 }
@@ -10440,11 +10432,11 @@ unsafe fn ZSTD_selectSequenceCopier(mode: ZSTD_SequenceFormat_e) -> ZSTD_Sequenc
                     *mut ZSTD_CCtx,
                     *mut ZSTD_SequencePosition,
                     *const ZSTD_Sequence,
-                    size_t,
+                    usize,
                     *const core::ffi::c_void,
-                    size_t,
+                    usize,
                     ZSTD_ParamSwitch_e,
-                ) -> size_t,
+                ) -> usize,
         );
     }
     Some(
@@ -10453,25 +10445,25 @@ unsafe fn ZSTD_selectSequenceCopier(mode: ZSTD_SequenceFormat_e) -> ZSTD_Sequenc
                 *mut ZSTD_CCtx,
                 *mut ZSTD_SequencePosition,
                 *const ZSTD_Sequence,
-                size_t,
+                usize,
                 *const core::ffi::c_void,
-                size_t,
+                usize,
                 ZSTD_ParamSwitch_e,
-            ) -> size_t,
+            ) -> usize,
     )
 }
 unsafe fn blockSize_explicitDelimiter(
     inSeqs: *const ZSTD_Sequence,
-    inSeqsSize: size_t,
+    inSeqsSize: usize,
     seqPos: ZSTD_SequencePosition,
-) -> size_t {
+) -> usize {
     let mut end = 0;
-    let mut blockSize = 0 as size_t;
-    let mut spos = seqPos.idx as size_t;
+    let mut blockSize = 0 as usize;
+    let mut spos = seqPos.idx as usize;
     while spos < inSeqsSize {
         end = ((*inSeqs.add(spos)).offset == 0) as core::ffi::c_int;
         blockSize = blockSize.wrapping_add(
-            ((*inSeqs.add(spos)).litLength).wrapping_add((*inSeqs.add(spos)).matchLength) as size_t,
+            ((*inSeqs.add(spos)).litLength).wrapping_add((*inSeqs.add(spos)).matchLength) as usize,
         );
         if end != 0 {
             if (*inSeqs.add(spos)).matchLength != 0 {
@@ -10489,12 +10481,12 @@ unsafe fn blockSize_explicitDelimiter(
 }
 unsafe fn determine_blockSize(
     mode: ZSTD_SequenceFormat_e,
-    blockSize: size_t,
-    remaining: size_t,
+    blockSize: usize,
+    remaining: usize,
     inSeqs: *const ZSTD_Sequence,
-    inSeqsSize: size_t,
+    inSeqsSize: usize,
     seqPos: ZSTD_SequencePosition,
-) -> size_t {
+) -> usize {
     if mode as core::ffi::c_uint
         == ZSTD_sf_noBlockDelimiters as core::ffi::c_int as core::ffi::c_uint
     {
@@ -10520,13 +10512,13 @@ unsafe fn determine_blockSize(
 unsafe fn ZSTD_compressSequences_internal(
     cctx: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    mut dstCapacity: size_t,
+    mut dstCapacity: usize,
     inSeqs: *const ZSTD_Sequence,
-    inSeqsSize: size_t,
+    inSeqsSize: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
-    let mut cSize = 0 as size_t;
+    srcSize: usize,
+) -> usize {
+    let mut cSize = 0 as usize;
     let mut remaining = srcSize;
     let mut seqPos = {
         ZSTD_SequencePosition {
@@ -10549,8 +10541,8 @@ unsafe fn ZSTD_compressSequences_internal(
         cSize = cSize.wrapping_add(ZSTD_blockHeaderSize);
     }
     while remaining != 0 {
-        let mut compressedSeqsSize: size_t = 0;
-        let mut cBlockSize: size_t = 0;
+        let mut compressedSeqsSize: usize = 0;
+        let mut cBlockSize: usize = 0;
         let mut blockSize = determine_blockSize(
             (*cctx).appliedParams.blockDelimiters,
             (*cctx).blockSizeMax,
@@ -10579,7 +10571,7 @@ unsafe fn ZSTD_compressSequences_internal(
             return err_code_0;
         }
         if blockSize
-            < (MIN_CBLOCK_SIZE as size_t)
+            < (MIN_CBLOCK_SIZE as usize)
                 .wrapping_add(ZSTD_blockHeaderSize)
                 .wrapping_add(1)
                 .wrapping_add(1)
@@ -10687,14 +10679,14 @@ unsafe fn ZSTD_compressSequences_internal(
 pub unsafe extern "C" fn ZSTD_compressSequences(
     cctx: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    mut dstCapacity: size_t,
+    mut dstCapacity: usize,
     inSeqs: *const ZSTD_Sequence,
-    inSeqsSize: size_t,
+    inSeqsSize: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let mut op = dst as *mut u8;
-    let mut cSize = 0 as size_t;
+    let mut cSize = 0 as usize;
     let err_code = ZSTD_CCtx_init_compressStream2(cctx, ZSTD_e_end, srcSize);
     if ERR_isError(err_code) {
         return err_code;
@@ -10746,10 +10738,10 @@ pub unsafe extern "C" fn ZSTD_compressSequences(
 pub unsafe fn convertSequences_noRepcodes(
     dstSeqs: *mut SeqDef,
     inSeqs: *const ZSTD_Sequence,
-    nbSequences: size_t,
-) -> size_t {
+    nbSequences: usize,
+) -> usize {
     let mut longLen = 0;
-    let mut n: size_t = 0;
+    let mut n: usize = 0;
     n = 0;
     while n < nbSequences {
         (*dstSeqs.add(n)).offBase =
@@ -10770,9 +10762,9 @@ pub unsafe fn convertSequences_noRepcodes(
 pub unsafe fn ZSTD_convertBlockSequences(
     cctx: *mut ZSTD_CCtx,
     inSeqs: *const ZSTD_Sequence,
-    nbSequences: size_t,
+    nbSequences: usize,
     repcodeResolution: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let mut updatedRepcodes = repcodes_s { rep: [0; 3] };
     let mut seqNb = 0;
     if nbSequences >= (*cctx).seqStore.maxNbSeq {
@@ -10814,9 +10806,9 @@ pub unsafe fn ZSTD_convertBlockSequences(
             );
             ZSTD_storeSeqOnly(
                 &mut (*cctx).seqStore,
-                litLength as size_t,
+                litLength as usize,
                 offBase,
-                matchLength as size_t,
+                matchLength as usize,
             );
             ZSTD_updateRep((updatedRepcodes.rep).as_mut_ptr(), offBase, ll0);
             seqNb = seqNb.wrapping_add(1);
@@ -10856,14 +10848,14 @@ const fn matchLengthHalfIsZero(litMatchLength: u64) -> core::ffi::c_int {
     }
 }
 
-pub unsafe fn ZSTD_get1BlockSummary(seqs: *const ZSTD_Sequence, nbSeqs: size_t) -> BlockSummary {
+pub unsafe fn ZSTD_get1BlockSummary(seqs: *const ZSTD_Sequence, nbSeqs: usize) -> BlockSummary {
     let mut current_block: u64;
     let mut litMatchSize0 = 0u64;
     let mut litMatchSize1 = 0u64;
     let mut litMatchSize2 = 0u64;
     let mut litMatchSize3 = 0u64;
-    let mut n = 0 as size_t;
-    if nbSeqs > 3 as size_t {
+    let mut n = 0 as usize;
+    if nbSeqs > 3 as usize {
         loop {
             let mut litMatchLength = MEM_read64(
                 &(*seqs.add(n)).litLength as *const core::ffi::c_uint as *const core::ffi::c_void,
@@ -10930,12 +10922,12 @@ pub unsafe fn ZSTD_get1BlockSummary(seqs: *const ZSTD_Sequence, nbSeqs: size_t) 
                 };
                 bs_0.nbSequences = n.wrapping_add(1);
                 if cfg!(target_endian = "little") {
-                    bs_0.litSize = litMatchSize0 as u32 as size_t;
+                    bs_0.litSize = litMatchSize0 as u32 as usize;
                     bs_0.blockSize =
                         (bs_0.litSize as u64).wrapping_add(litMatchSize0 >> 32) as usize;
                 } else {
                     bs_0.litSize = (litMatchSize0 >> 32) as usize;
-                    bs_0.blockSize = (bs_0.litSize).wrapping_add(litMatchSize0 as u32 as size_t);
+                    bs_0.blockSize = (bs_0.litSize).wrapping_add(litMatchSize0 as u32 as usize);
                 }
                 return bs_0;
             }
@@ -10968,15 +10960,15 @@ pub unsafe fn ZSTD_get1BlockSummary(seqs: *const ZSTD_Sequence, nbSeqs: size_t) 
 unsafe fn ZSTD_compressSequencesAndLiterals_internal(
     cctx: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    mut dstCapacity: size_t,
+    mut dstCapacity: usize,
     mut inSeqs: *const ZSTD_Sequence,
-    mut nbSequences: size_t,
+    mut nbSequences: usize,
     mut literals: *const core::ffi::c_void,
-    mut litSize: size_t,
-    srcSize: size_t,
-) -> size_t {
+    mut litSize: usize,
+    srcSize: usize,
+) -> usize {
     let mut remaining = srcSize;
-    let mut cSize = 0 as size_t;
+    let mut cSize = 0 as usize;
     let mut op = dst as *mut u8;
     let repcodeResolution = ((*cctx).appliedParams.searchForExternalRepcodes
         == ZSTD_ParamSwitch_e::ZSTD_ps_enable) as core::ffi::c_int;
@@ -10994,9 +10986,9 @@ unsafe fn ZSTD_compressSequencesAndLiterals_internal(
         cSize = cSize.wrapping_add(ZSTD_blockHeaderSize);
     }
     while nbSequences != 0 {
-        let mut compressedSeqsSize: size_t = 0;
-        let mut cBlockSize: size_t = 0;
-        let mut conversionStatus: size_t = 0;
+        let mut compressedSeqsSize: usize = 0;
+        let mut cBlockSize: usize = 0;
+        let mut conversionStatus: usize = 0;
         let block = ZSTD_get1BlockSummary(inSeqs, nbSequences);
         let lastBlock = (block.nbSequences == nbSequences) as core::ffi::c_int as u32;
         let err_code = block.nbSequences;
@@ -11084,16 +11076,16 @@ unsafe fn ZSTD_compressSequencesAndLiterals_internal(
 pub unsafe extern "C" fn ZSTD_compressSequencesAndLiterals(
     cctx: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    mut dstCapacity: size_t,
+    mut dstCapacity: usize,
     inSeqs: *const ZSTD_Sequence,
-    inSeqsSize: size_t,
+    inSeqsSize: usize,
     literals: *const core::ffi::c_void,
-    litSize: size_t,
-    litCapacity: size_t,
-    decompressedSize: size_t,
-) -> size_t {
+    litSize: usize,
+    litCapacity: usize,
+    decompressedSize: usize,
+) -> usize {
     let mut op = dst as *mut u8;
-    let mut cSize = 0 as size_t;
+    let mut cSize = 0 as usize;
     if litCapacity < litSize {
         return Error::workSpace_tooSmall.to_error_code();
     }
@@ -11161,7 +11153,7 @@ unsafe fn inBuffer_forEndFlush(zcs: *const ZSTD_CStream) -> ZSTD_inBuffer {
 pub unsafe extern "C" fn ZSTD_flushStream(
     zcs: *mut ZSTD_CStream,
     output: *mut ZSTD_outBuffer,
-) -> size_t {
+) -> usize {
     let mut input = inBuffer_forEndFlush(zcs);
     input.size = input.pos;
     ZSTD_compressStream2(zcs, output, &mut input, ZSTD_e_flush)
@@ -11170,7 +11162,7 @@ pub unsafe extern "C" fn ZSTD_flushStream(
 pub unsafe extern "C" fn ZSTD_endStream(
     zcs: *mut ZSTD_CStream,
     output: *mut ZSTD_outBuffer,
-) -> size_t {
+) -> usize {
     let mut input = inBuffer_forEndFlush(zcs);
     let remainingToFlush = ZSTD_compressStream2(zcs, output, &mut input, ZSTD_e_end);
     let err_code = remainingToFlush;
@@ -11184,12 +11176,12 @@ pub unsafe extern "C" fn ZSTD_endStream(
         0
     } else {
         ZSTD_BLOCKHEADERSIZE
-    }) as size_t;
+    }) as usize;
     let checksumSize = (if (*zcs).frameEnded != 0 {
         0
     } else {
         (*zcs).appliedParams.fParams.checksumFlag * 4
-    }) as size_t;
+    }) as usize;
 
     remainingToFlush
         .wrapping_add(lastBlockSize)
@@ -11232,7 +11224,7 @@ unsafe fn ZSTD_dedicatedDictSearch_revertCParams(cParams: *mut ZSTD_compressionP
 }
 unsafe fn ZSTD_getCParamRowSize(
     srcSizeHint: u64,
-    mut dictSize: size_t,
+    mut dictSize: usize,
     mode: ZSTD_CParamMode_e,
 ) -> u64 {
     if mode as core::ffi::c_uint == 1 {
@@ -11253,7 +11245,7 @@ unsafe fn ZSTD_getCParamRowSize(
 pub unsafe extern "C" fn ZSTD_getCParams(
     compressionLevel: core::ffi::c_int,
     mut srcSizeHint: core::ffi::c_ulonglong,
-    dictSize: size_t,
+    dictSize: usize,
 ) -> ZSTD_compressionParameters {
     if srcSizeHint == 0 {
         srcSizeHint = ZSTD_CONTENTSIZE_UNKNOWN;
@@ -11264,7 +11256,7 @@ pub unsafe extern "C" fn ZSTD_getCParams(
 pub unsafe extern "C" fn ZSTD_getParams(
     compressionLevel: core::ffi::c_int,
     mut srcSizeHint: core::ffi::c_ulonglong,
-    dictSize: size_t,
+    dictSize: usize,
 ) -> ZSTD_parameters {
     if srcSizeHint == 0 {
         srcSizeHint = ZSTD_CONTENTSIZE_UNKNOWN;
@@ -12298,7 +12290,7 @@ static ZSTD_defaultCParameters: [[ZSTD_compressionParameters; 23]; 4] = [
 
 unsafe fn ZSTD_dedicatedDictSearch_getCParams(
     compressionLevel: core::ffi::c_int,
-    dictSize: size_t,
+    dictSize: usize,
 ) -> ZSTD_compressionParameters {
     let mut cParams = ZSTD_getCParams_internal(compressionLevel, 0, dictSize, ZSTD_cpm_createCDict);
     if let 3..=5 = cParams.strategy as core::ffi::c_uint {
@@ -12310,7 +12302,7 @@ unsafe fn ZSTD_dedicatedDictSearch_getCParams(
 unsafe fn ZSTD_getCParams_internal(
     compressionLevel: core::ffi::c_int,
     srcSizeHint: core::ffi::c_ulonglong,
-    dictSize: size_t,
+    dictSize: usize,
     mode: ZSTD_CParamMode_e,
 ) -> ZSTD_compressionParameters {
     let rSize = ZSTD_getCParamRowSize(srcSizeHint, dictSize, mode);
@@ -12349,7 +12341,7 @@ unsafe fn ZSTD_getCParams_internal(
 unsafe fn ZSTD_getParams_internal(
     compressionLevel: core::ffi::c_int,
     srcSizeHint: core::ffi::c_ulonglong,
-    dictSize: size_t,
+    dictSize: usize,
     mode: ZSTD_CParamMode_e,
 ) -> ZSTD_parameters {
     let mut params = ZSTD_parameters {

--- a/lib/compress/zstd_compress_literals.rs
+++ b/lib/compress/zstd_compress_literals.rs
@@ -1,4 +1,4 @@
-use libc::size_t;
+
 
 use crate::lib::common::error_private::{ERR_isError, Error};
 use crate::lib::common::huf::{
@@ -22,20 +22,20 @@ pub const set_basic: SymbolEncodingType_e = 0;
 pub type huf_compress_f = Option<
     unsafe extern "C" fn(
         *mut core::ffi::c_void,
-        size_t,
+        usize,
         *const core::ffi::c_void,
-        size_t,
+        usize,
         core::ffi::c_uint,
         core::ffi::c_uint,
         *mut core::ffi::c_void,
-        size_t,
+        usize,
         *mut HUF_CElt,
         *mut HUF_repeat,
         core::ffi::c_int,
-    ) -> size_t,
+    ) -> usize,
 >;
 #[inline]
-unsafe fn ZSTD_minGain(srcSize: size_t, strat: ZSTD_strategy) -> size_t {
+unsafe fn ZSTD_minGain(srcSize: usize, strat: ZSTD_strategy) -> usize {
     let minlog =
         if strat as core::ffi::c_uint >= ZSTD_btultra as core::ffi::c_int as core::ffi::c_uint {
             strat.wrapping_sub(1)
@@ -46,32 +46,32 @@ unsafe fn ZSTD_minGain(srcSize: size_t, strat: ZSTD_strategy) -> size_t {
 }
 pub unsafe fn ZSTD_noCompressLiterals(
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let ostart = dst as *mut u8;
     let flSize =
         (1 + (srcSize > 31) as core::ffi::c_int + (srcSize > 4095) as core::ffi::c_int) as u32;
-    if srcSize.wrapping_add(flSize as size_t) > dstCapacity {
+    if srcSize.wrapping_add(flSize as usize) > dstCapacity {
         return Error::dstSize_tooSmall.to_error_code();
     }
     match flSize {
         1 => {
             *ostart =
-                (set_basic as core::ffi::c_int as u32 as size_t).wrapping_add(srcSize << 3) as u8;
+                (set_basic as core::ffi::c_int as u32 as usize).wrapping_add(srcSize << 3) as u8;
         }
         2 => {
             MEM_writeLE16(
                 ostart as *mut core::ffi::c_void,
-                ((set_basic as core::ffi::c_int as u32).wrapping_add(((1) << 2) as u32) as size_t)
+                ((set_basic as core::ffi::c_int as u32).wrapping_add(((1) << 2) as u32) as usize)
                     .wrapping_add(srcSize << 4) as u16,
             );
         }
         3 => {
             MEM_writeLE32(
                 ostart as *mut core::ffi::c_void,
-                ((set_basic as core::ffi::c_int as u32).wrapping_add(((3) << 2) as u32) as size_t)
+                ((set_basic as core::ffi::c_int as u32).wrapping_add(((3) << 2) as u32) as usize)
                     .wrapping_add(srcSize << 4) as u32,
             );
         }
@@ -80,13 +80,13 @@ pub unsafe fn ZSTD_noCompressLiterals(
     libc::memcpy(
         ostart.offset(flSize as isize) as *mut core::ffi::c_void,
         src,
-        srcSize as libc::size_t,
+        srcSize as usize,
     );
-    srcSize.wrapping_add(flSize as size_t)
+    srcSize.wrapping_add(flSize as usize)
 }
-unsafe fn allBytesIdentical(src: *const core::ffi::c_void, srcSize: size_t) -> bool {
+unsafe fn allBytesIdentical(src: *const core::ffi::c_void, srcSize: usize) -> bool {
     let b = *(src as *const u8);
-    let mut p: size_t = 0;
+    let mut p: usize = 0;
     p = 1;
     while p < srcSize {
         if *(src as *const u8).add(p) as core::ffi::c_int != b as core::ffi::c_int {
@@ -98,10 +98,10 @@ unsafe fn allBytesIdentical(src: *const core::ffi::c_void, srcSize: size_t) -> b
 }
 pub unsafe fn ZSTD_compressRleLiteralsBlock(
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let ostart = dst as *mut u8;
     let flSize =
         (1 + (srcSize > 31) as core::ffi::c_int + (srcSize > 4095) as core::ffi::c_int) as u32;
@@ -112,28 +112,28 @@ pub unsafe fn ZSTD_compressRleLiteralsBlock(
     match flSize {
         1 => {
             *ostart =
-                (set_rle as core::ffi::c_int as u32 as size_t).wrapping_add(srcSize << 3) as u8;
+                (set_rle as core::ffi::c_int as u32 as usize).wrapping_add(srcSize << 3) as u8;
         }
         2 => {
             MEM_writeLE16(
                 ostart as *mut core::ffi::c_void,
-                ((set_rle as core::ffi::c_int as u32).wrapping_add(((1) << 2) as u32) as size_t)
+                ((set_rle as core::ffi::c_int as u32).wrapping_add(((1) << 2) as u32) as usize)
                     .wrapping_add(srcSize << 4) as u16,
             );
         }
         3 => {
             MEM_writeLE32(
                 ostart as *mut core::ffi::c_void,
-                ((set_rle as core::ffi::c_int as u32).wrapping_add(((3) << 2) as u32) as size_t)
+                ((set_rle as core::ffi::c_int as u32).wrapping_add(((3) << 2) as u32) as usize)
                     .wrapping_add(srcSize << 4) as u32,
             );
         }
         _ => {}
     }
     *ostart.offset(flSize as isize) = *(src as *const u8);
-    flSize.wrapping_add(1) as size_t
+    flSize.wrapping_add(1) as usize
 }
-unsafe fn ZSTD_minLiteralsToCompress(strategy: ZSTD_strategy, huf_repeat: HUF_repeat) -> size_t {
+unsafe fn ZSTD_minLiteralsToCompress(strategy: ZSTD_strategy, huf_repeat: HUF_repeat) -> usize {
     let shift = if (9 - strategy as core::ffi::c_int) < 3 {
         9 - strategy as core::ffi::c_int
     } else {
@@ -149,29 +149,29 @@ unsafe fn ZSTD_minLiteralsToCompress(strategy: ZSTD_strategy, huf_repeat: HUF_re
 }
 pub unsafe fn ZSTD_compressLiterals(
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     entropyWorkspace: *mut core::ffi::c_void,
-    entropyWorkspaceSize: size_t,
+    entropyWorkspaceSize: usize,
     prevHuf: *const ZSTD_hufCTables_t,
     nextHuf: *mut ZSTD_hufCTables_t,
     strategy: ZSTD_strategy,
     disableLiteralCompression: core::ffi::c_int,
     suspectUncompressible: core::ffi::c_int,
     bmi2: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let lhSize = (3
-        + (srcSize >= ((1) << 10) as size_t) as core::ffi::c_int
-        + (srcSize >= (16 * ((1) << 10)) as size_t) as core::ffi::c_int) as size_t;
+        + (srcSize >= ((1) << 10) as usize) as core::ffi::c_int
+        + (srcSize >= (16 * ((1) << 10)) as usize) as core::ffi::c_int) as usize;
     let ostart = dst as *mut u8;
     let mut singleStream = (srcSize < 256) as core::ffi::c_int as u32;
     let mut hType = set_compressed;
-    let mut cLitSize: size_t = 0;
+    let mut cLitSize: usize = 0;
     libc::memcpy(
         nextHuf as *mut core::ffi::c_void,
         prevHuf as *const core::ffi::c_void,
-        ::core::mem::size_of::<ZSTD_hufCTables_t>() as core::ffi::c_ulong as libc::size_t,
+        ::core::mem::size_of::<ZSTD_hufCTables_t>() as core::ffi::c_ulong as usize,
     );
     if disableLiteralCompression != 0 {
         return ZSTD_noCompressLiterals(dst, dstCapacity, src, srcSize);
@@ -215,34 +215,34 @@ pub unsafe fn ZSTD_compressLiterals(
             HUF_compress1X_repeat
                 as unsafe extern "C" fn(
                     *mut core::ffi::c_void,
-                    size_t,
+                    usize,
                     *const core::ffi::c_void,
-                    size_t,
+                    usize,
                     core::ffi::c_uint,
                     core::ffi::c_uint,
                     *mut core::ffi::c_void,
-                    size_t,
+                    usize,
                     *mut HUF_CElt,
                     *mut HUF_repeat,
                     core::ffi::c_int,
-                ) -> size_t,
+                ) -> usize,
         )
     } else {
         Some(
             HUF_compress4X_repeat
                 as unsafe extern "C" fn(
                     *mut core::ffi::c_void,
-                    size_t,
+                    usize,
                     *const core::ffi::c_void,
-                    size_t,
+                    usize,
                     core::ffi::c_uint,
                     core::ffi::c_uint,
                     *mut core::ffi::c_void,
-                    size_t,
+                    usize,
                     *mut HUF_CElt,
                     *mut HUF_repeat,
                     core::ffi::c_int,
-                ) -> size_t,
+                ) -> usize,
         )
     };
     cLitSize = huf_compress.unwrap_unchecked()(
@@ -266,7 +266,7 @@ pub unsafe fn ZSTD_compressLiterals(
         libc::memcpy(
             nextHuf as *mut core::ffi::c_void,
             prevHuf as *const core::ffi::c_void,
-            ::core::mem::size_of::<ZSTD_hufCTables_t>() as core::ffi::c_ulong as libc::size_t,
+            ::core::mem::size_of::<ZSTD_hufCTables_t>() as core::ffi::c_ulong as usize,
         );
         return ZSTD_noCompressLiterals(dst, dstCapacity, src, srcSize);
     }
@@ -274,7 +274,7 @@ pub unsafe fn ZSTD_compressLiterals(
         libc::memcpy(
             nextHuf as *mut core::ffi::c_void,
             prevHuf as *const core::ffi::c_void,
-            ::core::mem::size_of::<ZSTD_hufCTables_t>() as core::ffi::c_ulong as libc::size_t,
+            ::core::mem::size_of::<ZSTD_hufCTables_t>() as core::ffi::c_ulong as usize,
         );
         return ZSTD_compressRleLiteralsBlock(dst, dstCapacity, src, srcSize);
     }

--- a/lib/compress/zstd_compress_sequences.rs
+++ b/lib/compress/zstd_compress_sequences.rs
@@ -1,4 +1,4 @@
-use libc::size_t;
+
 
 use crate::lib::common::bitstream::{
     BIT_CStream_t, BIT_addBits, BIT_closeCStream, BIT_flushBits, BIT_initCStream, BitContainerType,
@@ -53,15 +53,15 @@ unsafe fn ZSTD_getFSEMaxSymbolValue(ctable: *const FSE_CTable) -> core::ffi::c_u
 
     MEM_read16(u16ptr.add(1) as *const core::ffi::c_void) as u32
 }
-unsafe fn ZSTD_useLowProbCount(nbSeq: size_t) -> core::ffi::c_uint {
+unsafe fn ZSTD_useLowProbCount(nbSeq: usize) -> core::ffi::c_uint {
     (nbSeq >= 2048) as core::ffi::c_int as core::ffi::c_uint
 }
 unsafe fn ZSTD_NCountCost(
     count: *const core::ffi::c_uint,
     max: core::ffi::c_uint,
-    nbSeq: size_t,
+    nbSeq: usize,
     FSELog: core::ffi::c_uint,
-) -> size_t {
+) -> usize {
     let mut wksp: [u8; 512] = [0; 512];
     let mut norm: [i16; 53] = [0; 53];
     let tableLog = FSE_optimalTableLog(FSELog, nbSeq, max);
@@ -87,14 +87,14 @@ unsafe fn ZSTD_NCountCost(
 unsafe fn ZSTD_entropyCost(
     count: *const core::ffi::c_uint,
     max: core::ffi::c_uint,
-    total: size_t,
-) -> size_t {
+    total: usize,
+) -> usize {
     let mut cost = 0 as core::ffi::c_uint;
     let mut s: core::ffi::c_uint = 0;
     s = 0;
     while s <= max {
         let mut norm = ((256 as core::ffi::c_uint).wrapping_mul(*count.offset(s as isize))
-            as size_t
+            as usize
             / total) as core::ffi::c_uint;
         if *count.offset(s as isize) != 0 && norm == 0 {
             norm = 1;
@@ -105,15 +105,15 @@ unsafe fn ZSTD_entropyCost(
         );
         s = s.wrapping_add(1);
     }
-    (cost >> 8) as size_t
+    (cost >> 8) as usize
 }
 pub unsafe fn ZSTD_fseBitCost(
     ctable: *const FSE_CTable,
     count: *const core::ffi::c_uint,
     max: core::ffi::c_uint,
-) -> size_t {
+) -> usize {
     let kAccuracyLog = 8;
-    let mut cost = 0 as size_t;
+    let mut cost = 0 as usize;
     let mut s: core::ffi::c_uint = 0;
     let mut cstate = FSE_CState_t {
         value: 0,
@@ -134,7 +134,7 @@ pub unsafe fn ZSTD_fseBitCost(
             if bitCost >= badCost {
                 return Error::GENERIC.to_error_code();
             }
-            cost = cost.wrapping_add(*count.offset(s as isize) as size_t * bitCost as size_t);
+            cost = cost.wrapping_add(*count.offset(s as isize) as usize * bitCost as usize);
         }
         s = s.wrapping_add(1);
     }
@@ -145,9 +145,9 @@ pub unsafe fn ZSTD_crossEntropyCost(
     accuracyLog: core::ffi::c_uint,
     count: *const core::ffi::c_uint,
     max: core::ffi::c_uint,
-) -> size_t {
+) -> usize {
     let shift = (8 as core::ffi::c_uint).wrapping_sub(accuracyLog);
-    let mut cost = 0 as size_t;
+    let mut cost = 0 as usize;
     let mut s: core::ffi::c_uint = 0;
     s = 0;
     while s <= max {
@@ -160,7 +160,7 @@ pub unsafe fn ZSTD_crossEntropyCost(
         cost = cost.wrapping_add(
             (*count.offset(s as isize))
                 .wrapping_mul(*kInverseProbabilityLog256.as_ptr().offset(norm256 as isize))
-                as size_t,
+                as usize,
         );
         s = s.wrapping_add(1);
     }
@@ -170,8 +170,8 @@ pub unsafe fn ZSTD_selectEncodingType(
     repeatMode: *mut FSE_repeat,
     count: *const core::ffi::c_uint,
     max: core::ffi::c_uint,
-    mostFrequent: size_t,
-    nbSeq: size_t,
+    mostFrequent: usize,
+    nbSeq: usize,
     FSELog: core::ffi::c_uint,
     prevCTable: *const FSE_CTable,
     defaultNorm: *const core::ffi::c_short,
@@ -190,7 +190,7 @@ pub unsafe fn ZSTD_selectEncodingType(
         if isDefaultAllowed as u64 != 0 {
             let staticFse_nbSeq_max = 1000;
             let mult =
-                (10 as core::ffi::c_uint).wrapping_sub(strategy as core::ffi::c_uint) as size_t;
+                (10 as core::ffi::c_uint).wrapping_sub(strategy as core::ffi::c_uint) as usize;
             let baseLog = 3;
             let dynamicFse_nbSeq_min = (((1) << defaultNormLog) * mult) >> baseLog;
             if *repeatMode as core::ffi::c_uint
@@ -239,22 +239,22 @@ pub unsafe fn ZSTD_selectEncodingType(
 }
 pub unsafe fn ZSTD_buildCTable(
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     nextCTable: *mut FSE_CTable,
     FSELog: u32,
     type_0: SymbolEncodingType_e,
     count: *mut core::ffi::c_uint,
     max: u32,
     codeTable: *const u8,
-    nbSeq: size_t,
+    nbSeq: usize,
     defaultNorm: *const i16,
     defaultNormLog: u32,
     defaultMax: u32,
     prevCTable: *const FSE_CTable,
-    prevCTableSize: size_t,
+    prevCTableSize: usize,
     entropyWorkspace: *mut core::ffi::c_void,
-    entropyWorkspaceSize: size_t,
-) -> size_t {
+    entropyWorkspaceSize: usize,
+) -> usize {
     let op = dst as *mut u8;
     let oend: *const u8 = op.add(dstCapacity);
     match type_0 as core::ffi::c_uint {
@@ -273,7 +273,7 @@ pub unsafe fn ZSTD_buildCTable(
             libc::memcpy(
                 nextCTable as *mut core::ffi::c_void,
                 prevCTable as *const core::ffi::c_void,
-                prevCTableSize as libc::size_t,
+                prevCTableSize as usize,
             );
             0
         }
@@ -340,7 +340,7 @@ pub unsafe fn ZSTD_buildCTable(
 }
 unsafe fn ZSTD_encodeSequences_body(
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     CTable_MatchLength: *const FSE_CTable,
     mlCodeTable: *const u8,
     CTable_OffsetBits: *const FSE_CTable,
@@ -348,9 +348,9 @@ unsafe fn ZSTD_encodeSequences_body(
     CTable_LitLength: *const FSE_CTable,
     llCodeTable: *const u8,
     sequences: *const SeqDef,
-    nbSeq: size_t,
+    nbSeq: usize,
     longOffsets: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let mut blockStream = BIT_CStream_t {
         bitContainer: 0,
         bitPos: 0,
@@ -444,7 +444,7 @@ unsafe fn ZSTD_encodeSequences_body(
         );
     }
     BIT_flushBits(&mut blockStream);
-    let mut n: size_t = 0;
+    let mut n: usize = 0;
     n = nbSeq.wrapping_sub(2);
     while n < nbSeq {
         let llCode = *llCodeTable.add(n);
@@ -535,7 +535,7 @@ unsafe fn ZSTD_encodeSequences_body(
 }
 unsafe fn ZSTD_encodeSequences_default(
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     CTable_MatchLength: *const FSE_CTable,
     mlCodeTable: *const u8,
     CTable_OffsetBits: *const FSE_CTable,
@@ -543,9 +543,9 @@ unsafe fn ZSTD_encodeSequences_default(
     CTable_LitLength: *const FSE_CTable,
     llCodeTable: *const u8,
     sequences: *const SeqDef,
-    nbSeq: size_t,
+    nbSeq: usize,
     longOffsets: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     ZSTD_encodeSequences_body(
         dst,
         dstCapacity,
@@ -562,7 +562,7 @@ unsafe fn ZSTD_encodeSequences_default(
 }
 unsafe fn ZSTD_encodeSequences_bmi2(
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     CTable_MatchLength: *const FSE_CTable,
     mlCodeTable: *const u8,
     CTable_OffsetBits: *const FSE_CTable,
@@ -570,9 +570,9 @@ unsafe fn ZSTD_encodeSequences_bmi2(
     CTable_LitLength: *const FSE_CTable,
     llCodeTable: *const u8,
     sequences: *const SeqDef,
-    nbSeq: size_t,
+    nbSeq: usize,
     longOffsets: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     ZSTD_encodeSequences_body(
         dst,
         dstCapacity,
@@ -589,7 +589,7 @@ unsafe fn ZSTD_encodeSequences_bmi2(
 }
 pub unsafe fn ZSTD_encodeSequences(
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     CTable_MatchLength: *const FSE_CTable,
     mlCodeTable: *const u8,
     CTable_OffsetBits: *const FSE_CTable,
@@ -597,10 +597,10 @@ pub unsafe fn ZSTD_encodeSequences(
     CTable_LitLength: *const FSE_CTable,
     llCodeTable: *const u8,
     sequences: *const SeqDef,
-    nbSeq: size_t,
+    nbSeq: usize,
     longOffsets: core::ffi::c_int,
     bmi2: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     if bmi2 != 0 {
         return ZSTD_encodeSequences_bmi2(
             dst,

--- a/lib/compress/zstd_compress_superblock.rs
+++ b/lib/compress/zstd_compress_superblock.rs
@@ -1,4 +1,4 @@
-use libc::size_t;
+
 
 use crate::lib::common::error_private::{ERR_isError, Error};
 use crate::lib::common::fse::FSE_CTable;
@@ -58,14 +58,14 @@ pub type ZSTD_prefixDict = ZSTD_prefixDict_s;
 #[repr(C)]
 pub struct ZSTD_prefixDict_s {
     pub dict: *const core::ffi::c_void,
-    pub dictSize: size_t,
+    pub dictSize: usize,
     pub dictContentType: ZSTD_dictContentType_e,
 }
 #[repr(C)]
 pub struct ZSTD_localDict {
     pub dictBuffer: *mut core::ffi::c_void,
     pub dict: *const core::ffi::c_void,
-    pub dictSize: size_t,
+    pub dictSize: usize,
     pub dictContentType: ZSTD_dictContentType_e,
     pub cdict: *mut ZSTD_CDict,
 }
@@ -73,8 +73,8 @@ pub type ZSTD_inBuffer = ZSTD_inBuffer_s;
 #[repr(C)]
 pub struct ZSTD_inBuffer_s {
     pub src: *const core::ffi::c_void,
-    pub size: size_t,
-    pub pos: size_t,
+    pub size: usize,
+    pub pos: usize,
 }
 pub type ZSTD_cStreamStage = core::ffi::c_uint;
 pub const zcss_flush: ZSTD_cStreamStage = 2;
@@ -116,7 +116,7 @@ pub struct ldmState_t {
     pub hashTable: *mut ldmEntry_t,
     pub loadedDictEnd: u32,
     pub bucketOffsets: *mut u8,
-    pub splitIndices: [size_t; 64],
+    pub splitIndices: [usize; 64],
     pub matchCandidates: [ldmMatchCandidate_t; 64],
 }
 #[repr(C)]
@@ -137,8 +137,8 @@ pub struct ldmEntry_t {
 pub struct SeqCollector {
     pub collectSequences: core::ffi::c_int,
     pub seqStart: *mut ZSTD_Sequence,
-    pub seqIndex: size_t,
-    pub maxSequences: size_t,
+    pub seqIndex: usize,
+    pub maxSequences: usize,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -178,14 +178,14 @@ pub type ZSTD_sequenceProducer_F = Option<
     unsafe extern "C" fn(
         *mut core::ffi::c_void,
         *mut ZSTD_Sequence,
-        size_t,
+        usize,
         *const core::ffi::c_void,
-        size_t,
+        usize,
         *const core::ffi::c_void,
-        size_t,
+        usize,
         core::ffi::c_int,
-        size_t,
-    ) -> size_t,
+        usize,
+    ) -> usize,
 >;
 pub type ZSTD_SequenceFormat_e = core::ffi::c_uint;
 pub const ZSTD_sf_explicitBlockDelimiters: ZSTD_SequenceFormat_e = 1;
@@ -227,8 +227,8 @@ pub struct ZSTD_SequenceLength {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct EstimatedBlockSize {
-    pub estLitSize: size_t,
-    pub estBlockSize: size_t,
+    pub estLitSize: usize,
+    pub estBlockSize: usize,
 }
 pub const ZSTD_TARGETCBLOCKSIZE_MIN: core::ffi::c_int = 1340;
 #[inline]
@@ -258,11 +258,11 @@ unsafe fn ZSTD_getSequenceLength(
 #[inline]
 unsafe fn ZSTD_noCompressBlock(
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     lastBlock: u32,
-) -> size_t {
+) -> usize {
     let cBlockHeader24 = lastBlock
         .wrapping_add((bt_raw as core::ffi::c_int as u32) << 1)
         .wrapping_add((srcSize << 3) as u32);
@@ -273,13 +273,13 @@ unsafe fn ZSTD_noCompressBlock(
     libc::memcpy(
         (dst as *mut u8).add(ZSTD_blockHeaderSize) as *mut core::ffi::c_void,
         src,
-        srcSize as libc::size_t,
+        srcSize as usize,
     );
     ZSTD_blockHeaderSize.wrapping_add(srcSize)
 }
 
 pub const ZSTD_BLOCKHEADERSIZE: core::ffi::c_int = 3;
-static ZSTD_blockHeaderSize: size_t = ZSTD_BLOCKHEADERSIZE as size_t;
+static ZSTD_blockHeaderSize: usize = ZSTD_BLOCKHEADERSIZE as usize;
 pub const LONGNBSEQ: core::ffi::c_int = 0x7f00 as core::ffi::c_int;
 pub const STREAM_ACCUMULATOR_MIN_32: core::ffi::c_int = 25;
 pub const STREAM_ACCUMULATOR_MIN_64: core::ffi::c_int = 57;
@@ -287,18 +287,18 @@ unsafe fn ZSTD_compressSubBlock_literal(
     hufTable: *const HUF_CElt,
     hufMetadata: *const ZSTD_hufCTablesMetadata_t,
     literals: *const u8,
-    litSize: size_t,
+    litSize: usize,
     dst: *mut core::ffi::c_void,
-    dstSize: size_t,
+    dstSize: usize,
     bmi2: core::ffi::c_int,
     writeEntropy: core::ffi::c_int,
     entropyWritten: *mut core::ffi::c_int,
-) -> size_t {
-    let header = (if writeEntropy != 0 { 200 } else { 0 }) as size_t;
+) -> usize {
+    let header = (if writeEntropy != 0 { 200 } else { 0 }) as usize;
     let lhSize = (3
-        + (litSize >= (((1) << 10) as size_t).wrapping_sub(header)) as core::ffi::c_int
-        + (litSize >= ((16 * ((1) << 10)) as size_t).wrapping_sub(header)) as core::ffi::c_int)
-        as size_t;
+        + (litSize >= (((1) << 10) as usize).wrapping_sub(header)) as core::ffi::c_int
+        + (litSize >= ((16 * ((1) << 10)) as usize).wrapping_sub(header)) as core::ffi::c_int)
+        as usize;
     let ostart = dst as *mut u8;
     let oend = ostart.add(dstSize);
     let mut op = ostart.add(lhSize);
@@ -308,7 +308,7 @@ unsafe fn ZSTD_compressSubBlock_literal(
     } else {
         set_repeat as core::ffi::c_int as core::ffi::c_uint
     }) as SymbolEncodingType_e;
-    let mut cLitSize = 0 as size_t;
+    let mut cLitSize = 0 as usize;
     *entropyWritten = 0;
     if litSize == 0
         || (*hufMetadata).hType as core::ffi::c_uint
@@ -337,7 +337,7 @@ unsafe fn ZSTD_compressSubBlock_literal(
         libc::memcpy(
             op as *mut core::ffi::c_void,
             ((*hufMetadata).hufDesBuffer).as_ptr() as *const core::ffi::c_void,
-            (*hufMetadata).hufDesSize as libc::size_t,
+            (*hufMetadata).hufDesSize as usize,
         );
         op = op.add((*hufMetadata).hufDesSize);
         cLitSize = cLitSize.wrapping_add((*hufMetadata).hufDesSize);
@@ -380,8 +380,8 @@ unsafe fn ZSTD_compressSubBlock_literal(
         );
     }
     if lhSize
-        < (3 + (cLitSize >= ((1) << 10) as size_t) as core::ffi::c_int
-            + (cLitSize >= (16 * ((1) << 10)) as size_t) as core::ffi::c_int) as size_t
+        < (3 + (cLitSize >= ((1) << 10) as usize) as core::ffi::c_int
+            + (cLitSize >= (16 * ((1) << 10)) as usize) as core::ffi::c_int) as usize
     {
         return ZSTD_noCompressLiterals(
             dst,
@@ -421,18 +421,18 @@ unsafe fn ZSTD_compressSubBlock_literal(
 unsafe fn ZSTD_seqDecompressedSize(
     seqStore: *const SeqStore_t,
     sequences: *const SeqDef,
-    nbSeqs: size_t,
-    litSize: size_t,
+    nbSeqs: usize,
+    litSize: usize,
     lastSubBlock: core::ffi::c_int,
-) -> size_t {
-    let mut matchLengthSum = 0 as size_t;
-    let mut litLengthSum = 0 as size_t;
-    let mut n: size_t = 0;
+) -> usize {
+    let mut matchLengthSum = 0 as usize;
+    let mut litLengthSum = 0 as usize;
+    let mut n: usize = 0;
     n = 0;
     while n < nbSeqs {
         let seqLen = ZSTD_getSequenceLength(seqStore, sequences.add(n));
-        litLengthSum = litLengthSum.wrapping_add(seqLen.litLength as size_t);
-        matchLengthSum = matchLengthSum.wrapping_add(seqLen.matchLength as size_t);
+        litLengthSum = litLengthSum.wrapping_add(seqLen.litLength as usize);
+        matchLengthSum = matchLengthSum.wrapping_add(seqLen.matchLength as usize);
         n = n.wrapping_add(1);
     }
 
@@ -448,17 +448,17 @@ unsafe fn ZSTD_compressSubBlock_sequences(
     fseTables: *const ZSTD_fseCTables_t,
     fseMetadata: *const ZSTD_fseCTablesMetadata_t,
     sequences: *const SeqDef,
-    nbSeq: size_t,
+    nbSeq: usize,
     llCode: *const u8,
     mlCode: *const u8,
     ofCode: *const u8,
     cctxParams: *const ZSTD_CCtx_params,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     bmi2: core::ffi::c_int,
     writeEntropy: core::ffi::c_int,
     entropyWritten: *mut core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let longOffsets = ((*cctxParams).cParams.windowLog
         > (if MEM_32bits() {
             STREAM_ACCUMULATOR_MIN_32
@@ -477,15 +477,15 @@ unsafe fn ZSTD_compressSubBlock_sequences(
         let fresh0 = op;
         op = op.add(1);
         *fresh0 = nbSeq as u8;
-    } else if nbSeq < LONGNBSEQ as size_t {
-        *op = (nbSeq >> 8).wrapping_add(0x80 as core::ffi::c_int as size_t) as u8;
+    } else if nbSeq < LONGNBSEQ as usize {
+        *op = (nbSeq >> 8).wrapping_add(0x80 as core::ffi::c_int as usize) as u8;
         *op.add(1) = nbSeq as u8;
         op = op.add(2);
     } else {
         *op = 0xff as core::ffi::c_int as u8;
         MEM_writeLE16(
             op.add(1) as *mut core::ffi::c_void,
-            nbSeq.wrapping_sub(LONGNBSEQ as size_t) as u16,
+            nbSeq.wrapping_sub(LONGNBSEQ as usize) as u16,
         );
         op = op.add(3);
     }
@@ -505,7 +505,7 @@ unsafe fn ZSTD_compressSubBlock_sequences(
         libc::memcpy(
             op as *mut core::ffi::c_void,
             ((*fseMetadata).fseTablesBuffer).as_ptr() as *const core::ffi::c_void,
-            (*fseMetadata).fseTablesSize as libc::size_t,
+            (*fseMetadata).fseTablesSize as usize,
         );
         op = op.add((*fseMetadata).fseTablesSize);
     } else {
@@ -549,22 +549,22 @@ unsafe fn ZSTD_compressSubBlock(
     entropy: *const ZSTD_entropyCTables_t,
     entropyMetadata: *const ZSTD_entropyCTablesMetadata_t,
     sequences: *const SeqDef,
-    nbSeq: size_t,
+    nbSeq: usize,
     literals: *const u8,
-    litSize: size_t,
+    litSize: usize,
     llCode: *const u8,
     mlCode: *const u8,
     ofCode: *const u8,
     cctxParams: *const ZSTD_CCtx_params,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     bmi2: core::ffi::c_int,
     writeLitEntropy: core::ffi::c_int,
     writeSeqEntropy: core::ffi::c_int,
     litEntropyWritten: *mut core::ffi::c_int,
     seqEntropyWritten: *mut core::ffi::c_int,
     lastBlock: u32,
-) -> size_t {
+) -> usize {
     let ostart = dst as *mut u8;
     let oend = ostart.add(dstCapacity);
     let mut op = ostart.add(ZSTD_blockHeaderSize);
@@ -619,13 +619,13 @@ unsafe fn ZSTD_compressSubBlock(
 }
 unsafe fn ZSTD_estimateSubBlockSize_literal(
     literals: *const u8,
-    litSize: size_t,
+    litSize: usize,
     huf: *const ZSTD_hufCTables_t,
     hufMetadata: *const ZSTD_hufCTablesMetadata_t,
     workspace: *mut core::ffi::c_void,
-    wkspSize: size_t,
+    wkspSize: usize,
     writeEntropy: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let countWksp = workspace as *mut core::ffi::c_uint;
     let mut maxSymbolValue = 255;
     let literalSectionHeaderSize = 3;
@@ -666,15 +666,15 @@ unsafe fn ZSTD_estimateSubBlockSize_symbolType(
     type_0: SymbolEncodingType_e,
     codeTable: *const u8,
     maxCode: core::ffi::c_uint,
-    nbSeq: size_t,
+    nbSeq: usize,
     fseCTable: *const FSE_CTable,
     additionalBits: *const u8,
     defaultNorm: *const core::ffi::c_short,
     defaultNormLog: u32,
     defaultMax: u32,
     workspace: *mut core::ffi::c_void,
-    wkspSize: size_t,
-) -> size_t {
+    wkspSize: usize,
+) -> usize {
     let countWksp = workspace as *mut core::ffi::c_uint;
     let mut ctp = codeTable;
     let ctStart = ctp;
@@ -708,10 +708,10 @@ unsafe fn ZSTD_estimateSubBlockSize_symbolType(
     while ctp < ctEnd {
         if !additionalBits.is_null() {
             cSymbolTypeSizeEstimateInBits = cSymbolTypeSizeEstimateInBits
-                .wrapping_add(*additionalBits.offset(*ctp as isize) as size_t);
+                .wrapping_add(*additionalBits.offset(*ctp as isize) as usize);
         } else {
             cSymbolTypeSizeEstimateInBits =
-                cSymbolTypeSizeEstimateInBits.wrapping_add(*ctp as size_t);
+                cSymbolTypeSizeEstimateInBits.wrapping_add(*ctp as usize);
         }
         ctp = ctp.add(1);
     }
@@ -721,15 +721,15 @@ unsafe fn ZSTD_estimateSubBlockSize_sequences(
     ofCodeTable: *const u8,
     llCodeTable: *const u8,
     mlCodeTable: *const u8,
-    nbSeq: size_t,
+    nbSeq: usize,
     fseTables: *const ZSTD_fseCTables_t,
     fseMetadata: *const ZSTD_fseCTablesMetadata_t,
     workspace: *mut core::ffi::c_void,
-    wkspSize: size_t,
+    wkspSize: usize,
     writeEntropy: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let sequencesSectionHeaderSize = 3;
-    let mut cSeqSizeEstimate = 0 as size_t;
+    let mut cSeqSizeEstimate = 0 as usize;
     if nbSeq == 0 {
         return sequencesSectionHeaderSize;
     }
@@ -779,15 +779,15 @@ unsafe fn ZSTD_estimateSubBlockSize_sequences(
 }
 unsafe fn ZSTD_estimateSubBlockSize(
     literals: *const u8,
-    litSize: size_t,
+    litSize: usize,
     ofCodeTable: *const u8,
     llCodeTable: *const u8,
     mlCodeTable: *const u8,
-    nbSeq: size_t,
+    nbSeq: usize,
     entropy: *const ZSTD_entropyCTables_t,
     entropyMetadata: *const ZSTD_entropyCTablesMetadata_t,
     workspace: *mut core::ffi::c_void,
-    wkspSize: size_t,
+    wkspSize: usize,
     writeLitEntropy: core::ffi::c_int,
     writeSeqEntropy: core::ffi::c_int,
 ) -> EstimatedBlockSize {
@@ -848,14 +848,14 @@ unsafe fn ZSTD_needSequenceEntropyTables(
 unsafe fn countLiterals(
     seqStore: *const SeqStore_t,
     sp: *const SeqDef,
-    seqCount: size_t,
-) -> size_t {
-    let mut n: size_t = 0;
-    let mut total = 0 as size_t;
+    seqCount: usize,
+) -> usize {
+    let mut n: usize = 0;
+    let mut total = 0 as usize;
     n = 0;
     while n < seqCount {
         total =
-            total.wrapping_add((ZSTD_getSequenceLength(seqStore, sp.add(n))).litLength as size_t);
+            total.wrapping_add((ZSTD_getSequenceLength(seqStore, sp.add(n))).litLength as usize);
         n = n.wrapping_add(1);
     }
     total
@@ -863,32 +863,32 @@ unsafe fn countLiterals(
 pub const BYTESCALE: core::ffi::c_int = 256;
 unsafe fn sizeBlockSequences(
     sp: *const SeqDef,
-    nbSeqs: size_t,
-    targetBudget: size_t,
-    avgLitCost: size_t,
-    avgSeqCost: size_t,
+    nbSeqs: usize,
+    targetBudget: usize,
+    avgLitCost: usize,
+    avgSeqCost: usize,
     firstSubBlock: core::ffi::c_int,
-) -> size_t {
-    let mut n: size_t = 0;
-    let mut budget = 0 as size_t;
+) -> usize {
+    let mut n: usize = 0;
+    let mut budget = 0 as usize;
     let mut inSize = 0;
-    let headerSize = firstSubBlock as size_t * 120 * BYTESCALE as size_t;
+    let headerSize = firstSubBlock as usize * 120 * BYTESCALE as usize;
     budget = budget.wrapping_add(headerSize);
-    budget = budget.wrapping_add(((*sp).litLength as size_t * avgLitCost).wrapping_add(avgSeqCost));
+    budget = budget.wrapping_add(((*sp).litLength as usize * avgLitCost).wrapping_add(avgSeqCost));
     if budget > targetBudget {
         return 1;
     }
     inSize = ((*sp).litLength as core::ffi::c_int + ((*sp).mlBase as core::ffi::c_int + MINMATCH))
-        as size_t;
+        as usize;
     n = 1;
     while n < nbSeqs {
-        let currentCost = ((*sp.add(n)).litLength as size_t * avgLitCost).wrapping_add(avgSeqCost);
+        let currentCost = ((*sp.add(n)).litLength as usize * avgLitCost).wrapping_add(avgSeqCost);
         budget = budget.wrapping_add(currentCost);
         inSize = inSize.wrapping_add(
             ((*sp.add(n)).litLength as core::ffi::c_int
-                + ((*sp.add(n)).mlBase as core::ffi::c_int + MINMATCH)) as size_t,
+                + ((*sp.add(n)).mlBase as core::ffi::c_int + MINMATCH)) as usize,
         );
-        if budget > targetBudget && budget < inSize * BYTESCALE as size_t {
+        if budget > targetBudget && budget < inSize * BYTESCALE as usize {
             break;
         }
         n = n.wrapping_add(1);
@@ -902,14 +902,14 @@ unsafe fn ZSTD_compressSubBlock_multi(
     entropyMetadata: *const ZSTD_entropyCTablesMetadata_t,
     cctxParams: *const ZSTD_CCtx_params,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     bmi2: core::ffi::c_int,
     lastBlock: u32,
     workspace: *mut core::ffi::c_void,
-    wkspSize: size_t,
-) -> size_t {
+    wkspSize: usize,
+) -> usize {
     let sstart: *const SeqDef = (*seqStorePtr).sequencesStart;
     let send: *const SeqDef = (*seqStorePtr).sequences;
     let mut sp = sstart;
@@ -926,7 +926,7 @@ unsafe fn ZSTD_compressSubBlock_multi(
     let mut llCodePtr: *const u8 = (*seqStorePtr).llCode;
     let mut mlCodePtr: *const u8 = (*seqStorePtr).mlCode;
     let mut ofCodePtr: *const u8 = (*seqStorePtr).ofCode;
-    let minTarget = ZSTD_TARGETCBLOCKSIZE_MIN as size_t;
+    let minTarget = ZSTD_TARGETCBLOCKSIZE_MIN as usize;
     let targetCBlockSize = if minTarget > (*cctxParams).targetCBlockSize {
         minTarget
     } else {
@@ -952,12 +952,12 @@ unsafe fn ZSTD_compressSubBlock_multi(
             writeSeqEntropy,
         );
 
-        let avgLitCost = (ebs.estLitSize * BYTESCALE as size_t)
+        let avgLitCost = (ebs.estLitSize * BYTESCALE as usize)
             .checked_div(nbLiterals)
-            .unwrap_or(BYTESCALE as size_t);
+            .unwrap_or(BYTESCALE as usize);
 
         let avgSeqCost =
-            (ebs.estBlockSize).wrapping_sub(ebs.estLitSize) * BYTESCALE as size_t / nbSeqs;
+            (ebs.estBlockSize).wrapping_sub(ebs.estLitSize) * BYTESCALE as usize / nbSeqs;
 
         let nbSubBlocks =
             if (ebs.estBlockSize).wrapping_add(targetCBlockSize / 2) / targetCBlockSize > 1 {
@@ -965,10 +965,10 @@ unsafe fn ZSTD_compressSubBlock_multi(
             } else {
                 1
             };
-        let mut n: size_t = 0;
-        let mut avgBlockBudget: size_t = 0;
+        let mut n: usize = 0;
+        let mut avgBlockBudget: usize = 0;
         let mut blockBudgetSupp = 0;
-        avgBlockBudget = ebs.estBlockSize * BYTESCALE as size_t / nbSubBlocks;
+        avgBlockBudget = ebs.estBlockSize * BYTESCALE as usize / nbSubBlocks;
         if ebs.estBlockSize > srcSize {
             return 0;
         }
@@ -1080,7 +1080,7 @@ unsafe fn ZSTD_compressSubBlock_multi(
         libc::memcpy(
             &mut (*nextCBlock).entropy.huf as *mut ZSTD_hufCTables_t as *mut core::ffi::c_void,
             &(*prevCBlock).entropy.huf as *const ZSTD_hufCTables_t as *const core::ffi::c_void,
-            ::core::mem::size_of::<ZSTD_hufCTables_t>() as core::ffi::c_ulong as libc::size_t,
+            ::core::mem::size_of::<ZSTD_hufCTables_t>() as core::ffi::c_ulong as usize,
         );
     }
     if writeSeqEntropy != 0 && ZSTD_needSequenceEntropyTables(&(*entropyMetadata).fseMetadata) != 0
@@ -1107,7 +1107,7 @@ unsafe fn ZSTD_compressSubBlock_multi(
             libc::memcpy(
                 &mut rep as *mut Repcodes_t as *mut core::ffi::c_void,
                 ((*prevCBlock).rep).as_ptr() as *const core::ffi::c_void,
-                ::core::mem::size_of::<Repcodes_t>() as core::ffi::c_ulong as libc::size_t,
+                ::core::mem::size_of::<Repcodes_t>() as core::ffi::c_ulong as usize,
             );
             seq = sstart;
             while seq < sp {
@@ -1122,7 +1122,7 @@ unsafe fn ZSTD_compressSubBlock_multi(
             libc::memcpy(
                 ((*nextCBlock).rep).as_mut_ptr() as *mut core::ffi::c_void,
                 &mut rep as *mut Repcodes_t as *const core::ffi::c_void,
-                ::core::mem::size_of::<Repcodes_t>() as core::ffi::c_ulong as libc::size_t,
+                ::core::mem::size_of::<Repcodes_t>() as core::ffi::c_ulong as usize,
             );
         }
     }
@@ -1131,11 +1131,11 @@ unsafe fn ZSTD_compressSubBlock_multi(
 pub unsafe fn ZSTD_compressSuperBlock(
     zc: *mut ZSTD_CCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     lastBlock: core::ffi::c_uint,
-) -> size_t {
+) -> usize {
     let mut entropyMetadata = ZSTD_entropyCTablesMetadata_t {
         hufMetadata: ZSTD_hufCTablesMetadata_t {
             hType: set_basic,

--- a/lib/compress/zstd_double_fast.rs
+++ b/lib/compress/zstd_double_fast.rs
@@ -48,7 +48,7 @@ pub const ZSTD_tfp_forCDict: ZSTD_tableFillPurpose_e = 1;
 pub const ZSTD_tfp_forCCtx: ZSTD_tableFillPurpose_e = 0;
 pub const CACHELINE_SIZE: core::ffi::c_int = 64;
 
-use libc::size_t;
+
 
 use crate::lib::common::fse::{FSE_CTable, FSE_repeat};
 use crate::lib::common::huf::{HUF_CElt, HUF_repeat};
@@ -70,15 +70,15 @@ pub const ZSTD_SHORT_CACHE_TAG_BITS: core::ffi::c_int = 8;
 pub const ZSTD_SHORT_CACHE_TAG_MASK: core::ffi::c_uint =
     ((1 as core::ffi::c_uint) << ZSTD_SHORT_CACHE_TAG_BITS).wrapping_sub(1);
 #[inline]
-unsafe fn ZSTD_writeTaggedIndex(hashTable: *mut u32, hashAndTag: size_t, index: u32) {
+unsafe fn ZSTD_writeTaggedIndex(hashTable: *mut u32, hashAndTag: usize, index: u32) {
     let hash = hashAndTag >> ZSTD_SHORT_CACHE_TAG_BITS;
-    let tag = (hashAndTag & ZSTD_SHORT_CACHE_TAG_MASK as size_t) as u32;
+    let tag = (hashAndTag & ZSTD_SHORT_CACHE_TAG_MASK as usize) as u32;
     *hashTable.add(hash) = index << ZSTD_SHORT_CACHE_TAG_BITS | tag;
 }
 #[inline]
-unsafe fn ZSTD_comparePackedTags(packedTag1: size_t, packedTag2: size_t) -> core::ffi::c_int {
-    let tag1 = (packedTag1 & ZSTD_SHORT_CACHE_TAG_MASK as size_t) as u32;
-    let tag2 = (packedTag2 & ZSTD_SHORT_CACHE_TAG_MASK as size_t) as u32;
+unsafe fn ZSTD_comparePackedTags(packedTag1: usize, packedTag2: usize) -> core::ffi::c_int {
+    let tag1 = (packedTag1 & ZSTD_SHORT_CACHE_TAG_MASK as usize) as u32;
+    let tag2 = (packedTag2 & ZSTD_SHORT_CACHE_TAG_MASK as usize) as u32;
     (tag1 == tag2) as core::ffi::c_int
 }
 unsafe fn ZSTD_fillDoubleHashTableForCDict(
@@ -182,9 +182,9 @@ unsafe fn ZSTD_compressBlock_doubleFast_noDict_generic(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     mls: u32,
-) -> size_t {
+) -> usize {
     let cParams: *const ZSTD_compressionParameters = &mut ms.cParams;
     let hashLong = ms.hashTable;
     let hBitsL = (*cParams).hashLog;
@@ -202,14 +202,14 @@ unsafe fn ZSTD_compressBlock_doubleFast_noDict_generic(
     let mut offset_2 = *rep.add(1);
     let mut offsetSaved1 = 0;
     let mut offsetSaved2 = 0;
-    let mut mLength: size_t = 0;
+    let mut mLength: usize = 0;
     let mut offset: u32 = 0;
     let mut curr: u32 = 0;
-    let kStepIncr = ((1) << kSearchStrength) as size_t;
+    let kStepIncr = ((1) << kSearchStrength) as usize;
     let mut nextStep = core::ptr::null::<u8>();
-    let mut step: size_t = 0;
-    let mut hl0: size_t = 0;
-    let mut hl1: size_t = 0;
+    let mut step: usize = 0;
+    let mut hl0: usize = 0;
+    let mut hl1: usize = 0;
     let mut idxl0: u32 = 0;
     let mut idxl1: u32 = 0;
     let mut matchl0 = core::ptr::null::<u8>();
@@ -483,9 +483,9 @@ unsafe fn ZSTD_compressBlock_doubleFast_dictMatchState_generic(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     mls: u32,
-) -> size_t {
+) -> usize {
     let mut current_block: u64;
     let cParams: *const ZSTD_compressionParameters = &mut ms.cParams;
     let hashLong = ms.hashTable;
@@ -496,7 +496,7 @@ unsafe fn ZSTD_compressBlock_doubleFast_dictMatchState_generic(
     let istart = src as *const u8;
     let mut ip = istart;
     let mut anchor = istart;
-    let endIndex = (istart.wrapping_offset_from(base) as size_t).wrapping_add(srcSize) as u32;
+    let endIndex = (istart.wrapping_offset_from(base) as usize).wrapping_add(srcSize) as u32;
     let prefixLowestIndex = ZSTD_getLowestPrefixIndex(ms, endIndex, (*cParams).windowLog);
     let prefixLowest = base.wrapping_offset(prefixLowestIndex as isize);
     let iend = istart.add(srcSize);
@@ -521,27 +521,27 @@ unsafe fn ZSTD_compressBlock_doubleFast_dictMatchState_generic(
         + dictEnd.offset_from(dictStart) as core::ffi::c_long) as u32;
     if ms.prefetchCDictTables != 0 {
         let hashTableBytes =
-            ((1 as size_t) << (*dictCParams).hashLog).wrapping_mul(::core::mem::size_of::<u32>());
+            ((1 as usize) << (*dictCParams).hashLog).wrapping_mul(::core::mem::size_of::<u32>());
         let chainTableBytes =
-            ((1 as size_t) << (*dictCParams).chainLog).wrapping_mul(::core::mem::size_of::<u32>());
+            ((1 as usize) << (*dictCParams).chainLog).wrapping_mul(::core::mem::size_of::<u32>());
         let _ptr = dictHashLong as *const core::ffi::c_char;
         let _size = hashTableBytes;
-        let mut _pos: size_t = 0;
+        let mut _pos: usize = 0;
         _pos = 0;
         while _pos < _size {
-            _pos = _pos.wrapping_add(CACHELINE_SIZE as size_t);
+            _pos = _pos.wrapping_add(CACHELINE_SIZE as usize);
         }
         let _ptr_0 = dictHashSmall as *const core::ffi::c_char;
         let _size_0 = chainTableBytes;
-        let mut _pos_0: size_t = 0;
+        let mut _pos_0: usize = 0;
         _pos_0 = 0;
         while _pos_0 < _size_0 {
-            _pos_0 = _pos_0.wrapping_add(CACHELINE_SIZE as size_t);
+            _pos_0 = _pos_0.wrapping_add(CACHELINE_SIZE as usize);
         }
     }
     ip = ip.offset((dictAndPrefixLength == 0) as core::ffi::c_int as isize);
     while ip < ilimit {
-        let mut mLength: size_t = 0;
+        let mut mLength: usize = 0;
         let mut offset: u32 = 0;
         let h2 = ZSTD_hashPtr(ip as *const core::ffi::c_void, hBitsL, 8);
         let h = ZSTD_hashPtr(ip as *const core::ffi::c_void, hBitsS, mls);
@@ -551,9 +551,9 @@ unsafe fn ZSTD_compressBlock_doubleFast_dictMatchState_generic(
         let dictMatchIndexAndTagS =
             *dictHashSmall.add(dictHashAndTagS >> ZSTD_SHORT_CACHE_TAG_BITS);
         let dictTagsMatchL =
-            ZSTD_comparePackedTags(dictMatchIndexAndTagL as size_t, dictHashAndTagL);
+            ZSTD_comparePackedTags(dictMatchIndexAndTagL as usize, dictHashAndTagL);
         let dictTagsMatchS =
-            ZSTD_comparePackedTags(dictMatchIndexAndTagS as size_t, dictHashAndTagS);
+            ZSTD_comparePackedTags(dictMatchIndexAndTagS as usize, dictHashAndTagS);
         let curr = ip.wrapping_offset_from(base) as core::ffi::c_long as u32;
         let matchIndexL = *hashLong.add(h2);
         let mut matchIndexS = *hashSmall.add(h);
@@ -694,7 +694,7 @@ unsafe fn ZSTD_compressBlock_doubleFast_dictMatchState_generic(
                                 let dictMatchIndexAndTagL3 = *dictHashLong
                                     .add(dictHashAndTagL3 >> ZSTD_SHORT_CACHE_TAG_BITS);
                                 let dictTagsMatchL3 = ZSTD_comparePackedTags(
-                                    dictMatchIndexAndTagL3 as size_t,
+                                    dictMatchIndexAndTagL3 as usize,
                                     dictHashAndTagL3,
                                 );
                                 let mut matchL3 = base.wrapping_offset(matchIndexL3 as isize);
@@ -896,8 +896,8 @@ unsafe fn ZSTD_compressBlock_doubleFast_noDict_4(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_doubleFast_noDict_generic(ms, seqStore, rep, src, srcSize, 4)
 }
 unsafe fn ZSTD_compressBlock_doubleFast_noDict_5(
@@ -905,8 +905,8 @@ unsafe fn ZSTD_compressBlock_doubleFast_noDict_5(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_doubleFast_noDict_generic(ms, seqStore, rep, src, srcSize, 5)
 }
 unsafe fn ZSTD_compressBlock_doubleFast_noDict_6(
@@ -914,8 +914,8 @@ unsafe fn ZSTD_compressBlock_doubleFast_noDict_6(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_doubleFast_noDict_generic(ms, seqStore, rep, src, srcSize, 6)
 }
 unsafe fn ZSTD_compressBlock_doubleFast_noDict_7(
@@ -923,8 +923,8 @@ unsafe fn ZSTD_compressBlock_doubleFast_noDict_7(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_doubleFast_noDict_generic(ms, seqStore, rep, src, srcSize, 7)
 }
 unsafe fn ZSTD_compressBlock_doubleFast_dictMatchState_4(
@@ -932,8 +932,8 @@ unsafe fn ZSTD_compressBlock_doubleFast_dictMatchState_4(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_doubleFast_dictMatchState_generic(ms, seqStore, rep, src, srcSize, 4)
 }
 unsafe fn ZSTD_compressBlock_doubleFast_dictMatchState_5(
@@ -941,8 +941,8 @@ unsafe fn ZSTD_compressBlock_doubleFast_dictMatchState_5(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_doubleFast_dictMatchState_generic(ms, seqStore, rep, src, srcSize, 5)
 }
 unsafe fn ZSTD_compressBlock_doubleFast_dictMatchState_6(
@@ -950,8 +950,8 @@ unsafe fn ZSTD_compressBlock_doubleFast_dictMatchState_6(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_doubleFast_dictMatchState_generic(ms, seqStore, rep, src, srcSize, 6)
 }
 unsafe fn ZSTD_compressBlock_doubleFast_dictMatchState_7(
@@ -959,8 +959,8 @@ unsafe fn ZSTD_compressBlock_doubleFast_dictMatchState_7(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_doubleFast_dictMatchState_generic(ms, seqStore, rep, src, srcSize, 7)
 }
 pub unsafe fn ZSTD_compressBlock_doubleFast(
@@ -968,8 +968,8 @@ pub unsafe fn ZSTD_compressBlock_doubleFast(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let mls = ms.cParams.minMatch;
     match mls {
         5 => ZSTD_compressBlock_doubleFast_noDict_5(ms, seqStore, rep, src, srcSize),
@@ -983,8 +983,8 @@ pub unsafe fn ZSTD_compressBlock_doubleFast_dictMatchState(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let mls = ms.cParams.minMatch;
     match mls {
         5 => ZSTD_compressBlock_doubleFast_dictMatchState_5(ms, seqStore, rep, src, srcSize),
@@ -998,9 +998,9 @@ unsafe fn ZSTD_compressBlock_doubleFast_extDict_generic(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     mls: u32,
-) -> size_t {
+) -> usize {
     let cParams: *const ZSTD_compressionParameters = &mut ms.cParams;
     let hashLong = ms.hashTable;
     let hBitsL = (*cParams).hashLog;
@@ -1012,7 +1012,7 @@ unsafe fn ZSTD_compressBlock_doubleFast_extDict_generic(
     let iend = istart.add(srcSize);
     let ilimit = iend.sub(8);
     let base = ms.window.base;
-    let endIndex = (istart.wrapping_offset_from(base) as size_t).wrapping_add(srcSize) as u32;
+    let endIndex = (istart.wrapping_offset_from(base) as usize).wrapping_add(srcSize) as u32;
     let lowLimit = ZSTD_getLowestMatchIndex(ms, endIndex, (*cParams).windowLog);
     let dictStartIndex = lowLimit;
     let dictLimit = ms.window.dictLimit;
@@ -1055,7 +1055,7 @@ unsafe fn ZSTD_compressBlock_doubleFast_extDict_generic(
             base
         };
         let repMatch = repBase.wrapping_offset(repIndex as isize);
-        let mut mLength: size_t = 0;
+        let mut mLength: usize = 0;
         let fresh4 = &mut (*hashLong.add(hLong));
         *fresh4 = curr;
         *hashSmall.add(hSmall) = *fresh4;
@@ -1286,8 +1286,8 @@ unsafe fn ZSTD_compressBlock_doubleFast_extDict_4(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_doubleFast_extDict_generic(ms, seqStore, rep, src, srcSize, 4)
 }
 unsafe fn ZSTD_compressBlock_doubleFast_extDict_5(
@@ -1295,8 +1295,8 @@ unsafe fn ZSTD_compressBlock_doubleFast_extDict_5(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_doubleFast_extDict_generic(ms, seqStore, rep, src, srcSize, 5)
 }
 unsafe fn ZSTD_compressBlock_doubleFast_extDict_6(
@@ -1304,8 +1304,8 @@ unsafe fn ZSTD_compressBlock_doubleFast_extDict_6(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_doubleFast_extDict_generic(ms, seqStore, rep, src, srcSize, 6)
 }
 unsafe fn ZSTD_compressBlock_doubleFast_extDict_7(
@@ -1313,8 +1313,8 @@ unsafe fn ZSTD_compressBlock_doubleFast_extDict_7(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_doubleFast_extDict_generic(ms, seqStore, rep, src, srcSize, 7)
 }
 pub unsafe fn ZSTD_compressBlock_doubleFast_extDict(
@@ -1322,8 +1322,8 @@ pub unsafe fn ZSTD_compressBlock_doubleFast_extDict(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let mls = ms.cParams.minMatch;
     match mls {
         5 => ZSTD_compressBlock_doubleFast_extDict_5(ms, seqStore, rep, src, srcSize),

--- a/lib/compress/zstd_fast.rs
+++ b/lib/compress/zstd_fast.rs
@@ -48,7 +48,7 @@ pub const ZSTD_tfp_forCCtx: ZSTD_tableFillPurpose_e = 0;
 pub type ZSTD_match4Found = Option<unsafe fn(*const u8, *const u8, u32, u32) -> core::ffi::c_int>;
 pub const CACHELINE_SIZE: core::ffi::c_int = 64;
 
-use libc::size_t;
+
 
 use crate::lib::common::fse::{FSE_CTable, FSE_repeat};
 use crate::lib::common::huf::{HUF_CElt, HUF_repeat};
@@ -71,15 +71,15 @@ pub const ZSTD_SHORT_CACHE_TAG_BITS: core::ffi::c_int = 8;
 pub const ZSTD_SHORT_CACHE_TAG_MASK: core::ffi::c_uint =
     ((1 as core::ffi::c_uint) << ZSTD_SHORT_CACHE_TAG_BITS).wrapping_sub(1);
 #[inline]
-unsafe fn ZSTD_writeTaggedIndex(hashTable: *mut u32, hashAndTag: size_t, index: u32) {
+unsafe fn ZSTD_writeTaggedIndex(hashTable: *mut u32, hashAndTag: usize, index: u32) {
     let hash = hashAndTag >> ZSTD_SHORT_CACHE_TAG_BITS;
-    let tag = (hashAndTag & ZSTD_SHORT_CACHE_TAG_MASK as size_t) as u32;
+    let tag = (hashAndTag & ZSTD_SHORT_CACHE_TAG_MASK as usize) as u32;
     *hashTable.add(hash) = index << ZSTD_SHORT_CACHE_TAG_BITS | tag;
 }
 #[inline]
-unsafe fn ZSTD_comparePackedTags(packedTag1: size_t, packedTag2: size_t) -> core::ffi::c_int {
-    let tag1 = (packedTag1 & ZSTD_SHORT_CACHE_TAG_MASK as size_t) as u32;
-    let tag2 = (packedTag2 & ZSTD_SHORT_CACHE_TAG_MASK as size_t) as u32;
+unsafe fn ZSTD_comparePackedTags(packedTag1: usize, packedTag2: usize) -> core::ffi::c_int {
+    let tag1 = (packedTag1 & ZSTD_SHORT_CACHE_TAG_MASK as usize) as u32;
+    let tag2 = (packedTag2 & ZSTD_SHORT_CACHE_TAG_MASK as usize) as u32;
     (tag1 == tag2) as core::ffi::c_int
 }
 unsafe fn ZSTD_fillHashTableForCDict(
@@ -218,17 +218,17 @@ unsafe fn ZSTD_compressBlock_fast_noDict_generic(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     mls: u32,
     useCmov: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let mut current_block: u64;
     let cParams: *const ZSTD_compressionParameters = &mut ms.cParams;
     let hashTable = ms.hashTable;
     let hlog = (*cParams).hashLog;
     let stepSize = ((*cParams).targetLength)
         .wrapping_add(((*cParams).targetLength == 0) as core::ffi::c_int as core::ffi::c_uint)
-        .wrapping_add(1) as size_t;
+        .wrapping_add(1) as usize;
     let base = ms.window.base;
     let istart = src as *const u8;
     let endIndex = (istart.offset_from_unsigned(base)).wrapping_add(srcSize) as u32;
@@ -246,15 +246,15 @@ unsafe fn ZSTD_compressBlock_fast_noDict_generic(
     let mut rep_offset2 = *rep.add(1);
     let mut offsetSaved1 = 0;
     let mut offsetSaved2 = 0;
-    let mut hash0: size_t = 0;
-    let mut hash1: size_t = 0;
+    let mut hash0: usize = 0;
+    let mut hash1: usize = 0;
     let mut matchIdx: u32 = 0;
     let mut offcode: u32 = 0;
     let mut match0 = core::ptr::null::<u8>();
-    let mut mLength: size_t = 0;
-    let mut step: size_t = 0;
+    let mut mLength: usize = 0;
+    let mut step: usize = 0;
     let mut nextStep = core::ptr::null::<u8>();
-    let kStepIncr = ((1) << (kSearchStrength - 1)) as size_t;
+    let kStepIncr = ((1) << (kSearchStrength - 1)) as usize;
     let matchFound: ZSTD_match4Found = if useCmov != 0 {
         Some(ZSTD_match4Found_cmov as unsafe fn(*const u8, *const u8, u32, u32) -> core::ffi::c_int)
     } else {
@@ -298,7 +298,7 @@ unsafe fn ZSTD_compressBlock_fast_noDict_generic(
                 ip0 = ip2;
                 match0 = ip0.offset(-(rep_offset1 as isize));
                 mLength = (*ip0.sub(1) as core::ffi::c_int == *match0.sub(1) as core::ffi::c_int)
-                    as core::ffi::c_int as size_t;
+                    as core::ffi::c_int as usize;
                 ip0 = ip0.offset(-(mLength as isize));
                 match0 = match0.offset(-(mLength as isize));
                 offcode = REPCODE1_TO_OFFBASE as u32;
@@ -441,8 +441,8 @@ unsafe fn ZSTD_compressBlock_fast_noDict_4_1(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_fast_noDict_generic(ms, seqStore, rep, src, srcSize, 4, 1)
 }
 unsafe fn ZSTD_compressBlock_fast_noDict_5_1(
@@ -450,8 +450,8 @@ unsafe fn ZSTD_compressBlock_fast_noDict_5_1(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_fast_noDict_generic(ms, seqStore, rep, src, srcSize, 5, 1)
 }
 unsafe fn ZSTD_compressBlock_fast_noDict_6_1(
@@ -459,8 +459,8 @@ unsafe fn ZSTD_compressBlock_fast_noDict_6_1(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_fast_noDict_generic(ms, seqStore, rep, src, srcSize, 6, 1)
 }
 unsafe fn ZSTD_compressBlock_fast_noDict_7_1(
@@ -468,8 +468,8 @@ unsafe fn ZSTD_compressBlock_fast_noDict_7_1(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_fast_noDict_generic(ms, seqStore, rep, src, srcSize, 7, 1)
 }
 unsafe fn ZSTD_compressBlock_fast_noDict_4_0(
@@ -477,8 +477,8 @@ unsafe fn ZSTD_compressBlock_fast_noDict_4_0(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_fast_noDict_generic(ms, seqStore, rep, src, srcSize, 4, 0)
 }
 unsafe fn ZSTD_compressBlock_fast_noDict_5_0(
@@ -486,8 +486,8 @@ unsafe fn ZSTD_compressBlock_fast_noDict_5_0(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_fast_noDict_generic(ms, seqStore, rep, src, srcSize, 5, 0)
 }
 unsafe fn ZSTD_compressBlock_fast_noDict_6_0(
@@ -495,8 +495,8 @@ unsafe fn ZSTD_compressBlock_fast_noDict_6_0(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_fast_noDict_generic(ms, seqStore, rep, src, srcSize, 6, 0)
 }
 unsafe fn ZSTD_compressBlock_fast_noDict_7_0(
@@ -504,8 +504,8 @@ unsafe fn ZSTD_compressBlock_fast_noDict_7_0(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_fast_noDict_generic(ms, seqStore, rep, src, srcSize, 7, 0)
 }
 pub unsafe fn ZSTD_compressBlock_fast(
@@ -513,8 +513,8 @@ pub unsafe fn ZSTD_compressBlock_fast(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let mml = ms.cParams.minMatch;
     let useCmov = (ms.cParams.windowLog < 19) as core::ffi::c_int;
     if useCmov != 0 {
@@ -539,10 +539,10 @@ unsafe fn ZSTD_compressBlock_fast_dictMatchState_generic(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     mls: u32,
     hasStep: u32,
-) -> size_t {
+) -> usize {
     let cParams: *const ZSTD_compressionParameters = &mut ms.cParams;
     let hashTable = ms.hashTable;
     let hlog = (*cParams).hashLog;
@@ -584,29 +584,29 @@ unsafe fn ZSTD_compressBlock_fast_dictMatchState_generic(
     assert!(prefixStartIndex as usize >= dictEnd as usize - dictBase as usize);
 
     if ms.prefetchCDictTables != 0 {
-        let hashTableBytes = ((1 as core::ffi::c_int as size_t) << (*dictCParams).hashLog)
+        let hashTableBytes = ((1 as core::ffi::c_int as usize) << (*dictCParams).hashLog)
             .wrapping_mul(::core::mem::size_of::<u32>());
         let _ptr = dictHashTable as *const core::ffi::c_char;
         let _size = hashTableBytes;
-        let mut _pos: size_t = 0;
+        let mut _pos: usize = 0;
         _pos = 0;
         while _pos < _size {
-            _pos = _pos.wrapping_add(CACHELINE_SIZE as size_t);
+            _pos = _pos.wrapping_add(CACHELINE_SIZE as usize);
         }
     }
     ip0 = ip0.offset((dictAndPrefixLength == 0) as core::ffi::c_int as isize);
     's_135: while ip1 <= ilimit {
-        let mut mLength: size_t = 0;
+        let mut mLength: usize = 0;
         let mut hash0 = ZSTD_hashPtr(ip0 as *const core::ffi::c_void, hlog, mls);
         let dictHashAndTag0 = ZSTD_hashPtr(ip0 as *const core::ffi::c_void, dictHBits, mls);
         let mut dictMatchIndexAndTag =
             *dictHashTable.add(dictHashAndTag0 >> ZSTD_SHORT_CACHE_TAG_BITS);
         let mut dictTagsMatch =
-            ZSTD_comparePackedTags(dictMatchIndexAndTag as size_t, dictHashAndTag0);
+            ZSTD_comparePackedTags(dictMatchIndexAndTag as usize, dictHashAndTag0);
         let mut matchIndex = *hashTable.add(hash0);
         let mut curr = ip0.offset_from(base) as core::ffi::c_long as u32;
-        let mut step = stepSize as size_t;
-        let kStepIncr = ((1) << kSearchStrength) as size_t;
+        let mut step = stepSize as usize;
+        let kStepIncr = ((1) << kSearchStrength) as usize;
         let mut nextStep = ip0.add(kStepIncr);
         loop {
             let mut match_0 = base.offset(matchIndex as isize);
@@ -716,7 +716,7 @@ unsafe fn ZSTD_compressBlock_fast_dictMatchState_generic(
                     dictMatchIndexAndTag =
                         *dictHashTable.add(dictHashAndTag1 >> ZSTD_SHORT_CACHE_TAG_BITS);
                     dictTagsMatch =
-                        ZSTD_comparePackedTags(dictMatchIndexAndTag as size_t, dictHashAndTag1);
+                        ZSTD_comparePackedTags(dictMatchIndexAndTag as usize, dictHashAndTag1);
                     matchIndex = *hashTable.add(hash1);
                     if ip1 >= nextStep {
                         step = step.wrapping_add(1);
@@ -799,8 +799,8 @@ unsafe fn ZSTD_compressBlock_fast_dictMatchState_4_0(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_fast_dictMatchState_generic(ms, seqStore, rep, src, srcSize, 4, 0)
 }
 unsafe fn ZSTD_compressBlock_fast_dictMatchState_5_0(
@@ -808,8 +808,8 @@ unsafe fn ZSTD_compressBlock_fast_dictMatchState_5_0(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_fast_dictMatchState_generic(ms, seqStore, rep, src, srcSize, 5, 0)
 }
 unsafe fn ZSTD_compressBlock_fast_dictMatchState_6_0(
@@ -817,8 +817,8 @@ unsafe fn ZSTD_compressBlock_fast_dictMatchState_6_0(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_fast_dictMatchState_generic(ms, seqStore, rep, src, srcSize, 6, 0)
 }
 unsafe fn ZSTD_compressBlock_fast_dictMatchState_7_0(
@@ -826,8 +826,8 @@ unsafe fn ZSTD_compressBlock_fast_dictMatchState_7_0(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_fast_dictMatchState_generic(ms, seqStore, rep, src, srcSize, 7, 0)
 }
 pub unsafe fn ZSTD_compressBlock_fast_dictMatchState(
@@ -835,8 +835,8 @@ pub unsafe fn ZSTD_compressBlock_fast_dictMatchState(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let mls = ms.cParams.minMatch;
     match mls {
         5 => ZSTD_compressBlock_fast_dictMatchState_5_0(ms, seqStore, rep, src, srcSize),
@@ -850,17 +850,17 @@ unsafe fn ZSTD_compressBlock_fast_extDict_generic(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     mls: u32,
     hasStep: u32,
-) -> size_t {
+) -> usize {
     let mut current_block: u64;
     let cParams: *const ZSTD_compressionParameters = &mut ms.cParams;
     let hashTable = ms.hashTable;
     let hlog = (*cParams).hashLog;
     let stepSize = ((*cParams).targetLength)
         .wrapping_add(((*cParams).targetLength == 0) as core::ffi::c_int as core::ffi::c_uint)
-        .wrapping_add(1) as size_t;
+        .wrapping_add(1) as usize;
     let base = ms.window.base;
     let dictBase = ms.window.dictBase;
     let istart = src as *const u8;
@@ -888,17 +888,17 @@ unsafe fn ZSTD_compressBlock_fast_extDict_generic(
     let mut ip2 = core::ptr::null::<u8>();
     let mut ip3 = core::ptr::null::<u8>();
     let mut current0: u32 = 0;
-    let mut hash0: size_t = 0;
-    let mut hash1: size_t = 0;
+    let mut hash0: usize = 0;
+    let mut hash1: usize = 0;
     let mut idx: u32 = 0;
     let mut idxBase = core::ptr::null::<u8>();
     let mut offcode: u32 = 0;
     let mut match0 = core::ptr::null::<u8>();
-    let mut mLength: size_t = 0;
+    let mut mLength: usize = 0;
     let mut matchEnd = core::ptr::null::<u8>();
-    let mut step: size_t = 0;
+    let mut step: usize = 0;
     let mut nextStep = core::ptr::null::<u8>();
-    let kStepIncr = ((1) << (kSearchStrength - 1)) as size_t;
+    let kStepIncr = ((1) << (kSearchStrength - 1)) as usize;
 
     let _ = hasStep; /* not currently specialized on whether it's accelerated */
 
@@ -960,7 +960,7 @@ unsafe fn ZSTD_compressBlock_fast_extDict_generic(
                     iend
                 };
                 mLength = (*ip0.sub(1) as core::ffi::c_int == *match0.sub(1) as core::ffi::c_int)
-                    as core::ffi::c_int as size_t;
+                    as core::ffi::c_int as usize;
                 ip0 = ip0.offset(-(mLength as isize));
                 match0 = match0.offset(-(mLength as isize));
                 offcode = REPCODE1_TO_OFFBASE as u32;
@@ -1145,8 +1145,8 @@ unsafe fn ZSTD_compressBlock_fast_extDict_4_0(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_fast_extDict_generic(ms, seqStore, rep, src, srcSize, 4, 0)
 }
 unsafe fn ZSTD_compressBlock_fast_extDict_5_0(
@@ -1154,8 +1154,8 @@ unsafe fn ZSTD_compressBlock_fast_extDict_5_0(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_fast_extDict_generic(ms, seqStore, rep, src, srcSize, 5, 0)
 }
 unsafe fn ZSTD_compressBlock_fast_extDict_6_0(
@@ -1163,8 +1163,8 @@ unsafe fn ZSTD_compressBlock_fast_extDict_6_0(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_fast_extDict_generic(ms, seqStore, rep, src, srcSize, 6, 0)
 }
 unsafe fn ZSTD_compressBlock_fast_extDict_7_0(
@@ -1172,8 +1172,8 @@ unsafe fn ZSTD_compressBlock_fast_extDict_7_0(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_fast_extDict_generic(ms, seqStore, rep, src, srcSize, 7, 0)
 }
 pub unsafe fn ZSTD_compressBlock_fast_extDict(
@@ -1181,8 +1181,8 @@ pub unsafe fn ZSTD_compressBlock_fast_extDict(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let mls = ms.cParams.minMatch;
     match mls {
         5 => ZSTD_compressBlock_fast_extDict_5_0(ms, seqStore, rep, src, srcSize),

--- a/lib/compress/zstd_lazy.rs
+++ b/lib/compress/zstd_lazy.rs
@@ -55,7 +55,7 @@ pub const search_binaryTree: searchMethod_e = 1;
 pub const search_hashChain: searchMethod_e = 0;
 pub type ZSTD_VecMask = u64;
 
-use libc::size_t;
+
 
 use crate::lib::common::bits::ZSTD_highbit32;
 use crate::lib::common::fse::{FSE_CTable, FSE_repeat};
@@ -157,12 +157,12 @@ unsafe fn ZSTD_insertDUBT1(
             commonLengthLarger
         };
         if dictMode as core::ffi::c_uint != ZSTD_extDict as core::ffi::c_int as core::ffi::c_uint
-            || (matchIndex as size_t).wrapping_add(matchLength) >= dictLimit as size_t
+            || (matchIndex as usize).wrapping_add(matchLength) >= dictLimit as usize
             || curr < dictLimit
         {
             let mBase = if dictMode as core::ffi::c_uint
                 != ZSTD_extDict as core::ffi::c_int as core::ffi::c_uint
-                || (matchIndex as size_t).wrapping_add(matchLength) >= dictLimit as size_t
+                || (matchIndex as usize).wrapping_add(matchLength) >= dictLimit as usize
             {
                 base
             } else {
@@ -183,7 +183,7 @@ unsafe fn ZSTD_insertDUBT1(
                 dictEnd,
                 prefixStart,
             ));
-            if (matchIndex as size_t).wrapping_add(matchLength) >= dictLimit as size_t {
+            if (matchIndex as usize).wrapping_add(matchLength) >= dictLimit as usize {
                 match_0 = base.offset(matchIndex as isize);
             }
         }
@@ -223,12 +223,12 @@ unsafe fn ZSTD_DUBT_findBetterDictMatch(
     ms: *const ZSTD_MatchState_t,
     ip: *const u8,
     iend: *const u8,
-    offsetPtr: *mut size_t,
-    mut bestLength: size_t,
+    offsetPtr: *mut usize,
+    mut bestLength: usize,
     mut nbCompares: u32,
     mls: u32,
     dictMode: ZSTD_dictMode_e,
-) -> size_t {
+) -> usize {
     let dms = (*ms).dictMatchState;
     let dmsCParams: *const ZSTD_compressionParameters = &(*dms).cParams;
     let dictHashTable: *const u32 = (*dms).hashTable;
@@ -252,8 +252,8 @@ unsafe fn ZSTD_DUBT_findBetterDictMatch(
     } else {
         dictHighLimit.wrapping_sub(btMask)
     };
-    let mut commonLengthSmaller = 0 as size_t;
-    let mut commonLengthLarger = 0 as size_t;
+    let mut commonLengthSmaller = 0 as usize;
+    let mut commonLengthLarger = 0 as usize;
 
     assert_eq!(dictMode, ZSTD_dictMatchState);
 
@@ -272,7 +272,7 @@ unsafe fn ZSTD_DUBT_findBetterDictMatch(
             dictEnd,
             prefixStart,
         ));
-        if (dictMatchIndex as size_t).wrapping_add(matchLength) >= dictHighLimit as size_t {
+        if (dictMatchIndex as usize).wrapping_add(matchLength) >= dictHighLimit as usize {
             match_0 = base
                 .offset(dictMatchIndex as isize)
                 .offset(dictIndexDelta as isize);
@@ -287,7 +287,7 @@ unsafe fn ZSTD_DUBT_findBetterDictMatch(
                 bestLength = matchLength;
                 *offsetPtr = curr
                     .wrapping_sub(matchIndex)
-                    .wrapping_add(ZSTD_REP_NUM as u32) as size_t;
+                    .wrapping_add(ZSTD_REP_NUM as u32) as usize;
             }
             if ip.add(matchLength) == iend {
                 break;
@@ -317,10 +317,10 @@ unsafe fn ZSTD_DUBT_findBestMatch(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iend: *const u8,
-    offBasePtr: *mut size_t,
+    offBasePtr: *mut usize,
     mls: u32,
     dictMode: ZSTD_dictMode_e,
-) -> size_t {
+) -> usize {
     let cParams: *const ZSTD_compressionParameters = &mut ms.cParams;
     let hashTable = ms.hashTable;
     let hashLog = (*cParams).hashLog;
@@ -388,7 +388,7 @@ unsafe fn ZSTD_DUBT_findBestMatch(
         };
         let mut match_0 = core::ptr::null::<u8>();
         if dictMode as core::ffi::c_uint != ZSTD_extDict as core::ffi::c_int as core::ffi::c_uint
-            || (matchIndex as size_t).wrapping_add(matchLength) >= dictLimit as size_t
+            || (matchIndex as usize).wrapping_add(matchLength) >= dictLimit as usize
         {
             match_0 = base.offset(matchIndex as isize);
             matchLength = matchLength.wrapping_add(ZSTD_count(
@@ -405,12 +405,12 @@ unsafe fn ZSTD_DUBT_findBestMatch(
                 dictEnd,
                 prefixStart,
             ));
-            if (matchIndex as size_t).wrapping_add(matchLength) >= dictLimit as size_t {
+            if (matchIndex as usize).wrapping_add(matchLength) >= dictLimit as usize {
                 match_0 = base.offset(matchIndex as isize);
             }
         }
         if matchLength > bestLength {
-            if matchLength > matchEndIdx.wrapping_sub(matchIndex) as size_t {
+            if matchLength > matchEndIdx.wrapping_sub(matchIndex) as usize {
                 matchEndIdx = matchIndex.wrapping_add(matchLength as u32);
             }
             if 4 * matchLength.wrapping_sub(bestLength) as core::ffi::c_int
@@ -421,7 +421,7 @@ unsafe fn ZSTD_DUBT_findBestMatch(
                 bestLength = matchLength;
                 *offBasePtr = curr
                     .wrapping_sub(matchIndex)
-                    .wrapping_add(ZSTD_REP_NUM as u32) as size_t;
+                    .wrapping_add(ZSTD_REP_NUM as u32) as usize;
             }
             if ip.add(matchLength) == iend {
                 if dictMode as core::ffi::c_uint
@@ -475,10 +475,10 @@ unsafe fn ZSTD_BtFindBestMatch(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offBasePtr: *mut size_t,
+    offBasePtr: *mut usize,
     mls: u32,
     dictMode: ZSTD_dictMode_e,
-) -> size_t {
+) -> usize {
     if ip < (ms.window.base).offset(ms.nextToUpdate as isize) {
         return 0;
     }
@@ -612,8 +612,8 @@ pub unsafe fn ZSTD_dedicatedDictSearch_lazy_loadDictionary(
 }
 #[inline(always)]
 unsafe fn ZSTD_dedicatedDictSearch_lazy_search(
-    offsetPtr: *mut size_t,
-    mut ml: size_t,
+    offsetPtr: *mut usize,
+    mut ml: usize,
     nbAttempts: u32,
     dms: *const ZSTD_MatchState_t,
     ip: *const u8,
@@ -621,8 +621,8 @@ unsafe fn ZSTD_dedicatedDictSearch_lazy_search(
     prefixStart: *const u8,
     curr: u32,
     dictLimit: u32,
-    ddsIdx: size_t,
-) -> size_t {
+    ddsIdx: usize,
+) -> usize {
     let ddsLowestIndex = (*dms).window.dictLimit;
     let ddsBase = (*dms).window.base;
     let ddsEnd = (*dms).window.nextSrc;
@@ -648,7 +648,7 @@ unsafe fn ZSTD_dedicatedDictSearch_lazy_search(
 
     {
         let chainPackedPointer =
-            *((*dms).hashTable).add(ddsIdx.wrapping_add(bucketSize as size_t).wrapping_sub(1));
+            *((*dms).hashTable).add(ddsIdx.wrapping_add(bucketSize as usize).wrapping_sub(1));
         let chainIndex = chainPackedPointer >> 8;
 
         prefetch_read_data(
@@ -661,7 +661,7 @@ unsafe fn ZSTD_dedicatedDictSearch_lazy_search(
     while ddsAttempt < bucketLimit {
         let mut currentMl = 0;
         let mut match_0 = core::ptr::null::<u8>();
-        matchIndex = *((*dms).hashTable).add(ddsIdx.wrapping_add(ddsAttempt as size_t));
+        matchIndex = *((*dms).hashTable).add(ddsIdx.wrapping_add(ddsAttempt as usize));
         match_0 = ddsBase.offset(matchIndex as isize);
         if matchIndex == 0 {
             return ml;
@@ -682,7 +682,7 @@ unsafe fn ZSTD_dedicatedDictSearch_lazy_search(
             ml = currentMl;
             *offsetPtr = curr
                 .wrapping_sub(matchIndex.wrapping_add(ddsIndexDelta))
-                .wrapping_add(ZSTD_REP_NUM as u32) as size_t;
+                .wrapping_add(ZSTD_REP_NUM as u32) as usize;
             if ip.add(currentMl) == iLimit {
                 return ml;
             }
@@ -690,7 +690,7 @@ unsafe fn ZSTD_dedicatedDictSearch_lazy_search(
         ddsAttempt = ddsAttempt.wrapping_add(1);
     }
     let chainPackedPointer_0 =
-        *((*dms).hashTable).add(ddsIdx.wrapping_add(bucketSize as size_t).wrapping_sub(1));
+        *((*dms).hashTable).add(ddsIdx.wrapping_add(bucketSize as usize).wrapping_sub(1));
     let mut chainIndex_0 = chainPackedPointer_0 >> 8;
     let chainLength = chainPackedPointer_0 & 0xff as core::ffi::c_int as u32;
     let chainAttempts = nbAttempts.wrapping_sub(ddsAttempt);
@@ -721,7 +721,7 @@ unsafe fn ZSTD_dedicatedDictSearch_lazy_search(
             ml = currentMl_0;
             *offsetPtr = curr
                 .wrapping_sub(matchIndex.wrapping_add(ddsIndexDelta))
-                .wrapping_add(ZSTD_REP_NUM as u32) as size_t;
+                .wrapping_add(ZSTD_REP_NUM as u32) as usize;
             if ip.add(currentMl_0) == iLimit {
                 break;
             }
@@ -771,10 +771,10 @@ unsafe fn ZSTD_HcFindBestMatch(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
+    offsetPtr: *mut usize,
     mls: u32,
     dictMode: ZSTD_dictMode_e,
-) -> size_t {
+) -> usize {
     let cParams: *const ZSTD_compressionParameters = &mut ms.cParams;
     let chainTable = ms.chainTable;
     let chainSize = ((1) << (*cParams).chainLog) as u32;
@@ -804,7 +804,7 @@ unsafe fn ZSTD_HcFindBestMatch(
         0
     };
     let mut nbAttempts = (1 as core::ffi::c_uint) << (*cParams).searchLog;
-    let mut ml = (4 - 1) as size_t;
+    let mut ml = (4 - 1) as usize;
     let dms = ms.dictMatchState;
     let ddsHashLog = if dictMode as core::ffi::c_uint
         == ZSTD_dedicatedDictSearch as core::ffi::c_int as core::ffi::c_uint
@@ -854,7 +854,7 @@ unsafe fn ZSTD_HcFindBestMatch(
             ml = currentMl;
             *offsetPtr = curr
                 .wrapping_sub(matchIndex)
-                .wrapping_add(ZSTD_REP_NUM as u32) as size_t;
+                .wrapping_add(ZSTD_REP_NUM as u32) as usize;
             if ip.add(currentMl) == iLimit {
                 break;
             }
@@ -918,7 +918,7 @@ unsafe fn ZSTD_HcFindBestMatch(
                 ml = currentMl_0;
                 *offsetPtr = curr
                     .wrapping_sub(matchIndex.wrapping_add(dmsIndexDelta))
-                    .wrapping_add(ZSTD_REP_NUM as u32) as size_t;
+                    .wrapping_add(ZSTD_REP_NUM as u32) as usize;
                 if ip.add(currentMl_0) == iLimit {
                     break;
                 }
@@ -1241,11 +1241,11 @@ unsafe fn ZSTD_RowFindBestMatch(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
+    offsetPtr: *mut usize,
     mls: u32,
     dictMode: ZSTD_dictMode_e,
     rowLog: u32,
-) -> size_t {
+) -> usize {
     let hashTable = ms.hashTable;
     let tagTable = ms.tagTable;
     let hashCache = (ms.hashCache).as_mut_ptr();
@@ -1280,7 +1280,7 @@ unsafe fn ZSTD_RowFindBestMatch(
     let groupWidth = ZSTD_row_matchMaskGroupWidth(rowEntries);
     let hashSalt = ms.hashSalt;
     let mut nbAttempts = (1 as core::ffi::c_uint) << cappedSearchLog;
-    let mut ml = (4 - 1) as size_t;
+    let mut ml = (4 - 1) as usize;
     let mut hash: u32 = 0;
     let dms = ms.dictMatchState;
     let mut ddsIdx = 0;
@@ -1341,7 +1341,7 @@ unsafe fn ZSTD_RowFindBestMatch(
     let tagRow = tagTable.offset(relRow as isize);
     let headGrouped = (*tagRow as u32 & rowMask) * groupWidth;
     let mut matchBuffer: [u32; 64] = [0; 64];
-    let mut numMatches = 0 as size_t;
+    let mut numMatches = 0 as usize;
     let mut currMatch = 0;
     let mut matches = ZSTD_row_getMatchMask(tagRow, tag as u8, headGrouped, rowEntries);
     while matches > 0 && nbAttempts > 0 {
@@ -1397,7 +1397,7 @@ unsafe fn ZSTD_RowFindBestMatch(
             ml = currentMl;
             *offsetPtr = curr
                 .wrapping_sub(matchIndex_0)
-                .wrapping_add(ZSTD_REP_NUM as u32) as size_t;
+                .wrapping_add(ZSTD_REP_NUM as u32) as usize;
             if ip.add(currentMl) == iLimit {
                 break;
             }
@@ -1429,7 +1429,7 @@ unsafe fn ZSTD_RowFindBestMatch(
         let dmsIndexDelta = dictLimit.wrapping_sub(dmsSize);
         let headGrouped_0 = (*dmsTagRow as u32 & rowMask) * groupWidth;
         let mut matchBuffer_0: [u32; 64] = [0; 64];
-        let mut numMatches_0 = 0 as size_t;
+        let mut numMatches_0 = 0 as usize;
         let mut currMatch_0 = 0;
         let mut matches_0 =
             ZSTD_row_getMatchMask(dmsTagRow, dmsTag as u8, headGrouped_0, rowEntries);
@@ -1463,7 +1463,7 @@ unsafe fn ZSTD_RowFindBestMatch(
                 ml = currentMl_0;
                 *offsetPtr = curr
                     .wrapping_sub(matchIndex_2.wrapping_add(dmsIndexDelta))
-                    .wrapping_add(ZSTD_REP_NUM as u32) as size_t;
+                    .wrapping_add(ZSTD_REP_NUM as u32) as usize;
                 if ip.add(currentMl_0) == iLimit {
                     break;
                 }
@@ -1478,8 +1478,8 @@ unsafe fn ZSTD_RowFindBestMatch_dictMatchState_6_6(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 6, ZSTD_dictMatchState, 6)
 }
 #[inline(never)]
@@ -1487,8 +1487,8 @@ unsafe fn ZSTD_RowFindBestMatch_extDict_4_6(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 4, ZSTD_extDict, 6)
 }
 #[inline(never)]
@@ -1496,8 +1496,8 @@ unsafe fn ZSTD_RowFindBestMatch_dictMatchState_4_4(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 4, ZSTD_dictMatchState, 4)
 }
 #[inline(never)]
@@ -1505,8 +1505,8 @@ unsafe fn ZSTD_RowFindBestMatch_dedicatedDictSearch_6_6(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 6, ZSTD_dedicatedDictSearch, 6)
 }
 #[inline(never)]
@@ -1514,8 +1514,8 @@ unsafe fn ZSTD_RowFindBestMatch_extDict_6_6(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 6, ZSTD_extDict, 6)
 }
 #[inline(never)]
@@ -1523,8 +1523,8 @@ unsafe fn ZSTD_RowFindBestMatch_extDict_6_5(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 6, ZSTD_extDict, 5)
 }
 #[inline(never)]
@@ -1532,8 +1532,8 @@ unsafe fn ZSTD_RowFindBestMatch_extDict_6_4(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 6, ZSTD_extDict, 4)
 }
 #[inline(never)]
@@ -1541,8 +1541,8 @@ unsafe fn ZSTD_RowFindBestMatch_extDict_5_6(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 5, ZSTD_extDict, 6)
 }
 #[inline(never)]
@@ -1550,8 +1550,8 @@ unsafe fn ZSTD_RowFindBestMatch_extDict_5_5(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 5, ZSTD_extDict, 5)
 }
 #[inline(never)]
@@ -1559,8 +1559,8 @@ unsafe fn ZSTD_RowFindBestMatch_extDict_5_4(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 5, ZSTD_extDict, 4)
 }
 #[inline(never)]
@@ -1568,8 +1568,8 @@ unsafe fn ZSTD_RowFindBestMatch_dictMatchState_4_5(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 4, ZSTD_dictMatchState, 5)
 }
 #[inline(never)]
@@ -1577,8 +1577,8 @@ unsafe fn ZSTD_RowFindBestMatch_extDict_4_5(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 4, ZSTD_extDict, 5)
 }
 #[inline(never)]
@@ -1586,8 +1586,8 @@ unsafe fn ZSTD_RowFindBestMatch_extDict_4_4(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 4, ZSTD_extDict, 4)
 }
 #[inline(never)]
@@ -1595,8 +1595,8 @@ unsafe fn ZSTD_RowFindBestMatch_dedicatedDictSearch_6_5(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 6, ZSTD_dedicatedDictSearch, 5)
 }
 #[inline(never)]
@@ -1604,8 +1604,8 @@ unsafe fn ZSTD_RowFindBestMatch_dedicatedDictSearch_6_4(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 6, ZSTD_dedicatedDictSearch, 4)
 }
 #[inline(never)]
@@ -1613,8 +1613,8 @@ unsafe fn ZSTD_RowFindBestMatch_dedicatedDictSearch_5_6(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 5, ZSTD_dedicatedDictSearch, 6)
 }
 #[inline(never)]
@@ -1622,8 +1622,8 @@ unsafe fn ZSTD_RowFindBestMatch_dedicatedDictSearch_5_5(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 5, ZSTD_dedicatedDictSearch, 5)
 }
 #[inline(never)]
@@ -1631,8 +1631,8 @@ unsafe fn ZSTD_RowFindBestMatch_dedicatedDictSearch_5_4(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 5, ZSTD_dedicatedDictSearch, 4)
 }
 #[inline(never)]
@@ -1640,8 +1640,8 @@ unsafe fn ZSTD_RowFindBestMatch_dedicatedDictSearch_4_6(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 4, ZSTD_dedicatedDictSearch, 6)
 }
 #[inline(never)]
@@ -1649,8 +1649,8 @@ unsafe fn ZSTD_RowFindBestMatch_noDict_6_6(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 6, ZSTD_noDict, 6)
 }
 #[inline(never)]
@@ -1658,8 +1658,8 @@ unsafe fn ZSTD_RowFindBestMatch_dedicatedDictSearch_4_5(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 4, ZSTD_dedicatedDictSearch, 5)
 }
 #[inline(never)]
@@ -1667,8 +1667,8 @@ unsafe fn ZSTD_RowFindBestMatch_noDict_6_4(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 6, ZSTD_noDict, 4)
 }
 #[inline(never)]
@@ -1676,8 +1676,8 @@ unsafe fn ZSTD_RowFindBestMatch_noDict_5_6(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 5, ZSTD_noDict, 6)
 }
 #[inline(never)]
@@ -1685,8 +1685,8 @@ unsafe fn ZSTD_RowFindBestMatch_noDict_5_5(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 5, ZSTD_noDict, 5)
 }
 #[inline(never)]
@@ -1694,8 +1694,8 @@ unsafe fn ZSTD_RowFindBestMatch_noDict_5_4(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 5, ZSTD_noDict, 4)
 }
 #[inline(never)]
@@ -1703,8 +1703,8 @@ unsafe fn ZSTD_RowFindBestMatch_noDict_4_6(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 4, ZSTD_noDict, 6)
 }
 #[inline(never)]
@@ -1712,8 +1712,8 @@ unsafe fn ZSTD_RowFindBestMatch_noDict_4_5(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 4, ZSTD_noDict, 5)
 }
 #[inline(never)]
@@ -1721,8 +1721,8 @@ unsafe fn ZSTD_RowFindBestMatch_noDict_4_4(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 4, ZSTD_noDict, 4)
 }
 #[inline(never)]
@@ -1730,8 +1730,8 @@ unsafe fn ZSTD_RowFindBestMatch_dedicatedDictSearch_4_4(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 4, ZSTD_dedicatedDictSearch, 4)
 }
 #[inline(never)]
@@ -1739,8 +1739,8 @@ unsafe fn ZSTD_RowFindBestMatch_dictMatchState_4_6(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 4, ZSTD_dictMatchState, 6)
 }
 #[inline(never)]
@@ -1748,8 +1748,8 @@ unsafe fn ZSTD_RowFindBestMatch_dictMatchState_6_5(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 6, ZSTD_dictMatchState, 5)
 }
 #[inline(never)]
@@ -1757,8 +1757,8 @@ unsafe fn ZSTD_RowFindBestMatch_dictMatchState_6_4(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 6, ZSTD_dictMatchState, 4)
 }
 #[inline(never)]
@@ -1766,8 +1766,8 @@ unsafe fn ZSTD_RowFindBestMatch_dictMatchState_5_6(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 5, ZSTD_dictMatchState, 6)
 }
 #[inline(never)]
@@ -1775,8 +1775,8 @@ unsafe fn ZSTD_RowFindBestMatch_dictMatchState_5_5(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 5, ZSTD_dictMatchState, 5)
 }
 #[inline(never)]
@@ -1784,8 +1784,8 @@ unsafe fn ZSTD_RowFindBestMatch_dictMatchState_5_4(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 5, ZSTD_dictMatchState, 4)
 }
 #[inline(never)]
@@ -1793,8 +1793,8 @@ unsafe fn ZSTD_RowFindBestMatch_noDict_6_5(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_RowFindBestMatch(ms, ip, iLimit, offsetPtr, 6, ZSTD_noDict, 5)
 }
 #[inline(never)]
@@ -1802,8 +1802,8 @@ unsafe fn ZSTD_BtFindBestMatch_noDict_6(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offBasePtr: *mut size_t,
-) -> size_t {
+    offBasePtr: *mut usize,
+) -> usize {
     ZSTD_BtFindBestMatch(ms, ip, iLimit, offBasePtr, 6, ZSTD_noDict)
 }
 #[inline(never)]
@@ -1811,8 +1811,8 @@ unsafe fn ZSTD_BtFindBestMatch_dictMatchState_6(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offBasePtr: *mut size_t,
-) -> size_t {
+    offBasePtr: *mut usize,
+) -> usize {
     ZSTD_BtFindBestMatch(ms, ip, iLimit, offBasePtr, 6, ZSTD_dictMatchState)
 }
 #[inline(never)]
@@ -1820,8 +1820,8 @@ unsafe fn ZSTD_BtFindBestMatch_noDict_5(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offBasePtr: *mut size_t,
-) -> size_t {
+    offBasePtr: *mut usize,
+) -> usize {
     ZSTD_BtFindBestMatch(ms, ip, iLimit, offBasePtr, 5, ZSTD_noDict)
 }
 #[inline(never)]
@@ -1829,8 +1829,8 @@ unsafe fn ZSTD_BtFindBestMatch_dedicatedDictSearch_5(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offBasePtr: *mut size_t,
-) -> size_t {
+    offBasePtr: *mut usize,
+) -> usize {
     ZSTD_BtFindBestMatch(ms, ip, iLimit, offBasePtr, 5, ZSTD_dedicatedDictSearch)
 }
 #[inline(never)]
@@ -1838,8 +1838,8 @@ unsafe fn ZSTD_BtFindBestMatch_dedicatedDictSearch_6(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offBasePtr: *mut size_t,
-) -> size_t {
+    offBasePtr: *mut usize,
+) -> usize {
     ZSTD_BtFindBestMatch(ms, ip, iLimit, offBasePtr, 6, ZSTD_dedicatedDictSearch)
 }
 #[inline(never)]
@@ -1847,8 +1847,8 @@ unsafe fn ZSTD_BtFindBestMatch_dedicatedDictSearch_4(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offBasePtr: *mut size_t,
-) -> size_t {
+    offBasePtr: *mut usize,
+) -> usize {
     ZSTD_BtFindBestMatch(ms, ip, iLimit, offBasePtr, 4, ZSTD_dedicatedDictSearch)
 }
 #[inline(never)]
@@ -1856,8 +1856,8 @@ unsafe fn ZSTD_BtFindBestMatch_extDict_4(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offBasePtr: *mut size_t,
-) -> size_t {
+    offBasePtr: *mut usize,
+) -> usize {
     ZSTD_BtFindBestMatch(ms, ip, iLimit, offBasePtr, 4, ZSTD_extDict)
 }
 #[inline(never)]
@@ -1865,8 +1865,8 @@ unsafe fn ZSTD_BtFindBestMatch_dictMatchState_4(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offBasePtr: *mut size_t,
-) -> size_t {
+    offBasePtr: *mut usize,
+) -> usize {
     ZSTD_BtFindBestMatch(ms, ip, iLimit, offBasePtr, 4, ZSTD_dictMatchState)
 }
 #[inline(never)]
@@ -1874,8 +1874,8 @@ unsafe fn ZSTD_BtFindBestMatch_extDict_6(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offBasePtr: *mut size_t,
-) -> size_t {
+    offBasePtr: *mut usize,
+) -> usize {
     ZSTD_BtFindBestMatch(ms, ip, iLimit, offBasePtr, 6, ZSTD_extDict)
 }
 #[inline(never)]
@@ -1883,8 +1883,8 @@ unsafe fn ZSTD_BtFindBestMatch_noDict_4(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offBasePtr: *mut size_t,
-) -> size_t {
+    offBasePtr: *mut usize,
+) -> usize {
     ZSTD_BtFindBestMatch(ms, ip, iLimit, offBasePtr, 4, ZSTD_noDict)
 }
 #[inline(never)]
@@ -1892,8 +1892,8 @@ unsafe fn ZSTD_BtFindBestMatch_extDict_5(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offBasePtr: *mut size_t,
-) -> size_t {
+    offBasePtr: *mut usize,
+) -> usize {
     ZSTD_BtFindBestMatch(ms, ip, iLimit, offBasePtr, 5, ZSTD_extDict)
 }
 #[inline(never)]
@@ -1901,8 +1901,8 @@ unsafe fn ZSTD_BtFindBestMatch_dictMatchState_5(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offBasePtr: *mut size_t,
-) -> size_t {
+    offBasePtr: *mut usize,
+) -> usize {
     ZSTD_BtFindBestMatch(ms, ip, iLimit, offBasePtr, 5, ZSTD_dictMatchState)
 }
 #[inline(never)]
@@ -1910,8 +1910,8 @@ unsafe fn ZSTD_HcFindBestMatch_noDict_6(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_HcFindBestMatch(ms, ip, iLimit, offsetPtr, 6, ZSTD_noDict)
 }
 #[inline(never)]
@@ -1919,8 +1919,8 @@ unsafe fn ZSTD_HcFindBestMatch_dictMatchState_5(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_HcFindBestMatch(ms, ip, iLimit, offsetPtr, 5, ZSTD_dictMatchState)
 }
 #[inline(never)]
@@ -1928,8 +1928,8 @@ unsafe fn ZSTD_HcFindBestMatch_dedicatedDictSearch_6(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_HcFindBestMatch(ms, ip, iLimit, offsetPtr, 6, ZSTD_dedicatedDictSearch)
 }
 #[inline(never)]
@@ -1937,8 +1937,8 @@ unsafe fn ZSTD_HcFindBestMatch_dictMatchState_4(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_HcFindBestMatch(ms, ip, iLimit, offsetPtr, 4, ZSTD_dictMatchState)
 }
 #[inline(never)]
@@ -1946,8 +1946,8 @@ unsafe fn ZSTD_HcFindBestMatch_dedicatedDictSearch_5(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_HcFindBestMatch(ms, ip, iLimit, offsetPtr, 5, ZSTD_dedicatedDictSearch)
 }
 #[inline(never)]
@@ -1955,8 +1955,8 @@ unsafe fn ZSTD_HcFindBestMatch_dedicatedDictSearch_4(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_HcFindBestMatch(ms, ip, iLimit, offsetPtr, 4, ZSTD_dedicatedDictSearch)
 }
 #[inline(never)]
@@ -1964,8 +1964,8 @@ unsafe fn ZSTD_HcFindBestMatch_noDict_5(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_HcFindBestMatch(ms, ip, iLimit, offsetPtr, 5, ZSTD_noDict)
 }
 #[inline(never)]
@@ -1973,8 +1973,8 @@ unsafe fn ZSTD_HcFindBestMatch_dictMatchState_6(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_HcFindBestMatch(ms, ip, iLimit, offsetPtr, 6, ZSTD_dictMatchState)
 }
 #[inline(never)]
@@ -1982,8 +1982,8 @@ unsafe fn ZSTD_HcFindBestMatch_noDict_4(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_HcFindBestMatch(ms, ip, iLimit, offsetPtr, 4, ZSTD_noDict)
 }
 #[inline(never)]
@@ -1991,8 +1991,8 @@ unsafe fn ZSTD_HcFindBestMatch_extDict_6(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_HcFindBestMatch(ms, ip, iLimit, offsetPtr, 6, ZSTD_extDict)
 }
 #[inline(never)]
@@ -2000,8 +2000,8 @@ unsafe fn ZSTD_HcFindBestMatch_extDict_5(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_HcFindBestMatch(ms, ip, iLimit, offsetPtr, 5, ZSTD_extDict)
 }
 #[inline(never)]
@@ -2009,8 +2009,8 @@ unsafe fn ZSTD_HcFindBestMatch_extDict_4(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iLimit: *const u8,
-    offsetPtr: *mut size_t,
-) -> size_t {
+    offsetPtr: *mut usize,
+) -> usize {
     ZSTD_HcFindBestMatch(ms, ip, iLimit, offsetPtr, 4, ZSTD_extDict)
 }
 #[inline(always)]
@@ -2018,12 +2018,12 @@ unsafe fn ZSTD_searchMax(
     ms: &mut ZSTD_MatchState_t,
     ip: *const u8,
     iend: *const u8,
-    offsetPtr: *mut size_t,
+    offsetPtr: *mut usize,
     mls: u32,
     rowLog: u32,
     searchMethod: searchMethod_e,
     dictMode: ZSTD_dictMode_e,
-) -> size_t {
+) -> usize {
     if dictMode as core::ffi::c_uint == ZSTD_noDict as core::ffi::c_int as core::ffi::c_uint {
         match searchMethod as core::ffi::c_uint {
             0 => match mls {
@@ -2358,11 +2358,11 @@ unsafe fn ZSTD_compressBlock_lazy_generic(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     searchMethod: searchMethod_e,
     depth: u32,
     dictMode: ZSTD_dictMode_e,
-) -> size_t {
+) -> usize {
     let mut current_block: u64;
     let istart = src as *const u8;
     let mut ip = istart;
@@ -2475,7 +2475,7 @@ unsafe fn ZSTD_compressBlock_lazy_generic(
 
     while ip < ilimit {
         let mut matchLength = 0;
-        let mut offBase = REPCODE1_TO_OFFBASE as size_t;
+        let mut offBase = REPCODE1_TO_OFFBASE as usize;
         let mut start = ip.add(1);
         if isDxS != 0 {
             let repIndex = (ip.offset_from(base) as core::ffi::c_long as u32)
@@ -2565,7 +2565,7 @@ unsafe fn ZSTD_compressBlock_lazy_generic(
                         let step =
                             (ip.offset_from_unsigned(anchor) >> kSearchStrength).wrapping_add(1);
                         ip = ip.add(step);
-                        ms.lazySkipping = (step > kLazySkippingStep as size_t) as core::ffi::c_int;
+                        ms.lazySkipping = (step > kLazySkippingStep as usize) as core::ffi::c_int;
                         continue;
                     } else {
                         if depth >= 1 {
@@ -2589,12 +2589,12 @@ unsafe fn ZSTD_compressBlock_lazy_generic(
                                     .wrapping_add(4);
                                     let gain2 = (mlRep * 3) as core::ffi::c_int;
                                     let gain1 = (matchLength * 3)
-                                        .wrapping_sub(ZSTD_highbit32(offBase as u32) as size_t)
+                                        .wrapping_sub(ZSTD_highbit32(offBase as u32) as usize)
                                         .wrapping_add(1)
                                         as core::ffi::c_int;
                                     if mlRep >= 4 && gain2 > gain1 {
                                         matchLength = mlRep;
-                                        offBase = REPCODE1_TO_OFFBASE as size_t;
+                                        offBase = REPCODE1_TO_OFFBASE as usize;
                                         start = ip;
                                     }
                                 }
@@ -2628,12 +2628,12 @@ unsafe fn ZSTD_compressBlock_lazy_generic(
                                         .wrapping_add(4);
                                         let gain2_0 = (mlRep_0 * 3) as core::ffi::c_int;
                                         let gain1_0 = (matchLength * 3)
-                                            .wrapping_sub(ZSTD_highbit32(offBase as u32) as size_t)
+                                            .wrapping_sub(ZSTD_highbit32(offBase as u32) as usize)
                                             .wrapping_add(1)
                                             as core::ffi::c_int;
                                         if mlRep_0 >= 4 && gain2_0 > gain1_0 {
                                             matchLength = mlRep_0;
-                                            offBase = REPCODE1_TO_OFFBASE as size_t;
+                                            offBase = REPCODE1_TO_OFFBASE as usize;
                                             start = ip;
                                         }
                                     }
@@ -2650,10 +2650,10 @@ unsafe fn ZSTD_compressBlock_lazy_generic(
                                     dictMode,
                                 );
                                 let gain2_1 = (ml2_0 * 4)
-                                    .wrapping_sub(ZSTD_highbit32(ofbCandidate as u32) as size_t)
+                                    .wrapping_sub(ZSTD_highbit32(ofbCandidate as u32) as usize)
                                     as core::ffi::c_int;
                                 let gain1_1 = (matchLength * 4)
-                                    .wrapping_sub(ZSTD_highbit32(offBase as u32) as size_t)
+                                    .wrapping_sub(ZSTD_highbit32(offBase as u32) as usize)
                                     .wrapping_add(4)
                                     as core::ffi::c_int;
                                 if ml2_0 >= 4 && gain2_1 > gain1_1 {
@@ -2683,12 +2683,12 @@ unsafe fn ZSTD_compressBlock_lazy_generic(
                                         .wrapping_add(4);
                                         let gain2_2 = (mlRep_1 * 4) as core::ffi::c_int;
                                         let gain1_2 = (matchLength * 4)
-                                            .wrapping_sub(ZSTD_highbit32(offBase as u32) as size_t)
+                                            .wrapping_sub(ZSTD_highbit32(offBase as u32) as usize)
                                             .wrapping_add(1)
                                             as core::ffi::c_int;
                                         if mlRep_1 >= 4 && gain2_2 > gain1_2 {
                                             matchLength = mlRep_1;
-                                            offBase = REPCODE1_TO_OFFBASE as size_t;
+                                            offBase = REPCODE1_TO_OFFBASE as usize;
                                             start = ip;
                                         }
                                     }
@@ -2724,13 +2724,13 @@ unsafe fn ZSTD_compressBlock_lazy_generic(
                                             let gain2_3 = (mlRep_2 * 4) as core::ffi::c_int;
                                             let gain1_3 = (matchLength * 4)
                                                 .wrapping_sub(
-                                                    ZSTD_highbit32(offBase as u32) as size_t
+                                                    ZSTD_highbit32(offBase as u32) as usize
                                                 )
                                                 .wrapping_add(1)
                                                 as core::ffi::c_int;
                                             if mlRep_2 >= 4 && gain2_3 > gain1_3 {
                                                 matchLength = mlRep_2;
-                                                offBase = REPCODE1_TO_OFFBASE as size_t;
+                                                offBase = REPCODE1_TO_OFFBASE as usize;
                                                 start = ip;
                                             }
                                         }
@@ -2748,11 +2748,11 @@ unsafe fn ZSTD_compressBlock_lazy_generic(
                                     );
                                     let gain2_4 = (ml2_1 * 4)
                                         .wrapping_sub(
-                                            ZSTD_highbit32(ofbCandidate_0 as u32) as size_t
+                                            ZSTD_highbit32(ofbCandidate_0 as u32) as usize
                                         )
                                         as core::ffi::c_int;
                                     let gain1_4 = (matchLength * 4)
-                                        .wrapping_sub(ZSTD_highbit32(offBase as u32) as size_t)
+                                        .wrapping_sub(ZSTD_highbit32(offBase as u32) as usize)
                                         .wrapping_add(7)
                                         as core::ffi::c_int;
                                     if !(ml2_1 >= 4 && gain2_4 > gain1_4) {
@@ -2764,20 +2764,20 @@ unsafe fn ZSTD_compressBlock_lazy_generic(
                                 }
                             }
                         }
-                        if offBase > ZSTD_REP_NUM as size_t {
+                        if offBase > ZSTD_REP_NUM as usize {
                             if dictMode as core::ffi::c_uint
                                 == ZSTD_noDict as core::ffi::c_int as core::ffi::c_uint
                             {
                                 while (start > anchor) as core::ffi::c_int
                                     & (start.offset(
-                                        -(offBase.wrapping_sub(ZSTD_REP_NUM as size_t) as isize),
+                                        -(offBase.wrapping_sub(ZSTD_REP_NUM as usize) as isize),
                                     ) > prefixLowest)
                                         as core::ffi::c_int
                                     != 0
                                     && *start.sub(1) as core::ffi::c_int
                                         == *start
                                             .offset(
-                                                -(offBase.wrapping_sub(ZSTD_REP_NUM as size_t)
+                                                -(offBase.wrapping_sub(ZSTD_REP_NUM as usize)
                                                     as isize),
                                             )
                                             .sub(1)
@@ -2789,8 +2789,8 @@ unsafe fn ZSTD_compressBlock_lazy_generic(
                             }
                             if isDxS != 0 {
                                 let matchIndex = (start.offset_from(base) as core::ffi::c_long
-                                    as size_t)
-                                    .wrapping_sub(offBase.wrapping_sub(ZSTD_REP_NUM as size_t))
+                                    as usize)
+                                    .wrapping_sub(offBase.wrapping_sub(ZSTD_REP_NUM as usize))
                                     as u32;
                                 let mut match_0 = if matchIndex < prefixLowestIndex {
                                     dictBase
@@ -2815,7 +2815,7 @@ unsafe fn ZSTD_compressBlock_lazy_generic(
                                 }
                             }
                             offset_2 = offset_1;
-                            offset_1 = offBase.wrapping_sub(ZSTD_REP_NUM as size_t) as u32;
+                            offset_1 = offBase.wrapping_sub(ZSTD_REP_NUM as usize) as u32;
                         }
                     }
                 }
@@ -2870,7 +2870,7 @@ unsafe fn ZSTD_compressBlock_lazy_generic(
                     prefixLowest,
                 ))
                 .wrapping_add(4);
-                offBase = offset_2 as size_t;
+                offBase = offset_2 as usize;
                 offset_2 = offset_1;
                 offset_1 = offBase as u32;
                 ZSTD_storeSeq(
@@ -2892,7 +2892,7 @@ unsafe fn ZSTD_compressBlock_lazy_generic(
             {
                 matchLength = (ZSTD_count(ip.add(4), ip.add(4).offset(-(offset_2 as isize)), iend))
                     .wrapping_add(4);
-                offBase = offset_2 as size_t;
+                offBase = offset_2 as usize;
                 offset_2 = offset_1;
                 offset_1 = offBase as u32;
                 ZSTD_storeSeq(
@@ -2930,8 +2930,8 @@ pub unsafe fn ZSTD_compressBlock_greedy(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_generic(
         ms,
         seqStore,
@@ -2948,8 +2948,8 @@ pub unsafe fn ZSTD_compressBlock_greedy_dictMatchState(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_generic(
         ms,
         seqStore,
@@ -2966,8 +2966,8 @@ pub unsafe fn ZSTD_compressBlock_greedy_dedicatedDictSearch(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_generic(
         ms,
         seqStore,
@@ -2984,8 +2984,8 @@ pub unsafe fn ZSTD_compressBlock_greedy_row(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_generic(
         ms,
         seqStore,
@@ -3002,8 +3002,8 @@ pub unsafe fn ZSTD_compressBlock_greedy_dictMatchState_row(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_generic(
         ms,
         seqStore,
@@ -3020,8 +3020,8 @@ pub unsafe fn ZSTD_compressBlock_greedy_dedicatedDictSearch_row(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_generic(
         ms,
         seqStore,
@@ -3038,8 +3038,8 @@ pub unsafe fn ZSTD_compressBlock_lazy(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_generic(
         ms,
         seqStore,
@@ -3056,8 +3056,8 @@ pub unsafe fn ZSTD_compressBlock_lazy_dictMatchState(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_generic(
         ms,
         seqStore,
@@ -3074,8 +3074,8 @@ pub unsafe fn ZSTD_compressBlock_lazy_dedicatedDictSearch(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_generic(
         ms,
         seqStore,
@@ -3092,8 +3092,8 @@ pub unsafe fn ZSTD_compressBlock_lazy_row(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_generic(
         ms,
         seqStore,
@@ -3110,8 +3110,8 @@ pub unsafe fn ZSTD_compressBlock_lazy_dictMatchState_row(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_generic(
         ms,
         seqStore,
@@ -3128,8 +3128,8 @@ pub unsafe fn ZSTD_compressBlock_lazy_dedicatedDictSearch_row(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_generic(
         ms,
         seqStore,
@@ -3146,8 +3146,8 @@ pub unsafe fn ZSTD_compressBlock_lazy2(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_generic(
         ms,
         seqStore,
@@ -3164,8 +3164,8 @@ pub unsafe fn ZSTD_compressBlock_lazy2_dictMatchState(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_generic(
         ms,
         seqStore,
@@ -3182,8 +3182,8 @@ pub unsafe fn ZSTD_compressBlock_lazy2_dedicatedDictSearch(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_generic(
         ms,
         seqStore,
@@ -3200,8 +3200,8 @@ pub unsafe fn ZSTD_compressBlock_lazy2_row(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_generic(
         ms,
         seqStore,
@@ -3218,8 +3218,8 @@ pub unsafe fn ZSTD_compressBlock_lazy2_dictMatchState_row(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_generic(
         ms,
         seqStore,
@@ -3236,8 +3236,8 @@ pub unsafe fn ZSTD_compressBlock_lazy2_dedicatedDictSearch_row(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_generic(
         ms,
         seqStore,
@@ -3254,8 +3254,8 @@ pub unsafe fn ZSTD_compressBlock_btlazy2(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_generic(
         ms,
         seqStore,
@@ -3272,8 +3272,8 @@ pub unsafe fn ZSTD_compressBlock_btlazy2_dictMatchState(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_generic(
         ms,
         seqStore,
@@ -3291,10 +3291,10 @@ unsafe fn ZSTD_compressBlock_lazy_extDict_generic(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     searchMethod: searchMethod_e,
     depth: u32,
-) -> size_t {
+) -> usize {
     let istart = src as *const u8;
     let mut ip = istart;
     let mut anchor = istart;
@@ -3352,7 +3352,7 @@ unsafe fn ZSTD_compressBlock_lazy_extDict_generic(
     let mut current_block_61: u64;
     while ip < ilimit {
         let mut matchLength = 0;
-        let mut offBase = REPCODE1_TO_OFFBASE as size_t;
+        let mut offBase = REPCODE1_TO_OFFBASE as usize;
         let mut start = ip.add(1);
         let mut curr = ip.offset_from(base) as core::ffi::c_long as u32;
         let windowLow = ZSTD_getLowestMatchIndex(ms, curr.wrapping_add(1), windowLog);
@@ -3406,7 +3406,7 @@ unsafe fn ZSTD_compressBlock_lazy_extDict_generic(
             if matchLength < 4 {
                 let step = ip.offset_from_unsigned(anchor) >> kSearchStrength;
                 ip = ip.add(step.wrapping_add(1));
-                ms.lazySkipping = (step > kLazySkippingStep as size_t) as core::ffi::c_int;
+                ms.lazySkipping = (step > kLazySkippingStep as usize) as core::ffi::c_int;
                 continue;
             } else {
                 if depth >= 1 {
@@ -3443,12 +3443,12 @@ unsafe fn ZSTD_compressBlock_lazy_extDict_generic(
                                 .wrapping_add(4);
                                 let gain2 = (repLength * 3) as core::ffi::c_int;
                                 let gain1 = (matchLength * 3)
-                                    .wrapping_sub(ZSTD_highbit32(offBase as u32) as size_t)
+                                    .wrapping_sub(ZSTD_highbit32(offBase as u32) as usize)
                                     .wrapping_add(1)
                                     as core::ffi::c_int;
                                 if repLength >= 4 && gain2 > gain1 {
                                     matchLength = repLength;
-                                    offBase = REPCODE1_TO_OFFBASE as size_t;
+                                    offBase = REPCODE1_TO_OFFBASE as usize;
                                     start = ip;
                                 }
                             }
@@ -3465,10 +3465,10 @@ unsafe fn ZSTD_compressBlock_lazy_extDict_generic(
                             ZSTD_extDict,
                         );
                         let gain2_0 = (ml2_0 * 4)
-                            .wrapping_sub(ZSTD_highbit32(ofbCandidate_0 as u32) as size_t)
+                            .wrapping_sub(ZSTD_highbit32(ofbCandidate_0 as u32) as usize)
                             as core::ffi::c_int;
                         let gain1_0 = (matchLength * 4)
-                            .wrapping_sub(ZSTD_highbit32(offBase as u32) as size_t)
+                            .wrapping_sub(ZSTD_highbit32(offBase as u32) as usize)
                             .wrapping_add(4)
                             as core::ffi::c_int;
                         if ml2_0 >= 4 && gain2_0 > gain1_0 {
@@ -3512,12 +3512,12 @@ unsafe fn ZSTD_compressBlock_lazy_extDict_generic(
                                     .wrapping_add(4);
                                     let gain2_1 = (repLength_0 * 4) as core::ffi::c_int;
                                     let gain1_1 = (matchLength * 4)
-                                        .wrapping_sub(ZSTD_highbit32(offBase as u32) as size_t)
+                                        .wrapping_sub(ZSTD_highbit32(offBase as u32) as usize)
                                         .wrapping_add(1)
                                         as core::ffi::c_int;
                                     if repLength_0 >= 4 && gain2_1 > gain1_1 {
                                         matchLength = repLength_0;
-                                        offBase = REPCODE1_TO_OFFBASE as size_t;
+                                        offBase = REPCODE1_TO_OFFBASE as usize;
                                         start = ip;
                                     }
                                 }
@@ -3534,10 +3534,10 @@ unsafe fn ZSTD_compressBlock_lazy_extDict_generic(
                                 ZSTD_extDict,
                             );
                             let gain2_2 = (ml2_1 * 4)
-                                .wrapping_sub(ZSTD_highbit32(ofbCandidate_1 as u32) as size_t)
+                                .wrapping_sub(ZSTD_highbit32(ofbCandidate_1 as u32) as usize)
                                 as core::ffi::c_int;
                             let gain1_2 = (matchLength * 4)
-                                .wrapping_sub(ZSTD_highbit32(offBase as u32) as size_t)
+                                .wrapping_sub(ZSTD_highbit32(offBase as u32) as usize)
                                 .wrapping_add(7)
                                 as core::ffi::c_int;
                             if !(ml2_1 >= 4 && gain2_2 > gain1_2) {
@@ -3549,9 +3549,9 @@ unsafe fn ZSTD_compressBlock_lazy_extDict_generic(
                         }
                     }
                 }
-                if offBase > ZSTD_REP_NUM as size_t {
+                if offBase > ZSTD_REP_NUM as usize {
                     let matchIndex = (start.offset_from_unsigned(base))
-                        .wrapping_sub(offBase.wrapping_sub(ZSTD_REP_NUM as size_t))
+                        .wrapping_sub(offBase.wrapping_sub(ZSTD_REP_NUM as usize))
                         as u32;
                     let mut match_0 = if matchIndex < dictLimit {
                         dictBase.offset(matchIndex as isize)
@@ -3572,7 +3572,7 @@ unsafe fn ZSTD_compressBlock_lazy_extDict_generic(
                         matchLength = matchLength.wrapping_add(1);
                     }
                     offset_2 = offset_1;
-                    offset_1 = offBase.wrapping_sub(ZSTD_REP_NUM as size_t) as u32;
+                    offset_1 = offBase.wrapping_sub(ZSTD_REP_NUM as usize) as u32;
                 }
             }
         }
@@ -3624,7 +3624,7 @@ unsafe fn ZSTD_compressBlock_lazy_extDict_generic(
             matchLength =
                 (ZSTD_count_2segments(ip.add(4), repMatch_2.add(4), iend, repEnd_2, prefixStart))
                     .wrapping_add(4);
-            offBase = offset_2 as size_t;
+            offBase = offset_2 as usize;
             offset_2 = offset_1;
             offset_1 = offBase as u32;
             ZSTD_storeSeq(
@@ -3648,8 +3648,8 @@ pub unsafe fn ZSTD_compressBlock_greedy_extDict(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_extDict_generic(ms, seqStore, rep, src, srcSize, search_hashChain, 0)
 }
 pub unsafe fn ZSTD_compressBlock_greedy_extDict_row(
@@ -3657,8 +3657,8 @@ pub unsafe fn ZSTD_compressBlock_greedy_extDict_row(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_extDict_generic(ms, seqStore, rep, src, srcSize, search_rowHash, 0)
 }
 pub unsafe fn ZSTD_compressBlock_lazy_extDict(
@@ -3666,8 +3666,8 @@ pub unsafe fn ZSTD_compressBlock_lazy_extDict(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_extDict_generic(ms, seqStore, rep, src, srcSize, search_hashChain, 1)
 }
 pub unsafe fn ZSTD_compressBlock_lazy_extDict_row(
@@ -3675,8 +3675,8 @@ pub unsafe fn ZSTD_compressBlock_lazy_extDict_row(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_extDict_generic(ms, seqStore, rep, src, srcSize, search_rowHash, 1)
 }
 pub unsafe fn ZSTD_compressBlock_lazy2_extDict(
@@ -3684,8 +3684,8 @@ pub unsafe fn ZSTD_compressBlock_lazy2_extDict(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_extDict_generic(ms, seqStore, rep, src, srcSize, search_hashChain, 2)
 }
 pub unsafe fn ZSTD_compressBlock_lazy2_extDict_row(
@@ -3693,8 +3693,8 @@ pub unsafe fn ZSTD_compressBlock_lazy2_extDict_row(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_extDict_generic(ms, seqStore, rep, src, srcSize, search_rowHash, 2)
 }
 pub unsafe fn ZSTD_compressBlock_btlazy2_extDict(
@@ -3702,7 +3702,7 @@ pub unsafe fn ZSTD_compressBlock_btlazy2_extDict(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_lazy_extDict_generic(ms, seqStore, rep, src, srcSize, search_binaryTree, 2)
 }

--- a/lib/compress/zstd_ldm.rs
+++ b/lib/compress/zstd_ldm.rs
@@ -49,7 +49,7 @@ pub struct ldmState_t {
     pub hashTable: *mut ldmEntry_t,
     pub loadedDictEnd: u32,
     pub bucketOffsets: *mut u8,
-    pub splitIndices: [size_t; 64],
+    pub splitIndices: [usize; 64],
     pub matchCandidates: [ldmMatchCandidate_t; 64],
 }
 #[derive(Copy, Clone)]
@@ -93,8 +93,8 @@ pub type ZSTD_BlockCompressor_f = Option<
         &mut SeqStore_t,
         *mut u32,
         *const core::ffi::c_void,
-        size_t,
-    ) -> size_t,
+        usize,
+    ) -> usize,
 >;
 #[repr(C)]
 pub struct ldmRollingHashState_t {
@@ -102,7 +102,7 @@ pub struct ldmRollingHashState_t {
     pub stopMask: u64,
 }
 
-use libc::size_t;
+
 
 use crate::lib::common::error_private::{ERR_isError, Error};
 use crate::lib::common::fse::{FSE_CTable, FSE_repeat};
@@ -221,7 +221,7 @@ unsafe fn ZSTD_window_enforceMaxDist(
     }
 }
 #[inline]
-unsafe fn ZSTD_cwksp_alloc_size(size: size_t) -> size_t {
+unsafe fn ZSTD_cwksp_alloc_size(size: usize) -> usize {
     if size == 0 {
         return 0;
     }
@@ -505,10 +505,10 @@ unsafe fn ZSTD_ldm_gear_init(state: *mut ldmRollingHashState_t, params: *const l
 unsafe fn ZSTD_ldm_gear_reset(
     state: *mut ldmRollingHashState_t,
     data: *const u8,
-    minMatchLength: size_t,
+    minMatchLength: usize,
 ) {
     let mut hash = (*state).rolling;
-    let mut n = 0 as size_t;
+    let mut n = 0 as usize;
     while n.wrapping_add(3) < minMatchLength {
         hash = (hash << 1).wrapping_add(
             *ZSTD_ldm_gearTab
@@ -547,12 +547,12 @@ unsafe fn ZSTD_ldm_gear_reset(
 unsafe fn ZSTD_ldm_gear_feed(
     state: *mut ldmRollingHashState_t,
     data: *const u8,
-    size: size_t,
-    splits: *mut size_t,
+    size: usize,
+    splits: *mut usize,
     numSplits: *mut core::ffi::c_uint,
-) -> size_t {
+) -> usize {
     let mut current_block: u64;
-    let mut n: size_t = 0;
+    let mut n: usize = 0;
     let mut hash: u64 = 0;
     let mut mask: u64 = 0;
     hash = (*state).rolling;
@@ -670,13 +670,13 @@ pub unsafe fn ZSTD_ldm_adjustParameters(
     if (*params).hashLog == 0 {
         (*params).hashLog = if 6
             > (if ((*params).windowLog).wrapping_sub((*params).hashRateLog)
-                < (if (if ::core::mem::size_of::<size_t>() as core::ffi::c_ulong == 4 {
+                < (if (if ::core::mem::size_of::<usize>() as core::ffi::c_ulong == 4 {
                     30
                 } else {
                     31
                 }) < 30
                 {
-                    if ::core::mem::size_of::<size_t>() as core::ffi::c_ulong == 4 {
+                    if ::core::mem::size_of::<usize>() as core::ffi::c_ulong == 4 {
                         30
                     } else {
                         31
@@ -687,13 +687,13 @@ pub unsafe fn ZSTD_ldm_adjustParameters(
             {
                 ((*params).windowLog).wrapping_sub((*params).hashRateLog)
             } else {
-                (if (if ::core::mem::size_of::<size_t>() as core::ffi::c_ulong == 4 {
+                (if (if ::core::mem::size_of::<usize>() as core::ffi::c_ulong == 4 {
                     30
                 } else {
                     31
                 }) < 30
                 {
-                    if ::core::mem::size_of::<size_t>() as core::ffi::c_ulong == 4 {
+                    if ::core::mem::size_of::<usize>() as core::ffi::c_ulong == 4 {
                         30
                     } else {
                         31
@@ -704,13 +704,13 @@ pub unsafe fn ZSTD_ldm_adjustParameters(
             }) {
             6
         } else if ((*params).windowLog).wrapping_sub((*params).hashRateLog)
-            < (if (if ::core::mem::size_of::<size_t>() as core::ffi::c_ulong == 4 {
+            < (if (if ::core::mem::size_of::<usize>() as core::ffi::c_ulong == 4 {
                 30
             } else {
                 31
             }) < 30
             {
-                if ::core::mem::size_of::<size_t>() as core::ffi::c_ulong == 4 {
+                if ::core::mem::size_of::<usize>() as core::ffi::c_ulong == 4 {
                     30
                 } else {
                     31
@@ -721,13 +721,13 @@ pub unsafe fn ZSTD_ldm_adjustParameters(
         {
             ((*params).windowLog).wrapping_sub((*params).hashRateLog)
         } else {
-            (if (if ::core::mem::size_of::<size_t>() as core::ffi::c_ulong == 4 {
+            (if (if ::core::mem::size_of::<usize>() as core::ffi::c_ulong == 4 {
                 30
             } else {
                 31
             }) < 30
             {
-                if ::core::mem::size_of::<size_t>() as core::ffi::c_ulong == 4 {
+                if ::core::mem::size_of::<usize>() as core::ffi::c_ulong == 4 {
                     30
                 } else {
                     31
@@ -765,14 +765,14 @@ pub unsafe fn ZSTD_ldm_adjustParameters(
         (*params).hashLog
     };
 }
-pub unsafe fn ZSTD_ldm_getTableSize(params: ldmParams_t) -> size_t {
-    let ldmHSize = (1 as size_t) << params.hashLog;
+pub unsafe fn ZSTD_ldm_getTableSize(params: ldmParams_t) -> usize {
+    let ldmHSize = (1 as usize) << params.hashLog;
     let ldmBucketSizeLog = (if params.bucketSizeLog < params.hashLog {
         params.bucketSizeLog
     } else {
         params.hashLog
-    }) as size_t;
-    let ldmBucketSize = (1) << (params.hashLog as size_t).wrapping_sub(ldmBucketSizeLog);
+    }) as usize;
+    let ldmBucketSize = (1) << (params.hashLog as usize).wrapping_sub(ldmBucketSizeLog);
     let totalSize = (ZSTD_cwksp_alloc_size(ldmBucketSize)).wrapping_add(ZSTD_cwksp_alloc_size(
         ldmHSize.wrapping_mul(::core::mem::size_of::<ldmEntry_t>()),
     ));
@@ -782,23 +782,23 @@ pub unsafe fn ZSTD_ldm_getTableSize(params: ldmParams_t) -> size_t {
         0
     }
 }
-pub unsafe fn ZSTD_ldm_getMaxNbSeq(params: ldmParams_t, maxChunkSize: size_t) -> size_t {
+pub unsafe fn ZSTD_ldm_getMaxNbSeq(params: ldmParams_t, maxChunkSize: usize) -> usize {
     if params.enableLdm == ZSTD_ParamSwitch_e::ZSTD_ps_enable {
-        maxChunkSize / params.minMatchLength as size_t
+        maxChunkSize / params.minMatchLength as usize
     } else {
         0
     }
 }
 unsafe fn ZSTD_ldm_getBucket(
     ldmState: *const ldmState_t,
-    hash: size_t,
+    hash: usize,
     bucketSizeLog: u32,
 ) -> *mut ldmEntry_t {
     ((*ldmState).hashTable).add(hash << bucketSizeLog)
 }
 unsafe fn ZSTD_ldm_insertEntry(
     ldmState: *mut ldmState_t,
-    hash: size_t,
+    hash: usize,
     entry: ldmEntry_t,
     bucketSizeLog: u32,
 ) {
@@ -813,8 +813,8 @@ unsafe fn ZSTD_ldm_countBackwardsMatch(
     pAnchor: *const u8,
     mut pMatch: *const u8,
     pMatchBase: *const u8,
-) -> size_t {
-    let mut matchLength = 0 as size_t;
+) -> usize {
+    let mut matchLength = 0 as usize;
     while pIn > pAnchor
         && pMatch > pMatchBase
         && *pIn.sub(1) as core::ffi::c_int == *pMatch.sub(1) as core::ffi::c_int
@@ -832,7 +832,7 @@ unsafe fn ZSTD_ldm_countBackwardsMatch_2segments(
     pMatchBase: *const u8,
     pExtDictStart: *const u8,
     pExtDictEnd: *const u8,
-) -> size_t {
+) -> usize {
     let mut matchLength = ZSTD_ldm_countBackwardsMatch(pIn, pAnchor, pMatch, pMatchBase);
     if pMatch.offset(-(matchLength as isize)) != pMatchBase || pMatchBase == pExtDictStart {
         return matchLength;
@@ -848,7 +848,7 @@ unsafe fn ZSTD_ldm_countBackwardsMatch_2segments(
 unsafe fn ZSTD_ldm_fillFastTables(
     ms: &mut ZSTD_MatchState_t,
     end: *const core::ffi::c_void,
-) -> size_t {
+) -> usize {
     let iend = end as *const u8;
     match ms.cParams.strategy as core::ffi::c_uint {
         1 => {
@@ -890,7 +890,7 @@ pub unsafe fn ZSTD_ldm_fillHashTable(
     let mut numSplits: core::ffi::c_uint = 0;
     ZSTD_ldm_gear_init(&mut hashState, params);
     while ip < iend {
-        let mut hashed: size_t = 0;
+        let mut hashed: usize = 0;
         let mut n: core::ffi::c_uint = 0;
         numSplits = 0;
         hashed = ZSTD_ldm_gear_feed(
@@ -918,7 +918,7 @@ pub unsafe fn ZSTD_ldm_fillHashTable(
                 };
                 entry.offset = split.offset_from(base) as core::ffi::c_long as u32;
                 entry.checksum = (xxhash >> 32) as u32;
-                ZSTD_ldm_insertEntry(ldmState, hash as size_t, entry, (*params).bucketSizeLog);
+                ZSTD_ldm_insertEntry(ldmState, hash as usize, entry, (*params).bucketSizeLog);
             }
             n = n.wrapping_add(1);
         }
@@ -942,8 +942,8 @@ unsafe fn ZSTD_ldm_generateSequences_internal(
     rawSeqStore: *mut RawSeqStore_t,
     params: *const ldmParams_t,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let extDict = ZSTD_window_hasExtDict((*ldmState).window) as core::ffi::c_int;
     let minMatchLength = (*params).minMatchLength;
     let entsPerBucket = (1) << (*params).bucketSizeLog;
@@ -983,14 +983,14 @@ unsafe fn ZSTD_ldm_generateSequences_internal(
     let splits = ((*ldmState).splitIndices).as_mut_ptr();
     let candidates = ((*ldmState).matchCandidates).as_mut_ptr();
     let mut numSplits: core::ffi::c_uint = 0;
-    if srcSize < minMatchLength as size_t {
+    if srcSize < minMatchLength as usize {
         return iend.offset_from_unsigned(anchor);
     }
     ZSTD_ldm_gear_init(&mut hashState, params);
-    ZSTD_ldm_gear_reset(&mut hashState, ip, minMatchLength as size_t);
+    ZSTD_ldm_gear_reset(&mut hashState, ip, minMatchLength as usize);
     ip = ip.offset(minMatchLength as isize);
     while ip < ilimit {
-        let mut hashed: size_t = 0;
+        let mut hashed: usize = 0;
         let mut n: core::ffi::c_uint = 0;
         numSplits = 0;
         hashed = ZSTD_ldm_gear_feed(
@@ -1016,7 +1016,7 @@ unsafe fn ZSTD_ldm_generateSequences_internal(
             (*candidates.offset(n as isize)).hash = hash;
             (*candidates.offset(n as isize)).checksum = (xxhash >> 32) as u32;
             let fresh3 = &mut (*candidates.offset(n as isize)).bucket;
-            *fresh3 = ZSTD_ldm_getBucket(ldmState, hash as size_t, (*params).bucketSizeLog);
+            *fresh3 = ZSTD_ldm_getBucket(ldmState, hash as usize, (*params).bucketSizeLog);
             n = n.wrapping_add(1);
         }
         n = 0;
@@ -1024,7 +1024,7 @@ unsafe fn ZSTD_ldm_generateSequences_internal(
             let mut forwardMatchLength = 0;
             let mut backwardMatchLength = 0;
             let mut bestMatchLength = 0;
-            let mut mLength: size_t = 0;
+            let mut mLength: usize = 0;
             let mut offset: u32 = 0;
             let split_0 = (*candidates.offset(n as isize)).split;
             let checksum = (*candidates.offset(n as isize)).checksum;
@@ -1041,7 +1041,7 @@ unsafe fn ZSTD_ldm_generateSequences_internal(
             if split_0 < anchor {
                 ZSTD_ldm_insertEntry(
                     ldmState,
-                    hash_0 as size_t,
+                    hash_0 as usize,
                     newEntry,
                     (*params).bucketSizeLog,
                 );
@@ -1049,9 +1049,9 @@ unsafe fn ZSTD_ldm_generateSequences_internal(
                 let mut current_block_30: u64;
                 cur = bucket;
                 while cur < bucket.offset(entsPerBucket as isize) as *const ldmEntry_t {
-                    let mut curForwardMatchLength: size_t = 0;
-                    let mut curBackwardMatchLength: size_t = 0;
-                    let mut curTotalMatchLength: size_t = 0;
+                    let mut curForwardMatchLength: usize = 0;
+                    let mut curBackwardMatchLength: usize = 0;
+                    let mut curTotalMatchLength: usize = 0;
                     if !((*cur).checksum != checksum || (*cur).offset <= lowestIndex) {
                         if extDict != 0 {
                             let curMatchBase = if (*cur).offset < dictLimit {
@@ -1072,7 +1072,7 @@ unsafe fn ZSTD_ldm_generateSequences_internal(
                             };
                             curForwardMatchLength =
                                 ZSTD_count_2segments(split_0, pMatch, iend, matchEnd, lowPrefixPtr);
-                            if curForwardMatchLength < minMatchLength as size_t {
+                            if curForwardMatchLength < minMatchLength as usize {
                                 current_block_30 = 17788412896529399552;
                             } else {
                                 curBackwardMatchLength = ZSTD_ldm_countBackwardsMatch_2segments(
@@ -1088,7 +1088,7 @@ unsafe fn ZSTD_ldm_generateSequences_internal(
                         } else {
                             let pMatch_0 = base.offset((*cur).offset as isize);
                             curForwardMatchLength = ZSTD_count(split_0, pMatch_0, iend);
-                            if curForwardMatchLength < minMatchLength as size_t {
+                            if curForwardMatchLength < minMatchLength as usize {
                                 current_block_30 = 17788412896529399552;
                             } else {
                                 curBackwardMatchLength = ZSTD_ldm_countBackwardsMatch(
@@ -1119,7 +1119,7 @@ unsafe fn ZSTD_ldm_generateSequences_internal(
                 if bestEntry.is_null() {
                     ZSTD_ldm_insertEntry(
                         ldmState,
-                        hash_0 as size_t,
+                        hash_0 as usize,
                         newEntry,
                         (*params).bucketSizeLog,
                     );
@@ -1140,7 +1140,7 @@ unsafe fn ZSTD_ldm_generateSequences_internal(
                     (*rawSeqStore).size = ((*rawSeqStore).size).wrapping_add(1);
                     ZSTD_ldm_insertEntry(
                         ldmState,
-                        hash_0 as size_t,
+                        hash_0 as usize,
                         newEntry,
                         (*params).bucketSizeLog,
                     );
@@ -1149,7 +1149,7 @@ unsafe fn ZSTD_ldm_generateSequences_internal(
                         ZSTD_ldm_gear_reset(
                             &mut hashState,
                             anchor.offset(-(minMatchLength as isize)),
-                            minMatchLength as size_t,
+                            minMatchLength as usize,
                         );
                         ip = anchor.offset(-(hashed as isize));
                         break;
@@ -1180,15 +1180,15 @@ pub unsafe fn ZSTD_ldm_generateSequences(
     sequences: *mut RawSeqStore_t,
     params: *const ldmParams_t,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let maxDist = (1) << (*params).windowLog;
     let istart = src as *const u8;
     let iend = istart.add(srcSize);
-    let kMaxChunkSize = ((1) << 20) as size_t;
+    let kMaxChunkSize = ((1) << 20) as usize;
     let nbChunks = (srcSize / kMaxChunkSize)
-        .wrapping_add(!srcSize.is_multiple_of(kMaxChunkSize) as core::ffi::c_int as size_t);
-    let mut chunk: size_t = 0;
+        .wrapping_add(!srcSize.is_multiple_of(kMaxChunkSize) as core::ffi::c_int as usize);
+    let mut chunk: usize = 0;
     let mut leftoverSize = 0;
     chunk = 0;
     while chunk < nbChunks && (*sequences).size < (*sequences).capacity {
@@ -1200,7 +1200,7 @@ pub unsafe fn ZSTD_ldm_generateSequences(
             chunkStart.add(kMaxChunkSize)
         };
         let chunkSize = chunkEnd.offset_from_unsigned(chunkStart);
-        let mut newLeftoverSize: size_t = 0;
+        let mut newLeftoverSize: usize = 0;
         let prevSize = (*sequences).size;
         if ZSTD_window_needOverflowCorrection(
             (*ldmState).window,
@@ -1250,18 +1250,18 @@ pub unsafe fn ZSTD_ldm_generateSequences(
 }
 pub unsafe fn ZSTD_ldm_skipSequences(
     rawSeqStore: *mut RawSeqStore_t,
-    mut srcSize: size_t,
+    mut srcSize: usize,
     minMatch: u32,
 ) {
     while srcSize > 0 && (*rawSeqStore).pos < (*rawSeqStore).size {
         let seq = ((*rawSeqStore).seq).add((*rawSeqStore).pos);
-        if srcSize <= (*seq).litLength as size_t {
+        if srcSize <= (*seq).litLength as usize {
             (*seq).litLength = ((*seq).litLength).wrapping_sub(srcSize as u32);
             return;
         }
-        srcSize = srcSize.wrapping_sub((*seq).litLength as size_t);
+        srcSize = srcSize.wrapping_sub((*seq).litLength as usize);
         (*seq).litLength = 0;
-        if srcSize < (*seq).matchLength as size_t {
+        if srcSize < (*seq).matchLength as usize {
             (*seq).matchLength = ((*seq).matchLength).wrapping_sub(srcSize as u32);
             if (*seq).matchLength < minMatch {
                 if ((*rawSeqStore).pos).wrapping_add(1) < (*rawSeqStore).size {
@@ -1272,7 +1272,7 @@ pub unsafe fn ZSTD_ldm_skipSequences(
             }
             return;
         }
-        srcSize = srcSize.wrapping_sub((*seq).matchLength as size_t);
+        srcSize = srcSize.wrapping_sub((*seq).matchLength as usize);
         (*seq).matchLength = 0;
         (*rawSeqStore).pos = ((*rawSeqStore).pos).wrapping_add(1);
     }
@@ -1295,10 +1295,10 @@ unsafe fn maybeSplitSequence(
             sequence.offset = 0;
         }
     }
-    ZSTD_ldm_skipSequences(rawSeqStore, remaining as size_t, minMatch);
+    ZSTD_ldm_skipSequences(rawSeqStore, remaining as usize, minMatch);
     sequence
 }
-pub unsafe fn ZSTD_ldm_skipRawSeqStoreBytes(rawSeqStore: *mut RawSeqStore_t, nbBytes: size_t) {
+pub unsafe fn ZSTD_ldm_skipRawSeqStoreBytes(rawSeqStore: *mut RawSeqStore_t, nbBytes: usize) {
     let mut currPos = ((*rawSeqStore).posInSequence).wrapping_add(nbBytes) as u32;
     while currPos != 0 && (*rawSeqStore).pos < (*rawSeqStore).size {
         let currSeq = *((*rawSeqStore).seq).add((*rawSeqStore).pos);
@@ -1306,7 +1306,7 @@ pub unsafe fn ZSTD_ldm_skipRawSeqStoreBytes(rawSeqStore: *mut RawSeqStore_t, nbB
             currPos = currPos.wrapping_sub((currSeq.litLength).wrapping_add(currSeq.matchLength));
             (*rawSeqStore).pos = ((*rawSeqStore).pos).wrapping_add(1);
         } else {
-            (*rawSeqStore).posInSequence = currPos as size_t;
+            (*rawSeqStore).posInSequence = currPos as usize;
             break;
         }
     }
@@ -1321,8 +1321,8 @@ pub unsafe fn ZSTD_ldm_blockCompress(
     rep: *mut u32,
     useRowMatchFinder: ZSTD_ParamSwitch_e,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let cParams: *const ZSTD_compressionParameters = &mut ms.cParams;
     let minMatch = (*cParams).minMatch;
     let blockCompressor = ZSTD_selectBlockCompressor(
@@ -1336,7 +1336,7 @@ pub unsafe fn ZSTD_ldm_blockCompress(
     if (*cParams).strategy as core::ffi::c_uint
         >= ZSTD_btopt as core::ffi::c_int as core::ffi::c_uint
     {
-        let mut lastLLSize: size_t = 0;
+        let mut lastLLSize: usize = 0;
         ms.ldmSeqStore = rawSeqStore;
         lastLLSize = blockCompressor.unwrap_unchecked()(ms, seqStore, rep, src, srcSize);
         ZSTD_ldm_skipRawSeqStoreBytes(rawSeqStore, srcSize);
@@ -1359,7 +1359,7 @@ pub unsafe fn ZSTD_ldm_blockCompress(
             seqStore,
             rep,
             ip as *const core::ffi::c_void,
-            sequence.litLength as size_t,
+            sequence.litLength as usize,
         );
         ip = ip.offset(sequence.litLength as isize);
         i = ZSTD_REP_NUM - 1;
@@ -1374,7 +1374,7 @@ pub unsafe fn ZSTD_ldm_blockCompress(
             ip.offset(-(newLitLength as isize)),
             iend,
             (sequence.offset).wrapping_add(ZSTD_REP_NUM as u32),
-            sequence.matchLength as size_t,
+            sequence.matchLength as usize,
         );
         ip = ip.offset(sequence.matchLength as isize);
     }

--- a/lib/compress/zstd_opt.rs
+++ b/lib/compress/zstd_opt.rs
@@ -52,7 +52,7 @@ pub type base_directive_e = core::ffi::c_uint;
 pub const base_1guaranteed: base_directive_e = 1;
 pub const base_0possible: base_directive_e = 0;
 
-use libc::size_t;
+
 
 use crate::lib::common::bits::ZSTD_highbit32;
 use crate::lib::common::fse::{
@@ -119,7 +119,7 @@ unsafe fn ZSTD_newRep(rep: *const u32, offBase: u32, ll0: u32) -> Repcodes_t {
     libc::memcpy(
         &mut newReps as *mut Repcodes_t as *mut core::ffi::c_void,
         rep as *const core::ffi::c_void,
-        ::core::mem::size_of::<Repcodes_t>() as core::ffi::c_ulong as libc::size_t,
+        ::core::mem::size_of::<Repcodes_t>() as core::ffi::c_ulong as usize,
     );
     ZSTD_updateRep((newReps.rep).as_mut_ptr(), offBase, ll0);
     newReps
@@ -173,8 +173,8 @@ unsafe fn ZSTD_setBasePrices(optPtr: *mut optState_t, optLevel: core::ffi::c_int
         ZSTD_bitWeight((*optPtr).offCodeSum)
     };
 }
-unsafe fn sum_u32(table: *const core::ffi::c_uint, nbElts: size_t) -> u32 {
-    let mut n: size_t = 0;
+unsafe fn sum_u32(table: *const core::ffi::c_uint, nbElts: usize) -> u32 {
+    let mut n: usize = 0;
     let mut total = 0;
     n = 0;
     while n < nbElts {
@@ -208,7 +208,7 @@ unsafe fn ZSTD_downscaleStats(
 unsafe fn ZSTD_scaleStats(table: *mut core::ffi::c_uint, lastEltIndex: u32, logTarget: u32) -> u32 {
     let prevsum = sum_u32(
         table as *const core::ffi::c_uint,
-        lastEltIndex.wrapping_add(1) as size_t,
+        lastEltIndex.wrapping_add(1) as usize,
     );
     let factor = prevsum >> logTarget;
     if factor <= 1 {
@@ -224,13 +224,13 @@ unsafe fn ZSTD_scaleStats(table: *mut core::ffi::c_uint, lastEltIndex: u32, logT
 unsafe fn ZSTD_rescaleFreqs(
     optPtr: *mut optState_t,
     src: *const u8,
-    srcSize: size_t,
+    srcSize: usize,
     optLevel: core::ffi::c_int,
 ) {
     let compressedLiterals = ZSTD_compressedLiterals(optPtr);
     (*optPtr).priceType = zop_dynamic;
     if (*optPtr).litLengthSum == 0 {
-        if srcSize <= ZSTD_PREDEF_THRESHOLD as size_t {
+        if srcSize <= ZSTD_PREDEF_THRESHOLD as usize {
             (*optPtr).priceType = zop_predef;
         }
         if (*(*optPtr).symbolCosts).huf.repeatMode as core::ffi::c_uint
@@ -360,9 +360,9 @@ unsafe fn ZSTD_rescaleFreqs(
                 (*optPtr).litLengthFreq as *mut core::ffi::c_void,
                 baseLLfreqs.as_ptr() as *const core::ffi::c_void,
                 ::core::mem::size_of::<[core::ffi::c_uint; 36]>() as core::ffi::c_ulong
-                    as libc::size_t,
+                    as usize,
             );
-            (*optPtr).litLengthSum = sum_u32(baseLLfreqs.as_ptr(), (MaxLL + 1) as size_t);
+            (*optPtr).litLengthSum = sum_u32(baseLLfreqs.as_ptr(), (MaxLL + 1) as usize);
             let mut ml_0: core::ffi::c_uint = 0;
             ml_0 = 0;
             while ml_0 <= MaxML {
@@ -378,9 +378,9 @@ unsafe fn ZSTD_rescaleFreqs(
                 (*optPtr).offCodeFreq as *mut core::ffi::c_void,
                 baseOFCfreqs.as_ptr() as *const core::ffi::c_void,
                 ::core::mem::size_of::<[core::ffi::c_uint; 32]>() as core::ffi::c_ulong
-                    as libc::size_t,
+                    as usize,
             );
-            (*optPtr).offCodeSum = sum_u32(baseOFCfreqs.as_ptr(), (MaxOff + 1) as size_t);
+            (*optPtr).offCodeSum = sum_u32(baseOFCfreqs.as_ptr(), (MaxOff + 1) as usize);
         }
     } else {
         if compressedLiterals != 0 {
@@ -606,7 +606,7 @@ unsafe fn ZSTD_insertBt1(
         } else {
             commonLengthLarger
         };
-        if extDict == 0 || (matchIndex as size_t).wrapping_add(matchLength) >= dictLimit as size_t {
+        if extDict == 0 || (matchIndex as usize).wrapping_add(matchLength) >= dictLimit as usize {
             match_0 = base.offset(matchIndex as isize);
             matchLength = matchLength.wrapping_add(ZSTD_count(
                 ip.add(matchLength),
@@ -622,13 +622,13 @@ unsafe fn ZSTD_insertBt1(
                 dictEnd,
                 prefixStart,
             ));
-            if (matchIndex as size_t).wrapping_add(matchLength) >= dictLimit as size_t {
+            if (matchIndex as usize).wrapping_add(matchLength) >= dictLimit as usize {
                 match_0 = base.offset(matchIndex as isize);
             }
         }
         if matchLength > bestLength {
             bestLength = matchLength;
-            if matchLength > matchEndIdx.wrapping_sub(matchIndex) as size_t {
+            if matchLength > matchEndIdx.wrapping_sub(matchIndex) as usize {
                 matchEndIdx = matchIndex.wrapping_add(matchLength as u32);
             }
         }
@@ -831,7 +831,7 @@ unsafe fn ZSTD_insertBtAndGetAllMatches(
     } else {
         dmsLowLimit
     };
-    let mut bestLength = lengthToBeat.wrapping_sub(1) as size_t;
+    let mut bestLength = lengthToBeat.wrapping_sub(1) as usize;
     let lastR = (ZSTD_REP_NUM as u32).wrapping_add(ll0);
     let mut repCode: u32 = 0;
     repCode = ll0;
@@ -906,8 +906,8 @@ unsafe fn ZSTD_insertBtAndGetAllMatches(
                     .wrapping_add(minMatch);
             }
         }
-        if repLen as size_t > bestLength {
-            bestLength = repLen as size_t;
+        if repLen as usize > bestLength {
+            bestLength = repLen as usize;
             (*matches.offset(mnum as isize)).off = repCode.wrapping_sub(ll0).wrapping_add(1);
             (*matches.offset(mnum as isize)).len = repLen;
             mnum = mnum.wrapping_add(1);
@@ -920,13 +920,13 @@ unsafe fn ZSTD_insertBtAndGetAllMatches(
         }
         repCode = repCode.wrapping_add(1);
     }
-    if mls == 3 && bestLength < mls as size_t {
+    if mls == 3 && bestLength < mls as usize {
         let matchIndex3 = ZSTD_insertAndFindFirstIndexHash3(ms, nextToUpdate3, ip);
         if (matchIndex3 >= matchLow) as core::ffi::c_int
             & (curr.wrapping_sub(matchIndex3) < ((1) << 18) as u32) as core::ffi::c_int
             != 0
         {
-            let mut mlen: size_t = 0;
+            let mut mlen: usize = 0;
             if dictMode as core::ffi::c_uint == ZSTD_noDict as core::ffi::c_int as core::ffi::c_uint
                 || dictMode as core::ffi::c_uint
                     == ZSTD_dictMatchState as core::ffi::c_int as core::ffi::c_uint
@@ -938,14 +938,14 @@ unsafe fn ZSTD_insertBtAndGetAllMatches(
                 let match_1 = dictBase.offset(matchIndex3 as isize);
                 mlen = ZSTD_count_2segments(ip, match_1, iLimit, dictEnd, prefixStart);
             }
-            if mlen >= mls as size_t {
+            if mlen >= mls as usize {
                 bestLength = mlen;
                 (*matches).off = curr
                     .wrapping_sub(matchIndex3)
                     .wrapping_add(ZSTD_REP_NUM as u32);
                 (*matches).len = mlen as u32;
                 mnum = 1;
-                if (mlen > sufficient_len as size_t) as core::ffi::c_int
+                if (mlen > sufficient_len as usize) as core::ffi::c_int
                     | (ip.add(mlen) == iLimit) as core::ffi::c_int
                     != 0
                 {
@@ -967,7 +967,7 @@ unsafe fn ZSTD_insertBtAndGetAllMatches(
         if dictMode as core::ffi::c_uint == ZSTD_noDict as core::ffi::c_int as core::ffi::c_uint
             || dictMode as core::ffi::c_uint
                 == ZSTD_dictMatchState as core::ffi::c_int as core::ffi::c_uint
-            || (matchIndex as size_t).wrapping_add(matchLength) >= dictLimit as size_t
+            || (matchIndex as usize).wrapping_add(matchLength) >= dictLimit as usize
         {
             match_2 = base.offset(matchIndex as isize);
             if matchIndex >= dictLimit {
@@ -988,12 +988,12 @@ unsafe fn ZSTD_insertBtAndGetAllMatches(
                 dictEnd,
                 prefixStart,
             ));
-            if (matchIndex as size_t).wrapping_add(matchLength) >= dictLimit as size_t {
+            if (matchIndex as usize).wrapping_add(matchLength) >= dictLimit as usize {
                 match_2 = base.offset(matchIndex as isize);
             }
         }
         if matchLength > bestLength {
-            if matchLength > matchEndIdx.wrapping_sub(matchIndex) as size_t {
+            if matchLength > matchEndIdx.wrapping_sub(matchIndex) as usize {
                 matchEndIdx = matchIndex.wrapping_add(matchLength as u32);
             }
             bestLength = matchLength;
@@ -1002,7 +1002,7 @@ unsafe fn ZSTD_insertBtAndGetAllMatches(
                 .wrapping_add(ZSTD_REP_NUM as u32);
             (*matches.offset(mnum as isize)).len = matchLength as u32;
             mnum = mnum.wrapping_add(1);
-            if (matchLength > ZSTD_OPT_NUM as size_t) as core::ffi::c_int
+            if (matchLength > ZSTD_OPT_NUM as usize) as core::ffi::c_int
                 | (ip.add(matchLength) == iLimit) as core::ffi::c_int
                 != 0
             {
@@ -1064,14 +1064,14 @@ unsafe fn ZSTD_insertBtAndGetAllMatches(
                 dmsEnd,
                 prefixStart,
             ));
-            if (dictMatchIndex as size_t).wrapping_add(matchLength_0) >= dmsHighLimit as size_t {
+            if (dictMatchIndex as usize).wrapping_add(matchLength_0) >= dmsHighLimit as usize {
                 match_3 = base
                     .offset(dictMatchIndex as isize)
                     .offset(dmsIndexDelta as isize);
             }
             if matchLength_0 > bestLength {
                 matchIndex = dictMatchIndex.wrapping_add(dmsIndexDelta);
-                if matchLength_0 > matchEndIdx.wrapping_sub(matchIndex) as size_t {
+                if matchLength_0 > matchEndIdx.wrapping_sub(matchIndex) as usize {
                     matchEndIdx = matchIndex.wrapping_add(matchLength_0 as u32);
                 }
                 bestLength = matchLength_0;
@@ -1080,7 +1080,7 @@ unsafe fn ZSTD_insertBtAndGetAllMatches(
                     .wrapping_add(ZSTD_REP_NUM as u32);
                 (*matches.offset(mnum as isize)).len = matchLength_0 as u32;
                 mnum = mnum.wrapping_add(1);
-                if (matchLength_0 > ZSTD_OPT_NUM as size_t) as core::ffi::c_int
+                if (matchLength_0 > ZSTD_OPT_NUM as usize) as core::ffi::c_int
                     | (ip.add(matchLength_0) == iLimit) as core::ffi::c_int
                     != 0
                 {
@@ -1597,7 +1597,7 @@ unsafe fn ZSTD_selectBtGetAllMatches(
     .as_ptr()
     .offset(mls.wrapping_sub(3) as isize)
 }
-unsafe fn ZSTD_optLdm_skipRawSeqStoreBytes(rawSeqStore: *mut RawSeqStore_t, nbBytes: size_t) {
+unsafe fn ZSTD_optLdm_skipRawSeqStoreBytes(rawSeqStore: *mut RawSeqStore_t, nbBytes: usize) {
     let mut currPos = ((*rawSeqStore).posInSequence).wrapping_add(nbBytes) as u32;
     while currPos != 0 && (*rawSeqStore).pos < (*rawSeqStore).size {
         let currSeq = *((*rawSeqStore).seq).add((*rawSeqStore).pos);
@@ -1605,7 +1605,7 @@ unsafe fn ZSTD_optLdm_skipRawSeqStoreBytes(rawSeqStore: *mut RawSeqStore_t, nbBy
             currPos = currPos.wrapping_sub((currSeq.litLength).wrapping_add(currSeq.matchLength));
             (*rawSeqStore).pos = ((*rawSeqStore).pos).wrapping_add(1);
         } else {
-            (*rawSeqStore).posInSequence = currPos as size_t;
+            (*rawSeqStore).posInSequence = currPos as usize;
             break;
         }
     }
@@ -1633,7 +1633,7 @@ unsafe fn ZSTD_opt_getNextMatchAndUpdateSeqStore(
     }
     currSeq = *((*optLdm).seqStore.seq).add((*optLdm).seqStore.pos);
     currBlockEndPos = currPosInBlock.wrapping_add(blockBytesRemaining);
-    literalsBytesRemaining = if (*optLdm).seqStore.posInSequence < currSeq.litLength as size_t {
+    literalsBytesRemaining = if (*optLdm).seqStore.posInSequence < currSeq.litLength as usize {
         (currSeq.litLength).wrapping_sub((*optLdm).seqStore.posInSequence as u32)
     } else {
         0
@@ -1647,7 +1647,7 @@ unsafe fn ZSTD_opt_getNextMatchAndUpdateSeqStore(
     if literalsBytesRemaining >= blockBytesRemaining {
         (*optLdm).startPosInBlock = UINT_MAX;
         (*optLdm).endPosInBlock = UINT_MAX;
-        ZSTD_optLdm_skipRawSeqStoreBytes(&mut (*optLdm).seqStore, blockBytesRemaining as size_t);
+        ZSTD_optLdm_skipRawSeqStoreBytes(&mut (*optLdm).seqStore, blockBytesRemaining as usize);
         return;
     }
     (*optLdm).startPosInBlock = currPosInBlock.wrapping_add(literalsBytesRemaining);
@@ -1657,12 +1657,12 @@ unsafe fn ZSTD_opt_getNextMatchAndUpdateSeqStore(
         (*optLdm).endPosInBlock = currBlockEndPos;
         ZSTD_optLdm_skipRawSeqStoreBytes(
             &mut (*optLdm).seqStore,
-            currBlockEndPos.wrapping_sub(currPosInBlock) as size_t,
+            currBlockEndPos.wrapping_sub(currPosInBlock) as usize,
         );
     } else {
         ZSTD_optLdm_skipRawSeqStoreBytes(
             &mut (*optLdm).seqStore,
-            literalsBytesRemaining.wrapping_add(matchBytesRemaining) as size_t,
+            literalsBytesRemaining.wrapping_add(matchBytesRemaining) as usize,
         );
     }
 }
@@ -1707,7 +1707,7 @@ unsafe fn ZSTD_optLdm_processMatchCandidate(
     if currPosInBlock >= (*optLdm).endPosInBlock {
         if currPosInBlock > (*optLdm).endPosInBlock {
             let posOvershoot = currPosInBlock.wrapping_sub((*optLdm).endPosInBlock);
-            ZSTD_optLdm_skipRawSeqStoreBytes(&mut (*optLdm).seqStore, posOvershoot as size_t);
+            ZSTD_optLdm_skipRawSeqStoreBytes(&mut (*optLdm).seqStore, posOvershoot as usize);
         }
         ZSTD_opt_getNextMatchAndUpdateSeqStore(optLdm, currPosInBlock, remainingBytes);
     }
@@ -1719,10 +1719,10 @@ unsafe fn ZSTD_compressBlock_opt_generic(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     optLevel: core::ffi::c_int,
     dictMode: ZSTD_dictMode_e,
-) -> size_t {
+) -> usize {
     let mut current_block: u64;
     let optStatePtr: *mut optState_t = &mut ms.opt;
     let istart = src as *const u8;
@@ -1814,7 +1814,7 @@ unsafe fn ZSTD_compressBlock_opt_generic(
             libc::memcpy(
                 &mut (*opt).rep as *mut [u32; 3] as *mut core::ffi::c_void,
                 rep as *const core::ffi::c_void,
-                ::core::mem::size_of::<[u32; 3]>() as core::ffi::c_ulong as libc::size_t,
+                ::core::mem::size_of::<[u32; 3]>() as core::ffi::c_ulong as usize,
             );
             let maxML = (*matches.offset(nbMatches.wrapping_sub(1) as isize)).len;
             let maxOffBase = (*matches.offset(nbMatches.wrapping_sub(1) as isize)).off;
@@ -1932,7 +1932,7 @@ unsafe fn ZSTD_compressBlock_opt_generic(
                                         as *mut core::ffi::c_void,
                                     &newReps as *const Repcodes_t as *const core::ffi::c_void,
                                     ::core::mem::size_of::<Repcodes_t>() as core::ffi::c_ulong
-                                        as libc::size_t,
+                                        as usize,
                                 );
                                 (*opt.offset(cur.wrapping_add(1) as isize)).litlen = 1;
                                 (*opt.offset(cur.wrapping_add(1) as isize)).price = with1literal;
@@ -1954,7 +1954,7 @@ unsafe fn ZSTD_compressBlock_opt_generic(
                                 as *mut core::ffi::c_void,
                             &newReps_0 as *const Repcodes_t as *const core::ffi::c_void,
                             ::core::mem::size_of::<Repcodes_t>() as core::ffi::c_ulong
-                                as libc::size_t,
+                                as usize,
                         );
                     }
                     if inr <= ilimit {
@@ -2077,13 +2077,13 @@ unsafe fn ZSTD_compressBlock_opt_generic(
                     libc::memcpy(
                         rep as *mut core::ffi::c_void,
                         &reps as *const Repcodes_t as *const core::ffi::c_void,
-                        ::core::mem::size_of::<Repcodes_t>() as core::ffi::c_ulong as libc::size_t,
+                        ::core::mem::size_of::<Repcodes_t>() as core::ffi::c_ulong as usize,
                     );
                 } else {
                     libc::memcpy(
                         rep as *mut core::ffi::c_void,
                         (lastStretch.rep).as_mut_ptr() as *const core::ffi::c_void,
-                        ::core::mem::size_of::<Repcodes_t>() as core::ffi::c_ulong as libc::size_t,
+                        ::core::mem::size_of::<Repcodes_t>() as core::ffi::c_ulong as usize,
                     );
                     cur = cur.wrapping_sub(lastStretch.litlen);
                 }
@@ -2122,11 +2122,11 @@ unsafe fn ZSTD_compressBlock_opt_generic(
                         ZSTD_updateStats(optStatePtr, llen, anchor, offBase_0, mlen_0);
                         ZSTD_storeSeq(
                             seqStore,
-                            llen as size_t,
+                            llen as usize,
                             anchor,
                             iend,
                             offBase_0,
-                            mlen_0 as size_t,
+                            mlen_0 as usize,
                         );
                         anchor = anchor.offset(advance as isize);
                         ip = anchor;
@@ -2144,9 +2144,9 @@ unsafe fn ZSTD_compressBlock_opt0(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     dictMode: ZSTD_dictMode_e,
-) -> size_t {
+) -> usize {
     ZSTD_compressBlock_opt_generic(ms, seqStore, rep, src, srcSize, 0, dictMode)
 }
 unsafe fn ZSTD_compressBlock_opt2(
@@ -2154,9 +2154,9 @@ unsafe fn ZSTD_compressBlock_opt2(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     dictMode: ZSTD_dictMode_e,
-) -> size_t {
+) -> usize {
     ZSTD_compressBlock_opt_generic(ms, seqStore, rep, src, srcSize, 2, dictMode)
 }
 pub unsafe fn ZSTD_compressBlock_btopt(
@@ -2164,8 +2164,8 @@ pub unsafe fn ZSTD_compressBlock_btopt(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_opt0(ms, seqStore, rep, src, srcSize, ZSTD_noDict)
 }
 unsafe fn ZSTD_initStats_ultra(
@@ -2173,13 +2173,13 @@ unsafe fn ZSTD_initStats_ultra(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
 ) {
     let mut tmpRep: [u32; 3] = [0; 3];
     libc::memcpy(
         tmpRep.as_mut_ptr() as *mut core::ffi::c_void,
         rep as *const core::ffi::c_void,
-        ::core::mem::size_of::<[u32; 3]>() as core::ffi::c_ulong as libc::size_t,
+        ::core::mem::size_of::<[u32; 3]>() as core::ffi::c_ulong as usize,
     );
     ZSTD_compressBlock_opt2(ms, seqStore, tmpRep.as_mut_ptr(), src, srcSize, ZSTD_noDict);
     ZSTD_resetSeqStore(seqStore);
@@ -2193,8 +2193,8 @@ pub unsafe fn ZSTD_compressBlock_btultra(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_opt2(ms, seqStore, rep, src, srcSize, ZSTD_noDict)
 }
 pub unsafe fn ZSTD_compressBlock_btultra2(
@@ -2202,14 +2202,14 @@ pub unsafe fn ZSTD_compressBlock_btultra2(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let curr = (src as *const u8).offset_from(ms.window.base) as core::ffi::c_long as u32;
     if ms.opt.litLengthSum == 0
         && seqStore.sequences == seqStore.sequencesStart
         && ms.window.dictLimit == ms.window.lowLimit
         && curr == ms.window.dictLimit
-        && srcSize > ZSTD_PREDEF_THRESHOLD as size_t
+        && srcSize > ZSTD_PREDEF_THRESHOLD as usize
     {
         ZSTD_initStats_ultra(ms, seqStore, rep, src, srcSize);
     }
@@ -2220,8 +2220,8 @@ pub unsafe fn ZSTD_compressBlock_btopt_dictMatchState(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_opt0(ms, seqStore, rep, src, srcSize, ZSTD_dictMatchState)
 }
 pub unsafe fn ZSTD_compressBlock_btopt_extDict(
@@ -2229,8 +2229,8 @@ pub unsafe fn ZSTD_compressBlock_btopt_extDict(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_opt0(ms, seqStore, rep, src, srcSize, ZSTD_extDict)
 }
 pub unsafe fn ZSTD_compressBlock_btultra_dictMatchState(
@@ -2238,8 +2238,8 @@ pub unsafe fn ZSTD_compressBlock_btultra_dictMatchState(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_opt2(ms, seqStore, rep, src, srcSize, ZSTD_dictMatchState)
 }
 pub unsafe fn ZSTD_compressBlock_btultra_extDict(
@@ -2247,8 +2247,8 @@ pub unsafe fn ZSTD_compressBlock_btultra_extDict(
     seqStore: &mut SeqStore_t,
     rep: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_compressBlock_opt2(ms, seqStore, rep, src, srcSize, ZSTD_extDict)
 }
 pub const __INT_MAX__: core::ffi::c_int = 2147483647;

--- a/lib/compress/zstd_preSplit.rs
+++ b/lib/compress/zstd_preSplit.rs
@@ -1,7 +1,7 @@
 use core::ptr;
 
 use core::ffi::{c_char, c_int, c_uint, c_ulong, c_void};
-use libc::size_t;
+
 
 use crate::lib::common::mem::MEM_read16;
 use crate::lib::compress::hist::HIST_add;
@@ -34,7 +34,7 @@ unsafe fn hash2(p: *const c_void, hashLog: c_uint) -> c_uint {
 #[repr(C)]
 pub struct Fingerprint {
     pub events: [c_uint; 1024],
-    pub nbEvents: size_t,
+    pub nbEvents: usize,
 }
 
 #[repr(C)]
@@ -51,13 +51,13 @@ unsafe fn initStats(fpstats: *mut FPStats) {
 unsafe fn addEvents_generic(
     fp: &mut Fingerprint,
     src: *const c_void,
-    srcSize: size_t,
-    samplingRate: size_t,
+    srcSize: usize,
+    samplingRate: usize,
     hashLog: c_uint,
 ) {
     let p = src as *const c_char;
-    let limit = srcSize.wrapping_sub(HASHLENGTH as size_t).wrapping_add(1);
-    let mut n: size_t = 0;
+    let limit = srcSize.wrapping_sub(HASHLENGTH as usize).wrapping_add(1);
+    let mut n: usize = 0;
 
     debug_assert!(srcSize >= HASHLENGTH as usize);
     while n < limit {
@@ -69,10 +69,10 @@ unsafe fn addEvents_generic(
 }
 
 #[inline(always)]
-unsafe fn recordFingerprint_generic<const SAMPLING_RATE: size_t, const HASH_LOG: c_uint>(
+unsafe fn recordFingerprint_generic<const SAMPLING_RATE: usize, const HASH_LOG: c_uint>(
     fp: &mut Fingerprint,
     src: *const c_void,
-    srcSize: size_t,
+    srcSize: usize,
 ) {
     ptr::write_bytes(fp as *mut _ as *mut u8, 0, size_of::<c_uint>() << HASH_LOG);
     fp.nbEvents = 0;
@@ -126,12 +126,12 @@ pub const CHUNKSIZE: c_int = (8) << 10;
 
 unsafe fn ZSTD_splitBlock_byChunks(
     blockStart: *const c_void,
-    blockSize: size_t,
+    blockSize: usize,
     level: c_int,
     workspace: *mut c_void,
-    wkspSize: size_t,
-) -> size_t {
-    static records_fs: [unsafe fn(&mut Fingerprint, *const c_void, size_t) -> (); 4] = [
+    wkspSize: usize,
+) -> usize {
+    static records_fs: [unsafe fn(&mut Fingerprint, *const c_void, usize) -> (); 4] = [
         recordFingerprint_generic::<1, 10>,
         recordFingerprint_generic::<5, 10>,
         recordFingerprint_generic::<11, 9>,
@@ -156,14 +156,14 @@ unsafe fn ZSTD_splitBlock_byChunks(
     record_f(
         &mut (*fpstats).pastEvents,
         p as *const c_void,
-        CHUNKSIZE as size_t,
+        CHUNKSIZE as usize,
     );
-    pos = CHUNKSIZE as size_t;
-    while pos <= blockSize.wrapping_sub(CHUNKSIZE as size_t) {
+    pos = CHUNKSIZE as usize;
+    while pos <= blockSize.wrapping_sub(CHUNKSIZE as usize) {
         record_f(
             &mut (*fpstats).newEvents,
             p.add(pos) as *const c_void,
-            CHUNKSIZE as size_t,
+            CHUNKSIZE as usize,
         );
         if compareFingerprints(
             &(*fpstats).pastEvents,
@@ -179,7 +179,7 @@ unsafe fn ZSTD_splitBlock_byChunks(
                 penalty -= 1;
             }
         }
-        pos = pos.wrapping_add(CHUNKSIZE as size_t);
+        pos = pos.wrapping_add(CHUNKSIZE as usize);
     }
     debug_assert!(pos == blockSize);
     blockSize
@@ -198,10 +198,10 @@ unsafe fn ZSTD_splitBlock_byChunks(
 /// For better accuracy, use the more elaborate `*_byChunks` variant.
 unsafe fn ZSTD_splitBlock_fromBorders(
     blockStart: *const c_void,
-    blockSize: size_t,
+    blockSize: usize,
     workspace: *mut c_void,
-    wkspSize: size_t,
-) -> size_t {
+    wkspSize: usize,
+) -> usize {
     const SEGMENT_SIZE: c_int = 512;
 
     let fpstats = workspace as *mut FPStats;
@@ -219,16 +219,16 @@ unsafe fn ZSTD_splitBlock_fromBorders(
     HIST_add(
         ((*fpstats).pastEvents.events).as_mut_ptr(),
         blockStart,
-        SEGMENT_SIZE as size_t,
+        SEGMENT_SIZE as usize,
     );
     HIST_add(
         ((*fpstats).newEvents.events).as_mut_ptr(),
         (blockStart as *const c_char)
             .add(blockSize)
             .offset(-(SEGMENT_SIZE as isize)) as *const c_void,
-        SEGMENT_SIZE as size_t,
+        SEGMENT_SIZE as usize,
     );
-    (*fpstats).newEvents.nbEvents = SEGMENT_SIZE as size_t;
+    (*fpstats).newEvents.nbEvents = SEGMENT_SIZE as usize;
     (*fpstats).pastEvents.nbEvents = (*fpstats).newEvents.nbEvents;
     if compareFingerprints(&(*fpstats).pastEvents, &(*fpstats).newEvents, 0, 8) == 0 {
         return blockSize;
@@ -238,20 +238,20 @@ unsafe fn ZSTD_splitBlock_fromBorders(
         (blockStart as *const c_char)
             .add(blockSize / 2)
             .offset(-((SEGMENT_SIZE / 2) as isize)) as *const c_void,
-        SEGMENT_SIZE as size_t,
+        SEGMENT_SIZE as usize,
     );
-    (*middleEvents).nbEvents = SEGMENT_SIZE as size_t;
+    (*middleEvents).nbEvents = SEGMENT_SIZE as usize;
     let distFromBegin = fpDistance(&(*fpstats).pastEvents, middleEvents, 8);
     let distFromEnd = fpDistance(&(*fpstats).newEvents, middleEvents, 8);
     let minDistance = (SEGMENT_SIZE * SEGMENT_SIZE / 3) as u64;
     if abs64(distFromBegin as i64 - distFromEnd as i64) < minDistance {
-        return (64 * ((1) << 10)) as size_t;
+        return (64 * ((1) << 10)) as usize;
     }
     (if distFromBegin > distFromEnd {
         32 * ((1) << 10)
     } else {
         96 * ((1) << 10)
-    }) as size_t
+    }) as usize
 }
 
 /// Splits a block to find the optimal boundary for compression.
@@ -261,7 +261,7 @@ unsafe fn ZSTD_splitBlock_fromBorders(
 /// * `blockStart` - Pointer to the start of the block
 /// * `blockSize` - Size of the block (must be 128 KB)
 /// * `level` - Detection level (0-4). Higher levels spend more energy to detect block boundaries.
-/// * `workspace` - Workspace buffer (must be aligned for `size_t`)
+/// * `workspace` - Workspace buffer (must be aligned for `usize`)
 /// * `wkspSize` - Workspace size (must be at least `ZSTD_SLIPBLOCK_WORKSPACESIZE`)
 ///
 /// # Note
@@ -271,11 +271,11 @@ unsafe fn ZSTD_splitBlock_fromBorders(
 /// it is not yet clear if this would be useful. TBD.
 pub unsafe fn ZSTD_splitBlock(
     blockStart: *const c_void,
-    blockSize: size_t,
+    blockSize: usize,
     level: c_int,
     workspace: *mut c_void,
-    wkspSize: size_t,
-) -> size_t {
+    wkspSize: usize,
+) -> usize {
     debug_assert!((0..=4).contains(&level));
     if level == 0 {
         return ZSTD_splitBlock_fromBorders(blockStart, blockSize, workspace, wkspSize);

--- a/lib/compress/zstdmt_compress.rs
+++ b/lib/compress/zstdmt_compress.rs
@@ -1,7 +1,7 @@
 use core::ptr;
 use std::sync::{Condvar, Mutex};
 
-use libc::size_t;
+
 
 use crate::lib::common::allocations::{ZSTD_customCalloc, ZSTD_customFree, ZSTD_customMalloc};
 use crate::lib::common::bits::ZSTD_highbit32;
@@ -40,8 +40,8 @@ pub struct ZSTDMT_CCtx {
     cctxPool: *mut ZSTDMT_CCtxPool,
     seqPool: *mut ZSTDMT_seqPool,
     params: ZSTD_CCtx_params,
-    targetSectionSize: size_t,
-    targetPrefixSize: size_t,
+    targetSectionSize: usize,
+    targetPrefixSize: usize,
     jobReady: core::ffi::c_int,
     inBuff: InBuff_t,
     roundBuff: RoundBuff_t,
@@ -81,33 +81,33 @@ struct SerialState {
 #[repr(C)]
 struct RoundBuff_t {
     buffer: *mut u8,
-    capacity: size_t,
-    pos: size_t,
+    capacity: usize,
+    pos: usize,
 }
 #[repr(C)]
 struct InBuff_t {
     prefix: Range,
     buffer: Buffer,
-    filled: size_t,
+    filled: usize,
 }
 type Buffer = buffer_s;
 #[derive(Copy, Clone)]
 #[repr(C)]
 struct buffer_s {
     start: *mut core::ffi::c_void,
-    capacity: size_t,
+    capacity: usize,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
 struct Range {
     start: *const core::ffi::c_void,
-    size: size_t,
+    size: usize,
 }
 type ZSTDMT_seqPool = ZSTDMT_bufferPool;
 type ZSTDMT_bufferPool = ZSTDMT_bufferPool_s;
 struct ZSTDMT_bufferPool_s {
     poolMutex: Mutex<()>,
-    bufferSize: size_t,
+    bufferSize: usize,
     totalBuffers: core::ffi::c_uint,
     nbBuffers: core::ffi::c_uint,
     cMem: ZSTD_customMem,
@@ -121,8 +121,8 @@ struct ZSTDMT_CCtxPool {
     cctxs: *mut *mut ZSTD_CCtx,
 }
 struct ZSTDMT_jobDescription {
-    consumed: size_t,
-    cSize: size_t,
+    consumed: usize,
+    cSize: usize,
     job_mutex: Mutex<()>,
     job_cond: Condvar,
     cctxPool: *mut ZSTDMT_CCtxPool,
@@ -138,7 +138,7 @@ struct ZSTDMT_jobDescription {
     params: ZSTD_CCtx_params,
     cdict: *const ZSTD_CDict,
     fullFrameSize: core::ffi::c_ulonglong,
-    dstFlushed: size_t,
+    dstFlushed: usize,
     frameChecksumNeeded: core::ffi::c_uint,
 }
 type ZSTD_outBuffer = ZSTD_outBuffer_s;
@@ -150,7 +150,7 @@ type ZSTD_dictTableLoadMethod_e = core::ffi::c_uint;
 const ZSTD_dtlm_fast: ZSTD_dictTableLoadMethod_e = 0;
 #[repr(C)]
 struct SyncPoint {
-    toLoad: size_t,
+    toLoad: usize,
     flush: core::ffi::c_int,
 }
 type ZSTD_CParamMode_e = core::ffi::c_uint;
@@ -182,10 +182,10 @@ const ZSTD_ROLL_HASH_CHAR_OFFSET: core::ffi::c_int = 10;
 unsafe fn ZSTD_rollingHash_append(
     mut hash: u64,
     buf: *const core::ffi::c_void,
-    size: size_t,
+    size: usize,
 ) -> u64 {
     let istart = buf as *const u8;
-    let mut pos: size_t = 0;
+    let mut pos: usize = 0;
     pos = 0;
     while pos < size {
         hash *= prime8bytes;
@@ -197,7 +197,7 @@ unsafe fn ZSTD_rollingHash_append(
     hash
 }
 #[inline]
-unsafe fn ZSTD_rollingHash_compute(buf: *const core::ffi::c_void, size: size_t) -> u64 {
+unsafe fn ZSTD_rollingHash_compute(buf: *const core::ffi::c_void, size: usize) -> u64 {
     ZSTD_rollingHash_append(0, buf, size)
 }
 #[inline]
@@ -215,7 +215,7 @@ unsafe fn ZSTD_rollingHash_rotate(mut hash: u64, toRemove: u8, toAdd: u8, primeP
 }
 #[inline]
 unsafe fn ZSTD_window_clear(window: *mut ZSTD_window_t) {
-    let endT = ((*window).nextSrc).offset_from((*window).base) as size_t;
+    let endT = ((*window).nextSrc).offset_from((*window).base) as usize;
     let end = endT as u32;
     (*window).lowLimit = end;
     (*window).dictLimit = end;
@@ -238,7 +238,7 @@ unsafe fn ZSTD_window_init(window: *mut ZSTD_window_t) {
 unsafe fn ZSTD_window_update(
     window: *mut ZSTD_window_t,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     forceNonContiguous: core::ffi::c_int,
 ) -> u32 {
     let ip = src as *const u8;
@@ -247,7 +247,7 @@ unsafe fn ZSTD_window_update(
         return contiguous;
     }
     if src != (*window).nextSrc as *const core::ffi::c_void || forceNonContiguous != 0 {
-        let distanceFromBase = ((*window).nextSrc).offset_from((*window).base) as size_t;
+        let distanceFromBase = ((*window).nextSrc).offset_from((*window).base) as usize;
         (*window).lowLimit = (*window).dictLimit;
         (*window).dictLimit = distanceFromBase as u32;
         (*window).dictBase = (*window).base;
@@ -263,8 +263,8 @@ unsafe fn ZSTD_window_update(
         & (ip < ((*window).dictBase).offset((*window).dictLimit as isize)) as core::ffi::c_int
         != 0
     {
-        let highInputIdx = ip.add(srcSize).offset_from((*window).dictBase) as size_t;
-        let lowLimitMax = if highInputIdx > (*window).dictLimit as size_t {
+        let highInputIdx = ip.add(srcSize).offset_from((*window).dictBase) as usize;
+        let lowLimitMax = if highInputIdx > (*window).dictLimit as usize {
             (*window).dictLimit
         } else {
             highInputIdx as u32
@@ -328,18 +328,18 @@ unsafe fn ZSTDMT_createBufferPool(
         ZSTDMT_freeBufferPool(bufPool);
         return core::ptr::null_mut();
     }
-    (*bufPool).bufferSize = (64 * ((1) << 10)) as size_t;
+    (*bufPool).bufferSize = (64 * ((1) << 10)) as usize;
     (*bufPool).totalBuffers = maxNbBuffers;
     (*bufPool).nbBuffers = 0;
     (*bufPool).cMem = cMem;
     bufPool
 }
-unsafe fn ZSTDMT_sizeof_bufferPool(bufPool: *mut ZSTDMT_bufferPool) -> size_t {
+unsafe fn ZSTDMT_sizeof_bufferPool(bufPool: *mut ZSTDMT_bufferPool) -> usize {
     let poolSize = ::core::mem::size_of::<ZSTDMT_bufferPool>();
     let arraySize =
-        ((*bufPool).totalBuffers as size_t).wrapping_mul(::core::mem::size_of::<Buffer>());
+        ((*bufPool).totalBuffers as usize).wrapping_mul(::core::mem::size_of::<Buffer>());
     let mut u: core::ffi::c_uint = 0;
-    let mut totalBufferSize = 0 as size_t;
+    let mut totalBufferSize = 0 as usize;
     let _guard = (*bufPool).poolMutex.lock().unwrap();
     u = 0;
     while u < (*bufPool).totalBuffers {
@@ -351,7 +351,7 @@ unsafe fn ZSTDMT_sizeof_bufferPool(bufPool: *mut ZSTDMT_bufferPool) -> size_t {
         .wrapping_add(arraySize)
         .wrapping_add(totalBufferSize)
 }
-unsafe fn ZSTDMT_setBufferSize(bufPool: *mut ZSTDMT_bufferPool, bSize: size_t) {
+unsafe fn ZSTDMT_setBufferSize(bufPool: *mut ZSTDMT_bufferPool, bSize: usize) {
     let _guard = (*bufPool).poolMutex.lock().unwrap();
     (*bufPool).bufferSize = bSize;
 }
@@ -417,7 +417,7 @@ unsafe fn ZSTDMT_releaseBuffer(bufPool: *mut ZSTDMT_bufferPool, buf: Buffer) {
     drop(guard);
     ZSTD_customFree(buf.start, buf.capacity, (*bufPool).cMem);
 }
-unsafe fn ZSTDMT_sizeof_seqPool(seqPool: *mut ZSTDMT_seqPool) -> size_t {
+unsafe fn ZSTDMT_sizeof_seqPool(seqPool: *mut ZSTDMT_seqPool) -> usize {
     ZSTDMT_sizeof_bufferPool(seqPool)
 }
 unsafe fn bufferToSeq(buffer: Buffer) -> RawSeqStore_t {
@@ -444,7 +444,7 @@ unsafe fn ZSTDMT_getSeq(seqPool: *mut ZSTDMT_seqPool) -> RawSeqStore_t {
 unsafe fn ZSTDMT_releaseSeq(seqPool: *mut ZSTDMT_seqPool, seq: RawSeqStore_t) {
     ZSTDMT_releaseBuffer(seqPool, seqToBuffer(seq));
 }
-unsafe fn ZSTDMT_setNbSeq(seqPool: *mut ZSTDMT_seqPool, nbSeq: size_t) {
+unsafe fn ZSTDMT_setNbSeq(seqPool: *mut ZSTDMT_seqPool, nbSeq: usize) {
     ZSTDMT_setBufferSize(
         seqPool,
         nbSeq.wrapping_mul(::core::mem::size_of::<rawSeq>()),
@@ -537,13 +537,13 @@ unsafe fn ZSTDMT_expandCCtxPool(
     ZSTDMT_freeCCtxPool(srcPool);
     ZSTDMT_createCCtxPool(nbWorkers, cMem)
 }
-unsafe fn ZSTDMT_sizeof_CCtxPool(cctxPool: *mut ZSTDMT_CCtxPool) -> size_t {
+unsafe fn ZSTDMT_sizeof_CCtxPool(cctxPool: *mut ZSTDMT_CCtxPool) -> usize {
     let _guard = (*cctxPool).poolMutex.lock().unwrap();
     let nbWorkers = (*cctxPool).totalCCtx as core::ffi::c_uint;
     let poolSize = ::core::mem::size_of::<ZSTDMT_CCtxPool>();
     let arraySize =
         ((*cctxPool).totalCCtx as usize).wrapping_mul(::core::mem::size_of::<*mut ZSTD_CCtx>());
-    let mut totalCCtxSize = 0 as size_t;
+    let mut totalCCtxSize = 0 as usize;
     let mut u: core::ffi::c_uint = 0;
     u = 0;
     while u < nbWorkers {
@@ -580,9 +580,9 @@ unsafe fn ZSTDMT_serialState_reset(
     serialState: *mut SerialState,
     seqPool: *mut ZSTDMT_seqPool,
     mut params: ZSTD_CCtx_params,
-    jobSize: size_t,
+    jobSize: usize,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     dictContentType: ZSTD_dictContentType_e,
 ) -> core::ffi::c_int {
     if params.ldmParams.enableLdm == ZSTD_ParamSwitch_e::ZSTD_ps_enable {
@@ -602,7 +602,7 @@ unsafe fn ZSTDMT_serialState_reset(
         let cMem = params.customMem;
         let hashLog = params.ldmParams.hashLog;
         let hashSize =
-            ((1 as size_t) << hashLog).wrapping_mul(::core::mem::size_of::<ldmEntry_t>());
+            ((1 as usize) << hashLog).wrapping_mul(::core::mem::size_of::<ldmEntry_t>());
         let bucketLog = (params.ldmParams.hashLog).wrapping_sub(params.ldmParams.bucketSizeLog);
         let prevBucketLog = ((*serialState).params.ldmParams.hashLog)
             .wrapping_sub((*serialState).params.ldmParams.bucketSizeLog);
@@ -657,7 +657,7 @@ unsafe fn ZSTDMT_serialState_reset(
         (*serialState).ldmWindow = (*serialState).ldmState.window;
     }
     (*serialState).params = params;
-    (*serialState).params.jobSize = jobSize as u32 as size_t;
+    (*serialState).params.jobSize = jobSize as u32 as usize;
     0
 }
 unsafe fn ZSTDMT_serialState_init(serialState: *mut SerialState) -> core::ffi::c_int {
@@ -688,7 +688,7 @@ unsafe fn ZSTDMT_serialState_free(serialState: *mut SerialState) {
     core::ptr::drop_in_place(core::ptr::addr_of_mut!((*serialState).ldmWindowMutex));
     core::ptr::drop_in_place(core::ptr::addr_of_mut!((*serialState).ldmWindowCond));
     let hashLog = (*serialState).params.ldmParams.hashLog;
-    let hashSize = ((1 as size_t) << hashLog).wrapping_mul(::core::mem::size_of::<ldmEntry_t>());
+    let hashSize = ((1 as usize) << hashLog).wrapping_mul(::core::mem::size_of::<ldmEntry_t>());
     let bucketLog = ((*serialState).params.ldmParams.hashLog)
         .wrapping_sub((*serialState).params.ldmParams.bucketSizeLog);
     let numBuckets = 1usize << bucketLog;
@@ -752,7 +752,7 @@ unsafe fn ZSTDMT_serialState_applySequences(
 unsafe fn ZSTDMT_serialState_ensureFinished(
     serialState: *mut SerialState,
     jobID: core::ffi::c_uint,
-    _cSize: size_t,
+    _cSize: usize,
 ) {
     let _guard = (*serialState).mutex.lock().unwrap();
     if (*serialState).nextJobID <= jobID {
@@ -920,7 +920,7 @@ unsafe fn ZSTDMT_compressionJob(jobDescription: *mut core::ffi::c_void) {
                             match current_block {
                                 17100290475540901977 => {}
                                 _ => {
-                                    let chunkSize = (4 * ZSTD_BLOCKSIZE_MAX) as size_t;
+                                    let chunkSize = (4 * ZSTD_BLOCKSIZE_MAX) as usize;
                                     let nbChunks = (((*job).src.size)
                                         .wrapping_add(chunkSize.wrapping_sub(1))
                                         / chunkSize)
@@ -931,7 +931,7 @@ unsafe fn ZSTDMT_compressionJob(jobDescription: *mut core::ffi::c_void) {
                                     let oend = op.add(dstBuff.capacity);
                                     let mut chunkNb: core::ffi::c_int = 0;
 
-                                    if size_of::<size_t>() > size_of::<i32>() {
+                                    if size_of::<usize>() > size_of::<i32>() {
                                         /* check overflow */
                                         assert!(
                                             ((*job).src.size as u64)
@@ -964,7 +964,7 @@ unsafe fn ZSTDMT_compressionJob(jobDescription: *mut core::ffi::c_void) {
                                             op = op.add(cSize);
                                             let guard = (*job).job_mutex.lock().unwrap();
                                             (*job).cSize = ((*job).cSize).wrapping_add(cSize);
-                                            (*job).consumed = chunkSize * chunkNb as size_t;
+                                            (*job).consumed = chunkSize * chunkNb as usize;
                                             (*job).job_cond.notify_one();
                                             drop(guard);
                                             chunkNb += 1;
@@ -995,7 +995,7 @@ unsafe fn ZSTDMT_compressionJob(jobDescription: *mut core::ffi::c_void) {
                                                         cctx,
                                                         op as *mut core::ffi::c_void,
                                                         oend.offset_from(op) as core::ffi::c_long
-                                                            as size_t,
+                                                            as usize,
                                                         ip as *const core::ffi::c_void,
                                                         lastBlockSize,
                                                     )
@@ -1004,7 +1004,7 @@ unsafe fn ZSTDMT_compressionJob(jobDescription: *mut core::ffi::c_void) {
                                                         cctx,
                                                         op as *mut core::ffi::c_void,
                                                         oend.offset_from(op) as core::ffi::c_long
-                                                            as size_t,
+                                                            as usize,
                                                         ip as *const core::ffi::c_void,
                                                         lastBlockSize,
                                                     )
@@ -1122,7 +1122,7 @@ unsafe fn ZSTDMT_createJobsTable(
     }
     jobTable
 }
-unsafe fn ZSTDMT_expandJobsTable(mtctx: *mut ZSTDMT_CCtx, nbWorkers: u32) -> size_t {
+unsafe fn ZSTDMT_expandJobsTable(mtctx: *mut ZSTDMT_CCtx, nbWorkers: u32) -> usize {
     let mut nbJobs = nbWorkers.wrapping_add(2);
     if nbJobs > ((*mtctx).jobIDMask).wrapping_add(1) {
         ZSTDMT_freeJobsTable(
@@ -1142,7 +1142,7 @@ unsafe fn ZSTDMT_expandJobsTable(mtctx: *mut ZSTDMT_CCtx, nbWorkers: u32) -> siz
 unsafe fn ZSTDMT_CCtxParam_setNbWorkers(
     params: *mut ZSTD_CCtx_params,
     nbWorkers: core::ffi::c_uint,
-) -> size_t {
+) -> usize {
     ZSTD_CCtxParams_setParameter(
         params,
         ZSTD_cParameter::ZSTD_c_nbWorkers,
@@ -1186,7 +1186,7 @@ unsafe fn ZSTDMT_createCCtx_advanced_internal(
         (*mtctx).factory = pool;
         (*mtctx).providedFactory = true;
     } else {
-        (*mtctx).factory = POOL_create_advanced(nbWorkers as size_t, 0, cMem);
+        (*mtctx).factory = POOL_create_advanced(nbWorkers as usize, 0, cMem);
         (*mtctx).providedFactory = false;
     }
     (*mtctx).jobs = ZSTDMT_createJobsTable(&mut nbJobs, cMem);
@@ -1272,7 +1272,7 @@ unsafe fn ZSTDMT_waitForAllJobsCompleted(mtctx: *mut ZSTDMT_CCtx) {
         (*mtctx).doneJobID += 1;
     }
 }
-pub unsafe fn ZSTDMT_freeCCtx(mtctx: *mut ZSTDMT_CCtx) -> size_t {
+pub unsafe fn ZSTDMT_freeCCtx(mtctx: *mut ZSTDMT_CCtx) -> usize {
     if mtctx.is_null() {
         return 0;
     }
@@ -1304,7 +1304,7 @@ pub unsafe fn ZSTDMT_freeCCtx(mtctx: *mut ZSTDMT_CCtx) -> size_t {
     );
     0
 }
-pub unsafe fn ZSTDMT_sizeof_CCtx(mtctx: *mut ZSTDMT_CCtx) -> size_t {
+pub unsafe fn ZSTDMT_sizeof_CCtx(mtctx: *mut ZSTDMT_CCtx) -> usize {
     if mtctx.is_null() {
         return 0;
     }
@@ -1312,7 +1312,7 @@ pub unsafe fn ZSTDMT_sizeof_CCtx(mtctx: *mut ZSTDMT_CCtx) -> size_t {
         .wrapping_add(POOL_sizeof((*mtctx).factory))
         .wrapping_add(ZSTDMT_sizeof_bufferPool((*mtctx).bufPool))
         .wrapping_add(
-            (((*mtctx).jobIDMask).wrapping_add(1) as size_t)
+            (((*mtctx).jobIDMask).wrapping_add(1) as usize)
                 .wrapping_mul(::core::mem::size_of::<ZSTDMT_jobDescription>()),
         )
         .wrapping_add(ZSTDMT_sizeof_CCtxPool((*mtctx).cctxPool))
@@ -1320,8 +1320,8 @@ pub unsafe fn ZSTDMT_sizeof_CCtx(mtctx: *mut ZSTDMT_CCtx) -> size_t {
         .wrapping_add(ZSTD_sizeof_CDict((*mtctx).cdictLocal))
         .wrapping_add((*mtctx).roundBuff.capacity)
 }
-unsafe fn ZSTDMT_resize(mtctx: *mut ZSTDMT_CCtx, nbWorkers: core::ffi::c_uint) -> size_t {
-    if POOL_resize((*mtctx).factory, nbWorkers as size_t) != 0 {
+unsafe fn ZSTDMT_resize(mtctx: *mut ZSTDMT_CCtx, nbWorkers: core::ffi::c_uint) -> usize {
+    if POOL_resize((*mtctx).factory, nbWorkers as usize) != 0 {
         return Error::memory_allocation.to_error_code();
     }
     let err_code = ZSTDMT_expandJobsTable(mtctx, nbWorkers);
@@ -1406,8 +1406,8 @@ pub unsafe fn ZSTDMT_getFrameProgression(mtctx: *mut ZSTDMT_CCtx) -> ZSTD_frameP
     }
     fps
 }
-pub unsafe fn ZSTDMT_toFlushNow(mtctx: *mut ZSTDMT_CCtx) -> size_t {
-    let mut toFlush: size_t = 0;
+pub unsafe fn ZSTDMT_toFlushNow(mtctx: *mut ZSTDMT_CCtx) -> usize {
+    let mut toFlush: usize = 0;
     let jobID = (*mtctx).doneJobID;
     if jobID == (*mtctx).nextJobID {
         return 0;
@@ -1468,7 +1468,7 @@ unsafe fn ZSTDMT_overlapLog(ovlog: core::ffi::c_int, strat: ZSTD_strategy) -> co
     }
     ovlog
 }
-unsafe fn ZSTDMT_computeOverlapSize(params: *const ZSTD_CCtx_params) -> size_t {
+unsafe fn ZSTDMT_computeOverlapSize(params: *const ZSTD_CCtx_params) -> usize {
     let overlapRLog = 9 - ZSTDMT_overlapLog((*params).overlapLog, (*params).cParams.strategy);
     let mut ovLog = (if overlapRLog >= 8 {
         0
@@ -1494,33 +1494,33 @@ unsafe fn ZSTDMT_computeOverlapSize(params: *const ZSTD_CCtx_params) -> size_t {
 pub unsafe fn ZSTDMT_initCStream_internal(
     mtctx: *mut ZSTDMT_CCtx,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     dictContentType: ZSTD_dictContentType_e,
     cdict: *const ZSTD_CDict,
     mut params: ZSTD_CCtx_params,
     pledgedSrcSize: core::ffi::c_ulonglong,
-) -> size_t {
+) -> usize {
     if params.nbWorkers != (*mtctx).params.nbWorkers {
         let err_code = ZSTDMT_resize(mtctx, params.nbWorkers as core::ffi::c_uint);
         if ERR_isError(err_code) {
             return err_code;
         }
     }
-    if params.jobSize != 0 && params.jobSize < ZSTDMT_JOBSIZE_MIN as size_t {
-        params.jobSize = ZSTDMT_JOBSIZE_MIN as size_t;
+    if params.jobSize != 0 && params.jobSize < ZSTDMT_JOBSIZE_MIN as usize {
+        params.jobSize = ZSTDMT_JOBSIZE_MIN as usize;
     }
     if params.jobSize
         > (if MEM_32bits() {
             512 * (1 << 20)
         } else {
             1024 * (1 << 20)
-        }) as size_t
+        }) as usize
     {
         params.jobSize = (if MEM_32bits() {
             512 * ((1) << 20)
         } else {
             1024 * ((1) << 20)
-        }) as size_t;
+        }) as usize;
     }
     if (*mtctx).allJobsCompleted == 0 {
         ZSTDMT_waitForAllJobsCompleted(mtctx);
@@ -1550,7 +1550,7 @@ pub unsafe fn ZSTDMT_initCStream_internal(
     (*mtctx).targetPrefixSize = ZSTDMT_computeOverlapSize(&params);
     (*mtctx).targetSectionSize = params.jobSize;
     if (*mtctx).targetSectionSize == 0 {
-        (*mtctx).targetSectionSize = ((1) << ZSTDMT_computeTargetJobLog(&params)) as size_t;
+        (*mtctx).targetSectionSize = ((1) << ZSTDMT_computeTargetJobLog(&params)) as usize;
     }
     if params.rsyncable != 0 {
         let jobSizeKB = ((*mtctx).targetSectionSize >> 10) as u32;
@@ -1570,14 +1570,14 @@ pub unsafe fn ZSTDMT_initCStream_internal(
         (1) << (*mtctx).params.cParams.windowLog
     } else {
         0
-    }) as size_t;
-    let nbSlackBuffers = (2 + ((*mtctx).targetPrefixSize > 0) as core::ffi::c_int) as size_t;
+    }) as usize;
+    let nbSlackBuffers = (2 + ((*mtctx).targetPrefixSize > 0) as core::ffi::c_int) as usize;
     let slackSize = (*mtctx).targetSectionSize * nbSlackBuffers;
     let nbWorkers = (if (*mtctx).params.nbWorkers > 1 {
         (*mtctx).params.nbWorkers
     } else {
         1
-    }) as size_t;
+    }) as usize;
     let sectionsSize = (*mtctx).targetSectionSize * nbWorkers;
     let capacity = (if windowSize > sectionsSize {
         windowSize
@@ -1661,9 +1661,9 @@ unsafe fn ZSTDMT_writeLastEmptyBlock(job: *mut ZSTDMT_jobDescription) {
 }
 unsafe fn ZSTDMT_createCompressionJob(
     mtctx: *mut ZSTDMT_CCtx,
-    srcSize: size_t,
+    srcSize: usize,
     endOp: ZSTD_EndDirective,
-) -> size_t {
+) -> usize {
     let jobID = (*mtctx).nextJobID & (*mtctx).jobIDMask;
     let endFrame = (endOp as core::ffi::c_uint
         == ZSTD_e_end as core::ffi::c_int as core::ffi::c_uint)
@@ -1748,7 +1748,7 @@ unsafe fn ZSTDMT_flushProduced(
     output: *mut ZSTD_outBuffer,
     blockToFlush: core::ffi::c_uint,
     end: ZSTD_EndDirective,
-) -> size_t {
+) -> usize {
     let wJobID = (*mtctx).doneJobID & (*mtctx).jobIDMask;
     let mut guard = (*((*mtctx).jobs).offset(wJobID as isize))
         .job_mutex
@@ -1808,7 +1808,7 @@ unsafe fn ZSTDMT_flushProduced(
                     as *const core::ffi::c_char)
                     .add((*((*mtctx).jobs).offset(wJobID as isize)).dstFlushed)
                     as *const core::ffi::c_void,
-                toFlush as libc::size_t,
+                toFlush as usize,
             );
         }
         (*output).pos = ((*output).pos).wrapping_add(toFlush);
@@ -1844,7 +1844,7 @@ unsafe fn ZSTDMT_flushProduced(
     }
     (*mtctx).allJobsCompleted = (*mtctx).frameEnded;
     if end as core::ffi::c_uint == ZSTD_e_end as core::ffi::c_int as core::ffi::c_uint {
-        return ((*mtctx).frameEnded == 0) as core::ffi::c_int as size_t;
+        return ((*mtctx).frameEnded == 0) as core::ffi::c_int as usize;
     }
     0
 }
@@ -1854,13 +1854,13 @@ unsafe fn ZSTDMT_getInputDataInUse(mtctx: *mut ZSTDMT_CCtx) -> Range {
     let mut jobID: core::ffi::c_uint = 0;
     let roundBuffCapacity = (*mtctx).roundBuff.capacity;
     let nbJobs1stRoundMin = roundBuffCapacity / (*mtctx).targetSectionSize;
-    if (lastJobID as size_t) < nbJobs1stRoundMin {
+    if (lastJobID as usize) < nbJobs1stRoundMin {
         return kNullRange;
     }
     jobID = firstJobID;
     while jobID < lastJobID {
         let wJobID = jobID & (*mtctx).jobIDMask;
-        let mut consumed: size_t = 0;
+        let mut consumed: usize = 0;
         let guard = (*((*mtctx).jobs).offset(wJobID as isize))
             .job_mutex
             .lock()
@@ -1901,10 +1901,10 @@ unsafe fn ZSTDMT_doesOverlapWindow(buffer: Buffer, window: ZSTD_window_t) -> cor
         size: 0,
     };
     extDict.start = (window.dictBase).offset(window.lowLimit as isize) as *const core::ffi::c_void;
-    extDict.size = (window.dictLimit).wrapping_sub(window.lowLimit) as size_t;
+    extDict.size = (window.dictLimit).wrapping_sub(window.lowLimit) as usize;
     prefix.start = (window.base).offset(window.dictLimit as isize) as *const core::ffi::c_void;
     prefix.size =
-        (window.nextSrc).offset_from((window.base).offset(window.dictLimit as isize)) as size_t;
+        (window.nextSrc).offset_from((window.base).offset(window.dictLimit as isize)) as usize;
     (ZSTDMT_isOverlapped(buffer, extDict) != 0 || ZSTDMT_isOverlapped(buffer, prefix) != 0)
         as core::ffi::c_int
 }
@@ -1958,7 +1958,7 @@ unsafe fn findSynchronizationPoint(mtctx: *const ZSTDMT_CCtx, input: ZSTD_inBuff
     };
     let mut hash: u64 = 0;
     let mut prev = core::ptr::null::<u8>();
-    let mut pos: size_t = 0;
+    let mut pos: usize = 0;
     syncPoint.toLoad = if (input.size).wrapping_sub(input.pos)
         < ((*mtctx).targetSectionSize).wrapping_sub((*mtctx).inBuff.filled)
     {
@@ -1973,26 +1973,26 @@ unsafe fn findSynchronizationPoint(mtctx: *const ZSTDMT_CCtx, input: ZSTD_inBuff
     if ((*mtctx).inBuff.filled)
         .wrapping_add(input.size)
         .wrapping_sub(input.pos)
-        < RSYNC_MIN_BLOCK_SIZE as size_t
+        < RSYNC_MIN_BLOCK_SIZE as usize
     {
         return syncPoint;
     }
-    if ((*mtctx).inBuff.filled).wrapping_add(syncPoint.toLoad) < RSYNC_LENGTH as size_t {
+    if ((*mtctx).inBuff.filled).wrapping_add(syncPoint.toLoad) < RSYNC_LENGTH as usize {
         return syncPoint;
     }
-    if (*mtctx).inBuff.filled < RSYNC_MIN_BLOCK_SIZE as size_t {
-        pos = (RSYNC_MIN_BLOCK_SIZE as size_t).wrapping_sub((*mtctx).inBuff.filled);
-        if pos >= RSYNC_LENGTH as size_t {
+    if (*mtctx).inBuff.filled < RSYNC_MIN_BLOCK_SIZE as usize {
+        pos = (RSYNC_MIN_BLOCK_SIZE as usize).wrapping_sub((*mtctx).inBuff.filled);
+        if pos >= RSYNC_LENGTH as usize {
             prev = istart.add(pos).offset(-(RSYNC_LENGTH as isize));
             hash =
-                ZSTD_rollingHash_compute(prev as *const core::ffi::c_void, RSYNC_LENGTH as size_t);
+                ZSTD_rollingHash_compute(prev as *const core::ffi::c_void, RSYNC_LENGTH as usize);
         } else {
             prev = ((*mtctx).inBuff.buffer.start as *const u8)
                 .add((*mtctx).inBuff.filled)
                 .offset(-(RSYNC_LENGTH as isize));
             hash = ZSTD_rollingHash_compute(
                 prev.add(pos) as *const core::ffi::c_void,
-                (RSYNC_LENGTH as size_t).wrapping_sub(pos),
+                (RSYNC_LENGTH as usize).wrapping_sub(pos),
             );
             hash = ZSTD_rollingHash_append(hash, istart as *const core::ffi::c_void, pos);
         }
@@ -2001,7 +2001,7 @@ unsafe fn findSynchronizationPoint(mtctx: *const ZSTDMT_CCtx, input: ZSTD_inBuff
         prev = ((*mtctx).inBuff.buffer.start as *const u8)
             .add((*mtctx).inBuff.filled)
             .offset(-(RSYNC_LENGTH as isize));
-        hash = ZSTD_rollingHash_compute(prev as *const core::ffi::c_void, RSYNC_LENGTH as size_t);
+        hash = ZSTD_rollingHash_compute(prev as *const core::ffi::c_void, RSYNC_LENGTH as usize);
         if hash & hitMask == hitMask {
             syncPoint.toLoad = 0;
             syncPoint.flush = 1;
@@ -2009,10 +2009,10 @@ unsafe fn findSynchronizationPoint(mtctx: *const ZSTDMT_CCtx, input: ZSTD_inBuff
         }
     }
     while pos < syncPoint.toLoad {
-        let toRemove = (if pos < RSYNC_LENGTH as size_t {
+        let toRemove = (if pos < RSYNC_LENGTH as usize {
             *prev.add(pos) as core::ffi::c_int
         } else {
-            *istart.add(pos.wrapping_sub(RSYNC_LENGTH as size_t)) as core::ffi::c_int
+            *istart.add(pos.wrapping_sub(RSYNC_LENGTH as usize)) as core::ffi::c_int
         }) as u8;
         hash = ZSTD_rollingHash_rotate(hash, toRemove, *istart.add(pos), primePower);
         if hash & hitMask == hitMask {
@@ -2026,7 +2026,7 @@ unsafe fn findSynchronizationPoint(mtctx: *const ZSTDMT_CCtx, input: ZSTD_inBuff
     }
     syncPoint
 }
-pub unsafe fn ZSTDMT_nextInputSizeHint(mtctx: *const ZSTDMT_CCtx) -> size_t {
+pub unsafe fn ZSTDMT_nextInputSizeHint(mtctx: *const ZSTDMT_CCtx) -> usize {
     let mut hintInSize = ((*mtctx).targetSectionSize).wrapping_sub((*mtctx).inBuff.filled);
     if hintInSize == 0 {
         hintInSize = (*mtctx).targetSectionSize;
@@ -2038,7 +2038,7 @@ pub unsafe fn ZSTDMT_compressStream_generic(
     output: *mut ZSTD_outBuffer,
     input: *mut ZSTD_inBuffer,
     mut endOp: ZSTD_EndDirective,
-) -> size_t {
+) -> usize {
     let mut forwardInputProgress = 0;
     if (*mtctx).frameEnded != 0
         && endOp as core::ffi::c_uint == ZSTD_e_continue as core::ffi::c_int as core::ffi::c_uint
@@ -2067,7 +2067,7 @@ pub unsafe fn ZSTDMT_compressStream_generic(
                     as *mut core::ffi::c_void,
                 ((*input).src as *const core::ffi::c_char).add((*input).pos)
                     as *const core::ffi::c_void,
-                syncPoint.toLoad as libc::size_t,
+                syncPoint.toLoad as usize,
             );
             (*input).pos = ((*input).pos).wrapping_add(syncPoint.toLoad);
             (*mtctx).inBuff.filled = ((*mtctx).inBuff.filled).wrapping_add(syncPoint.toLoad);

--- a/lib/decompress/huf_decompress.rs
+++ b/lib/decompress/huf_decompress.rs
@@ -2,7 +2,7 @@ use core::marker::PhantomData;
 use core::ops::{Bound, Range};
 use core::ptr::NonNull;
 
-use libc::size_t;
+
 
 use crate::lib::common::bitstream::{BIT_DStream_t, BitContainerType, StreamStatus};
 use crate::lib::common::entropy_common::HUF_readStats_wksp;
@@ -155,7 +155,7 @@ pub struct HUF_DecompressFastArgs<'a> {
 pub const HUF_DECODER_FAST_TABLELOG: core::ffi::c_int = 11;
 pub const HUF_ENABLE_FAST_DECODE: core::ffi::c_int = 1;
 
-unsafe fn HUF_initFastDStream(ip: *const u8) -> size_t {
+unsafe fn HUF_initFastDStream(ip: *const u8) -> usize {
     let lastByte = *ip.add(7);
     let bitsConsumed = match lastByte.checked_ilog2() {
         Some(v) => 8 - v,
@@ -278,7 +278,7 @@ unsafe fn init_remaining_dstream<'a>(
     let bitContainer = MEM_readLEST(args.ip[stream] as *const core::ffi::c_void) as usize;
     let bitsConsumed = args.bits[stream].trailing_zeros();
     let start = args.ilowest as *const core::ffi::c_char;
-    let limitPtr = start.add(::core::mem::size_of::<size_t>());
+    let limitPtr = start.add(::core::mem::size_of::<usize>());
     let ptr = args.ip[stream] as *const core::ffi::c_char;
 
     Ok(BIT_DStream_t {
@@ -334,19 +334,19 @@ pub fn HUF_readDTableX1_wksp(
     src: &[u8],
     workSpace: &mut Workspace,
     flags: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let mut dtd = DTable.description;
     let dt = DTable.data.as_x1_mut();
 
     let mut tableLog = 0;
     let mut nbSymbols = 0;
-    let mut iSize: size_t = 0;
+    let mut iSize: usize = 0;
 
     let wksp = workSpace.as_x1_mut();
 
     iSize = HUF_readStats_wksp(
         &mut wksp.huffWeight,
-        (HUF_SYMBOLVALUE_MAX + 1) as size_t,
+        (HUF_SYMBOLVALUE_MAX + 1) as usize,
         &mut wksp.rankVal,
         &mut nbSymbols,
         &mut tableLog,
@@ -440,7 +440,7 @@ fn HUF_decodeStreamX1(
     bitDPtr: &mut BIT_DStream_t,
     dt: &[HUF_DEltX1; 4096],
     dtLog: u32,
-) -> size_t {
+) -> usize {
     let capacity = p.capacity();
 
     if p.capacity() >= 4 {
@@ -478,7 +478,7 @@ fn HUF_decompress1X1_usingDTable_internal_body(
     mut dst: Writer<'_>,
     src: &[u8],
     DTable: &DTable,
-) -> size_t {
+) -> usize {
     let dt = DTable.data.as_x1();
     let dtd = DTable.description;
     let dtLog = dtd.tableLog as u32;
@@ -502,7 +502,7 @@ fn HUF_decompress4X1_usingDTable_internal_body(
     mut dst: Writer<'_>,
     src: &[u8],
     DTable: &DTable,
-) -> size_t {
+) -> usize {
     // strict minimum : jump table + 1 byte per stream.
     let [b0, b1, b2, b3, b4, b5, _, _, _, _, ..] = *src else {
         return Error::corruption_detected.to_error_code();
@@ -551,7 +551,7 @@ fn HUF_decompress4X1_usingDTable_internal_body(
     let dt = DTable.data.as_x1();
     let dtLog = DTable.description.tableLog as u32;
 
-    if w4.capacity() >= size_of::<size_t>() {
+    if w4.capacity() >= size_of::<usize>() {
         while end_signal && w4.capacity() >= 4 {
             if cfg!(target_pointer_width = "64") {
                 w1.write_u8(HUF_decodeSymbolX1(&mut bitD1, dt, dtLog));
@@ -603,7 +603,7 @@ fn HUF_decompress4X1_usingDTable_internal_bmi2(
     dst: Writer<'_>,
     src: &[u8],
     DTable: &DTable,
-) -> size_t {
+) -> usize {
     HUF_decompress4X1_usingDTable_internal_body(dst, src, DTable)
 }
 
@@ -611,7 +611,7 @@ fn HUF_decompress4X1_usingDTable_internal_default(
     dst: Writer<'_>,
     src: &[u8],
     DTable: &DTable,
-) -> size_t {
+) -> usize {
     HUF_decompress4X1_usingDTable_internal_body(dst, src, DTable)
 }
 
@@ -750,7 +750,7 @@ unsafe fn HUF_decompress4X1_usingDTable_internal_fast(
     src: &[u8],
     DTable: &DTable,
     loopFn: HUF_DecompressFastLoopFn,
-) -> size_t {
+) -> usize {
     let oend = dst.as_mut_ptr_range().end;
 
     let mut args = match HUF_DecompressFastArgs::new(dst.subslice(..), src, DTable) {
@@ -806,7 +806,7 @@ fn HUF_decompress1X1_usingDTable_internal_bmi2(
     dst: Writer<'_>,
     src: &[u8],
     DTable: &DTable,
-) -> size_t {
+) -> usize {
     HUF_decompress1X1_usingDTable_internal_body(dst, src, DTable)
 }
 
@@ -814,7 +814,7 @@ fn HUF_decompress1X1_usingDTable_internal_default(
     dst: Writer<'_>,
     src: &[u8],
     DTable: &DTable,
-) -> size_t {
+) -> usize {
     HUF_decompress1X1_usingDTable_internal_body(dst, src, DTable)
 }
 
@@ -823,7 +823,7 @@ fn HUF_decompress1X1_usingDTable_internal(
     src: &[u8],
     DTable: &DTable,
     flags: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     match flags & HUF_flags_bmi2 as i32 {
         0 => HUF_decompress1X1_usingDTable_internal_default(dst, src, DTable),
         _ => unsafe { HUF_decompress1X1_usingDTable_internal_bmi2(dst, src, DTable) },
@@ -835,7 +835,7 @@ fn HUF_decompress4X1_usingDTable_internal(
     src: &[u8],
     DTable: &DTable,
     flags: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     if flags & HUF_flags_bmi2 as core::ffi::c_int != 0 {
         let loopFn = match flags & HUF_flags_disableAsm as i32 {
             #[cfg(all(unix, target_arch = "x86_64"))]
@@ -865,7 +865,7 @@ fn HUF_decompress4X1_DCtx_wksp(
     src: &[u8],
     workSpace: &mut Workspace,
     flags: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let hSize = HUF_readDTableX1_wksp(dctx, src, workSpace, flags);
     if ERR_isError(hSize) {
         return hSize;
@@ -1037,13 +1037,13 @@ pub fn HUF_readDTableX2_wksp(
     src: &[u8],
     wksp: &mut HUF_ReadDTableX2_Workspace,
     flags: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let mut dtd = DTable.description;
 
     let mut tableLog: u32 = 0;
     let mut nbSymbols: u32 = 0;
     let mut maxTableLog = dtd.maxTableLog as u32;
-    let mut iSize: size_t = 0;
+    let mut iSize: usize = 0;
 
     let dt = DTable.data.as_x2_mut();
 
@@ -1057,7 +1057,7 @@ pub fn HUF_readDTableX2_wksp(
 
     iSize = HUF_readStats_wksp(
         &mut wksp.weightList,
-        (HUF_SYMBOLVALUE_MAX + 1) as size_t,
+        (HUF_SYMBOLVALUE_MAX + 1) as usize,
         &mut wksp.rankStats,
         &mut nbSymbols,
         &mut tableLog,
@@ -1216,7 +1216,7 @@ fn HUF_decodeStreamX2(
     bitDPtr: &mut BIT_DStream_t,
     dt: &[HUF_DEltX2; 4096],
     dtLog: u32,
-) -> size_t {
+) -> usize {
     let capacity = p.capacity();
 
     /* up to 8 symbols at a time */
@@ -1267,7 +1267,7 @@ fn HUF_decompress1X2_usingDTable_internal_body(
     mut dst: Writer<'_>,
     src: &[u8],
     DTable: &DTable,
-) -> size_t {
+) -> usize {
     let mut bitD = match BIT_DStream_t::new(src) {
         Ok(v) => v,
         Err(e) => return e.to_error_code(),
@@ -1288,7 +1288,7 @@ fn HUF_decompress4X2_usingDTable_internal_body(
     mut dst: Writer<'_>,
     src: &[u8],
     DTable: &DTable,
-) -> size_t {
+) -> usize {
     // Strict minimum : jump table + 1 byte per stream.
     let [b0, b1, b2, b3, b4, b5, _, _, _, _, ..] = *src else {
         return Error::corruption_detected.to_error_code();
@@ -1430,7 +1430,7 @@ fn HUF_decompress4X2_usingDTable_internal_bmi2(
     dst: Writer<'_>,
     src: &[u8],
     DTable: &DTable,
-) -> size_t {
+) -> usize {
     HUF_decompress4X2_usingDTable_internal_body(dst, src, DTable)
 }
 
@@ -1438,7 +1438,7 @@ fn HUF_decompress4X2_usingDTable_internal_default(
     dst: Writer<'_>,
     src: &[u8],
     DTable: &DTable,
-) -> size_t {
+) -> usize {
     HUF_decompress4X2_usingDTable_internal_body(dst, src, DTable)
 }
 
@@ -1584,7 +1584,7 @@ unsafe fn HUF_decompress4X2_usingDTable_internal_fast(
     src: &[u8],
     DTable: &DTable,
     loopFn: HUF_DecompressFastLoopFn,
-) -> size_t {
+) -> usize {
     let oend = dst.as_mut_ptr_range().end;
 
     let mut args = match HUF_DecompressFastArgs::new(dst.subslice(..), src, DTable) {
@@ -1642,7 +1642,7 @@ fn HUF_decompress4X2_usingDTable_internal(
     src: &[u8],
     DTable: &DTable,
     flags: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     if flags & HUF_flags_bmi2 as core::ffi::c_int != 0 {
         let loopFn = match flags & HUF_flags_disableAsm as core::ffi::c_int {
             #[cfg(all(unix, target_arch = "x86_64"))]
@@ -1670,14 +1670,14 @@ fn HUF_decompress1X2_usingDTable_internal_bmi2(
     dst: Writer<'_>,
     src: &[u8],
     DTable: &DTable,
-) -> size_t {
+) -> usize {
     HUF_decompress1X2_usingDTable_internal_body(dst, src, DTable)
 }
 fn HUF_decompress1X2_usingDTable_internal_default(
     dst: Writer<'_>,
     src: &[u8],
     DTable: &DTable,
-) -> size_t {
+) -> usize {
     HUF_decompress1X2_usingDTable_internal_body(dst, src, DTable)
 }
 
@@ -1686,7 +1686,7 @@ fn HUF_decompress1X2_usingDTable_internal(
     src: &[u8],
     DTable: &DTable,
     flags: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     if flags & HUF_flags_bmi2 as core::ffi::c_int != 0 {
         HUF_decompress1X2_usingDTable_internal_bmi2(dst, src, DTable)
     } else {
@@ -1700,7 +1700,7 @@ pub fn HUF_decompress1X2_DCtx_wksp(
     src: &[u8],
     workSpace: &mut Workspace,
     flags: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let hSize = HUF_readDTableX2_wksp(dctx, src, workSpace.as_x2_mut(), flags);
     if ERR_isError(hSize) {
         return hSize;
@@ -1718,7 +1718,7 @@ fn HUF_decompress4X2_DCtx_wksp(
     src: &[u8],
     workSpace: &mut Workspace,
     flags: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let hSize = HUF_readDTableX2_wksp(dctx, src, workSpace.as_x2_mut(), flags);
     if ERR_isError(hSize) {
         return hSize;
@@ -1992,7 +1992,7 @@ pub fn HUF_decompress1X_usingDTable(
     src: &[u8],
     DTable: &DTable,
     flags: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     match DTable.description.tableType {
         0 => HUF_decompress1X1_usingDTable_internal(dst, src, DTable, flags),
         _ => HUF_decompress1X2_usingDTable_internal(dst, src, DTable, flags),
@@ -2005,7 +2005,7 @@ pub fn HUF_decompress1X1_DCtx_wksp(
     src: &[u8],
     workSpace: &mut Workspace,
     flags: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let hSize = { HUF_readDTableX1_wksp(dctx, src, workSpace, flags) };
     if ERR_isError(hSize) {
         return hSize;
@@ -2022,7 +2022,7 @@ pub fn HUF_decompress4X_usingDTable(
     src: &[u8],
     DTable: &DTable,
     flags: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     match DTable.description.tableType {
         0 => HUF_decompress4X1_usingDTable_internal(dst, src, DTable, flags),
         _ => HUF_decompress4X2_usingDTable_internal(dst, src, DTable, flags),
@@ -2035,7 +2035,7 @@ pub fn HUF_decompress4X_hufOnly_wksp(
     src: &[u8],
     workSpace: &mut Workspace,
     flags: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     if dst.is_empty() {
         return Error::dstSize_tooSmall.to_error_code();
     }

--- a/lib/decompress/mod.rs
+++ b/lib/decompress/mod.rs
@@ -1,5 +1,5 @@
 use core::ptr::NonNull;
-use libc::size_t;
+
 
 use crate::lib::common::xxhash::XXH64_state_t;
 
@@ -247,7 +247,7 @@ pub struct ZSTD_DCtx_s {
     prefixStart: *const core::ffi::c_void,
     virtualStart: *const core::ffi::c_void,
     dictEnd: *const core::ffi::c_void,
-    expected: size_t,
+    expected: usize,
     fParams: ZSTD_FrameHeader,
     processedCSize: u64,
     decodedSize: u64,
@@ -258,7 +258,7 @@ pub struct ZSTD_DCtx_s {
     fseEntropy: bool,
     _padding1: [u8; 3],
     xxhState: XXH64_state_t,
-    headerSize: size_t,
+    headerSize: usize,
     format: Format,
     forceIgnoreChecksum: ForceIgnoreChecksum,
     _padding5: [u8; 3],
@@ -266,9 +266,9 @@ pub struct ZSTD_DCtx_s {
     _padding4: [u8; 3],
     litPtr: *const u8,
     customMem: ZSTD_customMem,
-    litSize: size_t,
-    rleSize: size_t,
-    staticSize: size_t,
+    litSize: usize,
+    rleSize: usize,
+    staticSize: usize,
     isFrameDecompression: bool,
     _padding7: [u8; 3],
     bmi2: bool,
@@ -288,14 +288,14 @@ pub struct ZSTD_DCtx_s {
 
     // The fields below are part of the workspace and not copied by `ZSTD_copyDCtx`.
     inBuff: *mut u8,
-    inBuffSize: size_t,
-    inPos: size_t,
-    maxWindowSize: size_t,
+    inBuffSize: usize,
+    inPos: usize,
+    maxWindowSize: usize,
     outBuff: *mut u8,
-    outBuffSize: size_t,
-    outStart: size_t,
-    outEnd: size_t,
-    lhSize: size_t,
+    outBuffSize: usize,
+    outStart: usize,
+    outEnd: usize,
+    lhSize: usize,
     legacyContext: *mut core::ffi::c_void,
     previousLegacyVersion: u32,
     legacyVersion: u32,
@@ -309,6 +309,6 @@ pub struct ZSTD_DCtx_s {
     // literal buffer can be split between storage within dst and within this scratch buffer.
     litExtraBuffer: [u8; ZSTD_LITBUFFEREXTRASIZE + WILDCOPY_OVERLENGTH],
     headerBuffer: [u8; 18],
-    oversizedDuration: size_t,
+    oversizedDuration: usize,
     traceCtx: ZSTD_TraceCtx,
 }

--- a/lib/decompress/zstd_ddict.rs
+++ b/lib/decompress/zstd_ddict.rs
@@ -1,6 +1,6 @@
 use core::mem::MaybeUninit;
 use core::ptr::NonNull;
-use libc::size_t;
+
 
 use crate::lib::common::allocations::{ZSTD_customFree, ZSTD_customMalloc};
 use crate::lib::common::error_private::{ERR_isError, Error};
@@ -34,8 +34,8 @@ impl TryFrom<u32> for MultipleDDicts {
 #[repr(C)]
 pub struct ZSTD_DDictHashSet {
     pub ddictPtrTable: *mut *const ZSTD_DDict,
-    pub ddictPtrTableSize: size_t,
-    pub ddictPtrCount: size_t,
+    pub ddictPtrTableSize: usize,
+    pub ddictPtrCount: usize,
 }
 
 impl ZSTD_DDictHashSet {
@@ -48,7 +48,7 @@ impl ZSTD_DDictHashSet {
 pub struct ZSTD_DDict {
     dictBuffer: *mut core::ffi::c_void,
     dictContent: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     entropy: ZSTD_entropyDTables_t,
     pub(crate) dictID: u32,
     entropyPresent: u32,
@@ -77,7 +77,7 @@ pub fn ZSTD_DDict_dictContent(ddict: &ZSTD_DDict) -> *const core::ffi::c_void {
     ddict.dictContent
 }
 
-pub fn ZSTD_DDict_dictSize(ddict: &ZSTD_DDict) -> size_t {
+pub fn ZSTD_DDict_dictSize(ddict: &ZSTD_DDict) -> usize {
     ddict.dictSize
 }
 
@@ -158,7 +158,7 @@ fn ZSTD_loadEntropy_intoDDict(
 fn ZSTD_initDDict_internal(
     ddict: &mut ZSTD_DDict,
     dict: *const core::ffi::c_void,
-    mut dictSize: size_t,
+    mut dictSize: usize,
     dictLoadMethod: ZSTD_dictLoadMethod_e,
     dictContentType: ZSTD_dictContentType_e,
 ) -> Result<(), Error> {
@@ -194,7 +194,7 @@ fn ZSTD_initDDict_internal(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_createDDict_advanced))]
 pub unsafe extern "C" fn ZSTD_createDDict_advanced(
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     dictLoadMethod: ZSTD_dictLoadMethod_e,
     dictContentType: ZSTD_dictContentType_e,
     customMem: ZSTD_customMem,
@@ -236,7 +236,7 @@ pub unsafe extern "C" fn ZSTD_createDDict_advanced(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_createDDict))]
 pub unsafe extern "C" fn ZSTD_createDDict(
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
 ) -> *mut ZSTD_DDict {
     ZSTD_createDDict_advanced(
         dict,
@@ -254,7 +254,7 @@ pub unsafe extern "C" fn ZSTD_createDDict(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_createDDict_byReference))]
 pub unsafe extern "C" fn ZSTD_createDDict_byReference(
     dictBuffer: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
 ) -> *mut ZSTD_DDict {
     ZSTD_createDDict_advanced(
         dictBuffer,
@@ -268,9 +268,9 @@ pub unsafe extern "C" fn ZSTD_createDDict_byReference(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_initStaticDDict))]
 pub unsafe extern "C" fn ZSTD_initStaticDDict(
     sBuffer: *mut core::ffi::c_void,
-    sBufferSize: size_t,
+    sBufferSize: usize,
     mut dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     dictLoadMethod: ZSTD_dictLoadMethod_e,
     dictContentType: ZSTD_dictContentType_e,
 ) -> *const ZSTD_DDict {
@@ -311,7 +311,7 @@ pub unsafe extern "C" fn ZSTD_initStaticDDict(
 ///
 /// If a NULL pointer is passed, no operation is performed.
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_freeDDict))]
-pub unsafe extern "C" fn ZSTD_freeDDict(ddict: *mut ZSTD_DDict) -> size_t {
+pub unsafe extern "C" fn ZSTD_freeDDict(ddict: *mut ZSTD_DDict) -> usize {
     if ddict.is_null() {
         return 0;
     }
@@ -330,9 +330,9 @@ pub unsafe extern "C" fn ZSTD_freeDDict(ddict: *mut ZSTD_DDict) -> size_t {
 /// Note: dictionary created by reference using [`ZSTD_dlm_byRef`] are smaller
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_estimateDDictSize))]
 pub const extern "C" fn ZSTD_estimateDDictSize(
-    dict_size: size_t,
+    dict_size: usize,
     dict_load_method: ZSTD_dictLoadMethod_e,
-) -> size_t {
+) -> usize {
     if dict_load_method == ZSTD_dlm_byRef as ZSTD_dictLoadMethod_e {
         size_of::<ZSTD_DDict>()
     } else {
@@ -347,7 +347,7 @@ pub const extern "C" fn ZSTD_estimateDDictSize(
 /// - the size of the [`ZSTD_DDict`], including the size of the [`ZSTD_DDict`]'s `dictBuffer` if present
 /// - 0 if the `ddict` is NULL
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_sizeof_DDict))]
-pub unsafe extern "C" fn ZSTD_sizeof_DDict(ddict: *const ZSTD_DDict) -> size_t {
+pub unsafe extern "C" fn ZSTD_sizeof_DDict(ddict: *const ZSTD_DDict) -> usize {
     if ddict.is_null() {
         return 0;
     }

--- a/lib/decompress/zstd_decompress.rs
+++ b/lib/decompress/zstd_decompress.rs
@@ -2,7 +2,7 @@ use core::ffi::c_char;
 use core::mem::MaybeUninit;
 use core::ptr::{self, NonNull};
 
-use libc::size_t;
+
 
 use crate::lib::common::allocations::{ZSTD_customCalloc, ZSTD_customFree, ZSTD_customMalloc};
 use crate::lib::common::entropy_common::FSE_readNCount_slice;
@@ -92,14 +92,14 @@ pub const XXH_OK: XXH_errorcode = 0;
 #[derive(Default)]
 #[repr(C)]
 pub struct ZSTD_frameSizeInfo {
-    pub nbBlocks: size_t,
-    pub compressedSize: size_t,
+    pub nbBlocks: usize,
+    pub compressedSize: usize,
     pub decompressedBound: core::ffi::c_ulonglong,
 }
 
 #[repr(C)]
 pub struct ZSTD_bounds {
-    pub error: size_t,
+    pub error: usize,
     pub lowerBound: core::ffi::c_int,
     pub upperBound: core::ffi::c_int,
 }
@@ -194,7 +194,7 @@ fn ZSTD_decompressLegacy(
     mut dst: Writer<'_>,
     src: Reader<'_>,
     dict: &[u8],
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let version = is_legacy(src.as_slice());
     let dstCapacity = dst.capacity();
 
@@ -225,7 +225,7 @@ fn ZSTD_decompressLegacy(
                 src.as_ptr() as *const core::ffi::c_void
             };
 
-            let mut result: size_t = 0;
+            let mut result: usize = 0;
             let zd = unsafe { ZSTDv06_createDCtx() };
             if zd.is_null() {
                 return Err(Error::memory_allocation);
@@ -315,7 +315,7 @@ fn find_frame_size_info_legacy(src: &[u8]) -> Result<ZSTD_frameSizeInfo, Error> 
     if frameSizeInfo.decompressedBound != ZSTD_CONTENTSIZE_ERROR {
         frameSizeInfo.nbBlocks = (frameSizeInfo.decompressedBound)
             .wrapping_div(ZSTD_BLOCKSIZE_MAX as core::ffi::c_ulonglong)
-            as size_t;
+            as usize;
     }
 
     Ok(frameSizeInfo)
@@ -325,7 +325,7 @@ fn find_frame_size_info_legacy(src: &[u8]) -> Result<ZSTD_frameSizeInfo, Error> 
 unsafe fn ZSTD_freeLegacyStreamContext(
     legacyContext: *mut core::ffi::c_void,
     version: u32,
-) -> size_t {
+) -> usize {
     match version {
         5 => ZBUFFv05_freeDCtx(legacyContext as *mut ZBUFFv05_DCtx),
         6 => ZBUFFv06_freeDCtx(legacyContext as *mut ZBUFFv06_DCtx),
@@ -339,8 +339,8 @@ unsafe fn ZSTD_initLegacyStream(
     prevVersion: u32,
     newVersion: u32,
     mut dict: *const core::ffi::c_void,
-    dictSize: size_t,
-) -> size_t {
+    dictSize: usize,
+) -> usize {
     let mut x: core::ffi::c_char = 0;
     if dict.is_null() {
         dict = &mut x as *mut core::ffi::c_char as *const core::ffi::c_void;
@@ -405,7 +405,7 @@ unsafe fn ZSTD_decompressLegacyStream(
     version: u32,
     output: &mut ZSTD_outBuffer,
     input: &mut ZSTD_inBuffer,
-) -> size_t {
+) -> usize {
     static mut x: core::ffi::c_char = 0;
     if (output.dst).is_null() {
         output.dst = &raw mut x as *mut core::ffi::c_void;
@@ -479,10 +479,10 @@ pub const DDICT_HASHSET_RESIZE_FACTOR: core::ffi::c_int = 2;
 /// # Returns
 ///
 /// - an index between `0..hashSet.ddictPtrTableSize`
-fn ZSTD_DDictHashSet_getIndex(hashSet: &ZSTD_DDictHashSet, dictID: u32) -> size_t {
+fn ZSTD_DDictHashSet_getIndex(hashSet: &ZSTD_DDictHashSet, dictID: u32) -> usize {
     let hash = ZSTD_XXH64_slice(&dictID.to_ne_bytes(), 0);
     // `ddictPtrTableSize` is a multiple of 2, use `size - 1` as a mask to get an index within `0..hashSet.ddictPtrTableSize`
-    hash as size_t & (hashSet.ddictPtrTableSize).wrapping_sub(1)
+    hash as usize & (hashSet.ddictPtrTableSize).wrapping_sub(1)
 }
 
 /// Adds [`ZSTD_DDict`] to a hashset without resizing it.
@@ -491,7 +491,7 @@ fn ZSTD_DDictHashSet_getIndex(hashSet: &ZSTD_DDictHashSet, dictID: u32) -> size_
 unsafe fn ZSTD_DDictHashSet_emplaceDDict(
     hashSet: &mut ZSTD_DDictHashSet,
     ddict: *const ZSTD_DDict,
-) -> size_t {
+) -> usize {
     let dictID = ZSTD_getDictID_fromDDict(ddict);
     let mut idx = ZSTD_DDictHashSet_getIndex(hashSet, dictID);
     let idxRangeMask = (hashSet.ddictPtrTableSize).wrapping_sub(1);
@@ -518,15 +518,15 @@ unsafe fn ZSTD_DDictHashSet_emplaceDDict(
 unsafe fn ZSTD_DDictHashSet_expand(
     hashSet: &mut ZSTD_DDictHashSet,
     customMem: ZSTD_customMem,
-) -> size_t {
-    let newTableSize = hashSet.ddictPtrTableSize * DDICT_HASHSET_RESIZE_FACTOR as size_t;
+) -> usize {
+    let newTableSize = hashSet.ddictPtrTableSize * DDICT_HASHSET_RESIZE_FACTOR as usize;
     let newTable = ZSTD_customCalloc(
         (::core::mem::size_of::<*mut ZSTD_DDict>()).wrapping_mul(newTableSize),
         customMem,
     ) as *mut *const ZSTD_DDict;
     let oldTable = hashSet.ddictPtrTable;
     let oldTableSize = hashSet.ddictPtrTableSize;
-    let mut i: size_t = 0;
+    let mut i: usize = 0;
     if newTable.is_null() {
         return Error::memory_allocation.to_error_code();
     }
@@ -565,11 +565,11 @@ unsafe fn ZSTD_DDictHashSet_getDDict(
     let idxRangeMask = hashSet.ddictPtrTableSize - 1;
     loop {
         let currDictID = match hashSet.as_slice()[idx].as_ref() {
-            Some(ddict) => ddict.dictID as size_t,
+            Some(ddict) => ddict.dictID as usize,
             None => 0,
         };
 
-        if currDictID == dictID as size_t || currDictID == 0 {
+        if currDictID == dictID as usize || currDictID == 0 {
             // currDictID == 0 implies a NULL ddict entry
             break;
         }
@@ -595,7 +595,7 @@ unsafe fn ZSTD_createDDictHashSet(customMem: ZSTD_customMem) -> *mut ZSTD_DDictH
         return core::ptr::null_mut();
     }
     (*ret).ddictPtrTable = ZSTD_customCalloc(
-        (DDICT_HASHSET_TABLE_BASE_SIZE as size_t)
+        (DDICT_HASHSET_TABLE_BASE_SIZE as usize)
             .wrapping_mul(::core::mem::size_of::<*mut ZSTD_DDict>()),
         customMem,
     ) as *mut *const ZSTD_DDict;
@@ -607,7 +607,7 @@ unsafe fn ZSTD_createDDictHashSet(customMem: ZSTD_customMem) -> *mut ZSTD_DDictH
         );
         return core::ptr::null_mut();
     }
-    (*ret).ddictPtrTableSize = DDICT_HASHSET_TABLE_BASE_SIZE as size_t;
+    (*ret).ddictPtrTableSize = DDICT_HASHSET_TABLE_BASE_SIZE as usize;
     (*ret).ddictPtrCount = 0;
     ret
 }
@@ -639,10 +639,10 @@ unsafe fn ZSTD_DDictHashSet_addDDict(
     hashSet: &mut ZSTD_DDictHashSet,
     ddict: *const ZSTD_DDict,
     customMem: ZSTD_customMem,
-) -> size_t {
-    if hashSet.ddictPtrCount * DDICT_HASHSET_MAX_LOAD_FACTOR_COUNT_MULT as size_t
+) -> usize {
+    if hashSet.ddictPtrCount * DDICT_HASHSET_MAX_LOAD_FACTOR_COUNT_MULT as usize
         / hashSet.ddictPtrTableSize
-        * DDICT_HASHSET_MAX_LOAD_FACTOR_SIZE_MULT as size_t
+        * DDICT_HASHSET_MAX_LOAD_FACTOR_SIZE_MULT as usize
         != 0
     {
         let err_code = ZSTD_DDictHashSet_expand(hashSet, customMem);
@@ -664,7 +664,7 @@ unsafe fn ZSTD_DDictHashSet_addDDict(
 /// - the size of the decompression context, including the size of its internal buffers
 /// - 0 if the `dctx` is NULL
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_sizeof_DCtx))]
-pub unsafe extern "C" fn ZSTD_sizeof_DCtx(dctx: *const ZSTD_DCtx) -> size_t {
+pub unsafe extern "C" fn ZSTD_sizeof_DCtx(dctx: *const ZSTD_DCtx) -> usize {
     if dctx.is_null() {
         return 0;
     }
@@ -678,7 +678,7 @@ pub unsafe extern "C" fn ZSTD_sizeof_DCtx(dctx: *const ZSTD_DCtx) -> size_t {
 ///
 /// This is useful in combination with [`ZSTD_initStaticDCtx`]
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_estimateDCtxSize))]
-pub const extern "C" fn ZSTD_estimateDCtxSize() -> size_t {
+pub const extern "C" fn ZSTD_estimateDCtxSize() -> usize {
     size_of::<ZSTD_DCtx>()
 }
 
@@ -687,7 +687,7 @@ fn ZSTD_DCtx_resetParameters(dctx: &mut MaybeUninit<ZSTD_DCtx>) {
         let dctx = dctx.as_mut_ptr();
         debug_assert_eq!((*dctx).streamStage, StreamStage::Init);
         (*dctx).format = Format::ZSTD_f_zstd1;
-        (*dctx).maxWindowSize = ZSTD_MAXWINDOWSIZE_DEFAULT as size_t;
+        (*dctx).maxWindowSize = ZSTD_MAXWINDOWSIZE_DEFAULT as usize;
         (*dctx).outBufferMode = BufferMode::Buffered;
         (*dctx).forceIgnoreChecksum = ForceIgnoreChecksum::ValidateChecksum;
         (*dctx).refMultipleDDicts = MultipleDDicts::Single;
@@ -749,10 +749,10 @@ fn ZSTD_initDCtx_internal(dctx: &mut MaybeUninit<ZSTD_DCtx>) {
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_initStaticDCtx))]
 pub unsafe extern "C" fn ZSTD_initStaticDCtx(
     workspace: *mut core::ffi::c_void,
-    workspaceSize: size_t,
+    workspaceSize: usize,
 ) -> *mut ZSTD_DCtx {
     // workspace should be 8-aligned
-    if workspace as size_t & 7 != 0 {
+    if workspace as usize & 7 != 0 {
         return core::ptr::null_mut();
     }
 
@@ -809,7 +809,7 @@ unsafe fn ZSTD_clearDict(dctx: *mut ZSTD_DCtx) {
 
 /// Free a decompression context from memory
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_freeDCtx))]
-pub unsafe extern "C" fn ZSTD_freeDCtx(dctx: *mut ZSTD_DCtx) -> size_t {
+pub unsafe extern "C" fn ZSTD_freeDCtx(dctx: *mut ZSTD_DCtx) -> usize {
     if dctx.is_null() {
         return 0;
     }
@@ -884,7 +884,7 @@ fn ZSTD_DCtx_selectFrameDDict(dctx: &mut ZSTD_DCtx) {
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_isFrame))]
 pub unsafe extern "C" fn ZSTD_isFrame(
     buffer: *const core::ffi::c_void,
-    size: size_t,
+    size: usize,
 ) -> core::ffi::c_uint {
     let src = if buffer.is_null() {
         &[]
@@ -922,7 +922,7 @@ fn is_frame(src: &[u8]) -> bool {
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_isSkippableFrame))]
 pub unsafe extern "C" fn ZSTD_isSkippableFrame(
     buffer: *const core::ffi::c_void,
-    size: size_t,
+    size: usize,
 ) -> core::ffi::c_uint {
     let src = if buffer.is_null() {
         &[]
@@ -977,8 +977,8 @@ fn frame_header_size_internal(src: &[u8], format: Format) -> Result<usize, Error
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_frameHeaderSize))]
 pub unsafe extern "C" fn ZSTD_frameHeaderSize(
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let src = if src.is_null() {
         &[]
     } else {
@@ -1001,12 +1001,12 @@ pub unsafe extern "C" fn ZSTD_frameHeaderSize(
 pub unsafe extern "C" fn ZSTD_getFrameHeader(
     zfhPtr: *mut ZSTD_FrameHeader,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_getFrameHeader_advanced(zfhPtr, src, srcSize, ZSTD_format_e::ZSTD_f_zstd1)
 }
 
-fn get_frame_header(zfhPtr: &mut ZSTD_FrameHeader, src: &[u8]) -> Result<size_t, Error> {
+fn get_frame_header(zfhPtr: &mut ZSTD_FrameHeader, src: &[u8]) -> Result<usize, Error> {
     get_frame_header_advanced(zfhPtr, src, Format::ZSTD_f_zstd1)
 }
 
@@ -1021,9 +1021,9 @@ fn get_frame_header(zfhPtr: &mut ZSTD_FrameHeader, src: &[u8]) -> Result<size_t,
 pub unsafe extern "C" fn ZSTD_getFrameHeader_advanced(
     zfhPtr: *mut ZSTD_FrameHeader,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     format: ZSTD_format_e,
-) -> size_t {
+) -> usize {
     // Apparently some sanitizers require this?
     unsafe { zfhPtr.write(ZSTD_FrameHeader::default()) };
 
@@ -1056,7 +1056,7 @@ fn get_frame_header_advanced(
     zfhPtr: &mut ZSTD_FrameHeader,
     src: &[u8],
     format: Format,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let minInputSize = format.starting_input_length();
     if src.len() < minInputSize {
         // error out early if magic number is invalid
@@ -1079,7 +1079,7 @@ fn get_frame_header_advanced(
     {
         if is_skippable_frame(src) {
             if src.len() < ZSTD_SKIPPABLEHEADERSIZE as usize {
-                return Ok(ZSTD_SKIPPABLEHEADERSIZE as size_t);
+                return Ok(ZSTD_SKIPPABLEHEADERSIZE as usize);
             }
 
             let first_word = u32::from_le_bytes(*src.first_chunk().unwrap());
@@ -1221,7 +1221,7 @@ fn get_frame_header_advanced(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_getFrameContentSize))]
 pub unsafe extern "C" fn ZSTD_getFrameContentSize(
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
 ) -> core::ffi::c_ulonglong {
     let src = if src.is_null() {
         &[]
@@ -1252,7 +1252,7 @@ fn get_frame_content_size(src: &[u8]) -> u64 {
     }
 }
 
-fn read_skippable_frame_size(src: &[u8]) -> Result<size_t, Error> {
+fn read_skippable_frame_size(src: &[u8]) -> Result<usize, Error> {
     let [_, _, _, _, a, b, c, d, ..] = *src else {
         return Err(Error::srcSize_wrong);
     };
@@ -1284,11 +1284,11 @@ fn read_skippable_frame_size(src: &[u8]) -> Result<size_t, Error> {
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_readSkippableFrame))]
 pub unsafe extern "C" fn ZSTD_readSkippableFrame(
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     magicVariant: *mut core::ffi::c_uint,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     if srcSize < 8 || src.is_null() {
         return Error::srcSize_wrong.to_error_code();
     }
@@ -1296,7 +1296,7 @@ pub unsafe extern "C" fn ZSTD_readSkippableFrame(
     let skippableFrameSize =
         read_skippable_frame_size(core::slice::from_raw_parts(src.cast(), srcSize))
             .unwrap_or_else(Error::to_error_code);
-    let skippableContentSize = skippableFrameSize.wrapping_sub(ZSTD_SKIPPABLEHEADERSIZE as size_t);
+    let skippableContentSize = skippableFrameSize.wrapping_sub(ZSTD_SKIPPABLEHEADERSIZE as usize);
 
     // check input validity
     if !is_skippable_frame(core::slice::from_raw_parts(src.cast(), srcSize)) {
@@ -1334,7 +1334,7 @@ pub unsafe extern "C" fn ZSTD_readSkippableFrame(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_findDecompressedSize))]
 pub unsafe extern "C" fn ZSTD_findDecompressedSize(
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
 ) -> core::ffi::c_ulonglong {
     let src = if src.is_null() {
         &[]
@@ -1399,7 +1399,7 @@ fn find_decompressed_size(mut src: &[u8]) -> u64 {
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_getDecompressedSize))]
 pub unsafe extern "C" fn ZSTD_getDecompressedSize(
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
 ) -> core::ffi::c_ulonglong {
     let ret = ZSTD_getFrameContentSize(src, srcSize);
     if ret >= ZSTD_CONTENTSIZE_ERROR {
@@ -1414,7 +1414,7 @@ pub unsafe extern "C" fn ZSTD_getDecompressedSize(
 /// If multiple [`ZSTD_DDict`] references are enabled, it will choose the correct [`ZSTD_DDict`] to use.
 ///
 /// `headerSize` must be the size provided by [`ZSTD_frameHeaderSize`]
-fn ZSTD_decodeFrameHeader(dctx: &mut ZSTD_DCtx, src: &[u8]) -> Result<size_t, Error> {
+fn ZSTD_decodeFrameHeader(dctx: &mut ZSTD_DCtx, src: &[u8]) -> Result<usize, Error> {
     let result = get_frame_header_advanced(&mut dctx.fParams, src, dctx.format)?;
     if result > 0 {
         return Err(Error::srcSize_wrong);
@@ -1437,7 +1437,7 @@ fn ZSTD_decodeFrameHeader(dctx: &mut ZSTD_DCtx, src: &[u8]) -> Result<size_t, Er
     if dctx.validateChecksum {
         ZSTD_XXH64_reset(&mut dctx.xxhState, 0);
     }
-    dctx.processedCSize = (dctx.processedCSize as size_t).wrapping_add(src.len()) as u64;
+    dctx.processedCSize = (dctx.processedCSize as usize).wrapping_add(src.len()) as u64;
     Ok(0)
 }
 
@@ -1468,7 +1468,7 @@ fn find_frame_size_info(src: &[u8], format: Format) -> Result<ZSTD_frameSizeInfo
         }
 
         ip += zfh.headerSize as usize;
-        remainingSize = remainingSize.wrapping_sub(zfh.headerSize as size_t);
+        remainingSize = remainingSize.wrapping_sub(zfh.headerSize as usize);
 
         // iterate over each block
         loop {
@@ -1497,7 +1497,7 @@ fn find_frame_size_info(src: &[u8], format: Format) -> Result<ZSTD_frameSizeInfo
         }
 
         frameSizeInfo.nbBlocks = nbBlocks;
-        frameSizeInfo.compressedSize = ip as size_t;
+        frameSizeInfo.compressedSize = ip as usize;
         frameSizeInfo.decompressedBound = if zfh.frameContentSize != ZSTD_CONTENTSIZE_UNKNOWN {
             zfh.frameContentSize
         } else {
@@ -1508,7 +1508,7 @@ fn find_frame_size_info(src: &[u8], format: Format) -> Result<ZSTD_frameSizeInfo
     }
 }
 
-fn ZSTD_findFrameCompressedSize_advanced(src: &[u8], format: Format) -> Result<size_t, Error> {
+fn ZSTD_findFrameCompressedSize_advanced(src: &[u8], format: Format) -> Result<usize, Error> {
     Ok(find_frame_size_info(src, format)?.compressedSize)
 }
 
@@ -1538,8 +1538,8 @@ fn ZSTD_findFrameCompressedSize_advanced(src: &[u8], format: Format) -> Result<s
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_findFrameCompressedSize))]
 pub unsafe extern "C" fn ZSTD_findFrameCompressedSize(
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let src = if src.is_null() {
         &[]
     } else {
@@ -1570,7 +1570,7 @@ pub unsafe extern "C" fn ZSTD_findFrameCompressedSize(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_decompressBound))]
 pub unsafe extern "C" fn ZSTD_decompressBound(
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
 ) -> core::ffi::c_ulonglong {
     decompress_bound(if src.is_null() {
         &[]
@@ -1623,8 +1623,8 @@ fn decompress_bound(mut src: &[u8]) -> core::ffi::c_ulonglong {
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_decompressionMargin))]
 pub unsafe extern "C" fn ZSTD_decompressionMargin(
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     decompression_margin(if src.is_null() {
         &[]
     } else {
@@ -1633,7 +1633,7 @@ pub unsafe extern "C" fn ZSTD_decompressionMargin(
     .unwrap_or_else(|err| err.to_error_code())
 }
 
-fn decompression_margin(mut src: &[u8]) -> Result<size_t, Error> {
+fn decompression_margin(mut src: &[u8]) -> Result<usize, Error> {
     let mut margin = 0;
     let mut maxBlockSize = 0;
 
@@ -1649,7 +1649,7 @@ fn decompression_margin(mut src: &[u8]) -> Result<size_t, Error> {
 
         if zfh.frameType as core::ffi::c_uint == ZSTD_frame as core::ffi::c_uint {
             // add the frame header to our margin
-            margin += zfh.headerSize as size_t;
+            margin += zfh.headerSize as usize;
             margin += if zfh.checksumFlag != 0 { 4 } else { 0 };
             margin += 3 * frameSizeInfo.nbBlocks;
             maxBlockSize = Ord::max(maxBlockSize, zfh.blockSizeMax)
@@ -1663,7 +1663,7 @@ fn decompression_margin(mut src: &[u8]) -> Result<size_t, Error> {
     }
 
     // add the max block size back to the margin
-    margin += maxBlockSize as size_t;
+    margin += maxBlockSize as usize;
 
     Ok(margin)
 }
@@ -1673,15 +1673,15 @@ fn decompression_margin(mut src: &[u8]) -> Result<size_t, Error> {
 pub unsafe extern "C" fn ZSTD_insertBlock(
     dctx: *mut ZSTD_DCtx,
     blockStart: *const core::ffi::c_void,
-    blockSize: size_t,
-) -> size_t {
+    blockSize: usize,
+) -> usize {
     let src = Reader::from_raw_parts(blockStart.cast::<u8>(), blockSize);
     ZSTD_checkContinuity(dctx.as_mut().unwrap(), src.as_ptr_range());
     (*dctx).previousDstEnd = (blockStart).byte_add(blockSize);
     blockSize
 }
 
-fn copy_raw_block_slice(mut dst: Writer<'_>, src: &[u8]) -> Result<size_t, Error> {
+fn copy_raw_block_slice(mut dst: Writer<'_>, src: &[u8]) -> Result<usize, Error> {
     if src.len() > dst.capacity() {
         return Err(Error::dstSize_tooSmall);
     }
@@ -1698,7 +1698,7 @@ fn copy_raw_block_slice(mut dst: Writer<'_>, src: &[u8]) -> Result<size_t, Error
     Ok(src.len())
 }
 
-fn copy_raw_block_reader(mut dst: Writer<'_>, src: Reader<'_>) -> Result<size_t, Error> {
+fn copy_raw_block_reader(mut dst: Writer<'_>, src: Reader<'_>) -> Result<usize, Error> {
     if src.len() > dst.capacity() {
         return Err(Error::dstSize_tooSmall);
     }
@@ -1716,7 +1716,7 @@ fn copy_raw_block_reader(mut dst: Writer<'_>, src: Reader<'_>) -> Result<size_t,
     Ok(src.len())
 }
 
-fn ZSTD_setRleBlock(mut dst: Writer<'_>, b: u8, regenSize: size_t) -> Result<size_t, Error> {
+fn ZSTD_setRleBlock(mut dst: Writer<'_>, b: u8, regenSize: usize) -> Result<usize, Error> {
     if regenSize > dst.capacity() {
         return Err(Error::dstSize_tooSmall);
     }
@@ -1748,8 +1748,8 @@ fn ZSTD_DCtx_trace_end(
             trace.dictionarySize = ZSTD_DDict_dictSize(ddict);
             trace.dictionaryIsCold = dctx.ddictIsCold;
         }
-        trace.uncompressedSize = uncompressedSize as size_t;
-        trace.compressedSize = compressedSize as size_t;
+        trace.uncompressedSize = uncompressedSize as usize;
+        trace.compressedSize = compressedSize as usize;
         trace.dctx = dctx;
         ZSTD_trace_decompress_end(dctx.traceCtx, &trace);
     }
@@ -1762,7 +1762,7 @@ unsafe fn ZSTD_decompressFrame(
     dctx: &mut ZSTD_DCtx,
     dst: Writer<'_>,
     srcPtr: &mut Reader<'_>,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let ilen = srcPtr.len();
     let ip = srcPtr;
 
@@ -1826,16 +1826,16 @@ unsafe fn ZSTD_decompressFrame(
                 copy_raw_block_reader(op.subslice(..), ip.subslice(..cBlockSize))?
             }
             BlockType::Rle => {
-                let capacity = oBlockEnd.offset_from(op.as_mut_ptr()) as size_t;
+                let capacity = oBlockEnd.offset_from(op.as_mut_ptr()) as usize;
                 ZSTD_setRleBlock(
                     op.subslice(..capacity),
                     ip.as_slice()[0],
-                    blockProperties.origSize as size_t,
+                    blockProperties.origSize as usize,
                 )?
             }
             BlockType::Compressed => {
                 debug_assert!(dctx.isFrameDecompression);
-                let capacity = oBlockEnd.offset_from(op.as_mut_ptr()) as size_t;
+                let capacity = oBlockEnd.offset_from(op.as_mut_ptr()) as usize;
                 ZSTD_decompressBlock_internal_help(
                     dctx,
                     op.subslice(..capacity),
@@ -1901,7 +1901,7 @@ unsafe fn ZSTD_decompressMultiFrame<'a>(
     mut src: Reader<'_>,
     mut dict: &'a [u8],
     ddict: Option<&'a ZSTD_DDict>,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let start_capacity = dst.capacity();
     let mut more_than_one_frame = false;
 
@@ -1977,12 +1977,12 @@ unsafe fn ZSTD_decompressMultiFrame<'a>(
 pub unsafe extern "C" fn ZSTD_decompress_usingDict(
     dctx: *mut ZSTD_DCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
-) -> size_t {
+    dictSize: usize,
+) -> usize {
     // It is valid for src and dst to overlap.
     let src = Reader::from_raw_parts(src.cast::<u8>(), srcSize);
     let dst = Writer::from_raw_parts(dst.cast::<u8>(), dstCapacity);
@@ -2017,10 +2017,10 @@ unsafe fn ZSTD_getDDict(dctx: *mut ZSTD_DCtx) -> *const ZSTD_DDict {
 pub unsafe extern "C" fn ZSTD_decompressDCtx(
     dctx: *mut ZSTD_DCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     ZSTD_decompress_usingDDict(dctx, dst, dstCapacity, src, srcSize, ZSTD_getDDict(dctx))
 }
 
@@ -2041,11 +2041,11 @@ pub unsafe extern "C" fn ZSTD_decompressDCtx(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_decompress))]
 pub unsafe extern "C" fn ZSTD_decompress(
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
-    let mut regenSize: size_t = 0;
+    srcSize: usize,
+) -> usize {
+    let mut regenSize: usize = 0;
     let dctx = ZSTD_createDCtx_internal(ZSTD_customMem::default());
     if dctx.is_null() {
         return Error::memory_allocation.to_error_code();
@@ -2063,7 +2063,7 @@ pub unsafe extern "C" fn ZSTD_decompress(
 /// - 0 if a frame is fully decoded, in which case the context can be reset to start a new
 ///   decompression
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_nextSrcSizeToDecompress))]
-pub unsafe extern "C" fn ZSTD_nextSrcSizeToDecompress(dctx: *mut ZSTD_DCtx) -> size_t {
+pub unsafe extern "C" fn ZSTD_nextSrcSizeToDecompress(dctx: *mut ZSTD_DCtx) -> usize {
     (*dctx).expected
 }
 
@@ -2073,7 +2073,7 @@ pub unsafe extern "C" fn ZSTD_nextSrcSizeToDecompress(dctx: *mut ZSTD_DCtx) -> s
 ///
 /// For blocks that can be streamed, this allows us to reduce the latency until we produce
 /// output, and avoid copying the input.
-fn ZSTD_nextSrcSizeToDecompressWithInputSize(dctx: &mut ZSTD_DCtx, inputSize: size_t) -> size_t {
+fn ZSTD_nextSrcSizeToDecompressWithInputSize(dctx: &mut ZSTD_DCtx, inputSize: usize) -> usize {
     match dctx.stage {
         DecompressStage::DecompressBlock | DecompressStage::DecompressLastBlock => {
             if dctx.bType != BlockType::Raw {
@@ -2109,10 +2109,10 @@ pub unsafe extern "C" fn ZSTD_nextInputType(dctx: *mut ZSTD_DCtx) -> ZSTD_nextIn
 pub unsafe extern "C" fn ZSTD_decompressContinue(
     dctx: *mut ZSTD_DCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let dctx = dctx.as_mut().unwrap();
 
     // For `ZSTD_decompressContinue` is is not valid for src and dst to overlap.
@@ -2132,12 +2132,12 @@ fn decompress_continue(
     dctx: &mut ZSTD_DCtx,
     mut dst: Writer<'_>,
     src: &[u8],
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     if src.len() != ZSTD_nextSrcSizeToDecompressWithInputSize(dctx, src.len()) {
         return Err(Error::srcSize_wrong);
     }
     ZSTD_checkContinuity(dctx, dst.as_ptr_range());
-    dctx.processedCSize = (dctx.processedCSize as size_t).wrapping_add(src.len()) as u64;
+    dctx.processedCSize = (dctx.processedCSize as usize).wrapping_add(src.len()) as u64;
 
     match dctx.stage {
         DecompressStage::GetFrameHeaderSize => {
@@ -2145,7 +2145,7 @@ fn decompress_continue(
                 dctx.headerBuffer[..src.len()].copy_from_slice(src);
 
                 // remaining data to load to get full skippable frame header
-                dctx.expected = (ZSTD_SKIPPABLEHEADERSIZE as size_t).wrapping_sub(src.len());
+                dctx.expected = (ZSTD_SKIPPABLEHEADERSIZE as usize).wrapping_sub(src.len());
                 dctx.stage = DecompressStage::DecodeSkippableHeader;
                 return Ok(0);
             }
@@ -2166,12 +2166,12 @@ fn decompress_continue(
         DecompressStage::DecodeBlockHeader => {
             let (bp, cBlockSize) = getc_block_size(src)?;
 
-            if cBlockSize > dctx.fParams.blockSizeMax as size_t {
+            if cBlockSize > dctx.fParams.blockSizeMax as usize {
                 return Err(Error::corruption_detected);
             }
             dctx.expected = cBlockSize;
             dctx.bType = bp.blockType;
-            dctx.rleSize = bp.origSize as size_t;
+            dctx.rleSize = bp.origSize as usize;
             if cBlockSize != 0 {
                 dctx.stage = if bp.lastBlock {
                     DecompressStage::DecompressLastBlock
@@ -2198,7 +2198,7 @@ fn decompress_continue(
         }
 
         DecompressStage::DecompressBlock | DecompressStage::DecompressLastBlock => {
-            let mut rSize: size_t = 0;
+            let mut rSize: usize = 0;
             match dctx.bType {
                 BlockType::Compressed => {
                     debug_assert!(dctx.isFrameDecompression);
@@ -2224,7 +2224,7 @@ fn decompress_continue(
                     return Err(Error::corruption_detected);
                 }
             }
-            if rSize > dctx.fParams.blockSizeMax as size_t {
+            if rSize > dctx.fParams.blockSizeMax as usize {
                 return Err(Error::corruption_detected);
             }
             dctx.decodedSize = dctx.decodedSize.wrapping_add(rSize as u64);
@@ -2304,7 +2304,7 @@ fn decompress_continue(
 ///
 /// - size of entropy tables read
 /// - an error code, which can be tested with [`ZSTD_isError`]
-pub fn ZSTD_loadDEntropy(entropy: &mut ZSTD_entropyDTables_t, dict: &[u8]) -> size_t {
+pub fn ZSTD_loadDEntropy(entropy: &mut ZSTD_entropyDTables_t, dict: &[u8]) -> usize {
     // skip header = magic + dictID
     let Some((_, mut dictPtr)) = dict.split_at_checked(8) else {
         return Error::dictionary_corrupted.to_error_code();
@@ -2421,7 +2421,7 @@ pub fn ZSTD_loadDEntropy(entropy: &mut ZSTD_entropyDTables_t, dict: &[u8]) -> si
     let dict_content_size = dict_content.len();
     for (i, rep) in chunk.as_chunks::<4>().0.iter().enumerate() {
         let rep = u32::from_le_bytes(*rep);
-        if rep == 0 || rep as size_t > dict_content_size {
+        if rep == 0 || rep as usize > dict_content_size {
             return Error::dictionary_corrupted.to_error_code();
         }
         entropy.rep[i] = rep;
@@ -2468,7 +2468,7 @@ fn ZSTD_decompress_insertDictionary(dctx: &mut ZSTD_DCtx, dict: &[u8]) -> Result
 /// If decompression requires a dictionary, use [`ZSTD_decompressBegin_usingDict`] or
 /// [`ZSTD_decompressBegin_usingDDict`].
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_decompressBegin))]
-pub unsafe extern "C" fn ZSTD_decompressBegin(dctx: *mut ZSTD_DCtx) -> size_t {
+pub unsafe extern "C" fn ZSTD_decompressBegin(dctx: *mut ZSTD_DCtx) -> usize {
     let dctx = dctx.cast::<MaybeUninit<ZSTD_DCtx>>().as_mut().unwrap();
     decompress_begin(dctx);
     0
@@ -2509,8 +2509,8 @@ fn decompress_begin(dctx: &mut MaybeUninit<ZSTD_DCtx>) {
 pub unsafe extern "C" fn ZSTD_decompressBegin_usingDict(
     dctx: *mut ZSTD_DCtx,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
-) -> size_t {
+    dictSize: usize,
+) -> usize {
     let dctx = dctx.cast::<MaybeUninit<ZSTD_DCtx>>().as_mut().unwrap();
     decompress_begin(dctx);
 
@@ -2543,7 +2543,7 @@ unsafe fn ZSTD_decompressBegin_usingDict_slice(
 pub unsafe extern "C" fn ZSTD_decompressBegin_usingDDict(
     dctx: *mut ZSTD_DCtx,
     ddict: *const ZSTD_DDict,
-) -> size_t {
+) -> usize {
     // The C version does not check for NULL, we panic instead.
     let dctx = dctx.cast::<MaybeUninit<ZSTD_DCtx>>().as_mut().unwrap();
 
@@ -2574,7 +2574,7 @@ pub unsafe extern "C" fn ZSTD_decompressBegin_usingDDict(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_getDictID_fromDict))]
 pub unsafe extern "C" fn ZSTD_getDictID_fromDict(
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
 ) -> core::ffi::c_uint {
     if dictSize < 8 {
         return 0;
@@ -2605,7 +2605,7 @@ pub unsafe extern "C" fn ZSTD_getDictID_fromDict(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_getDictID_fromFrame))]
 pub unsafe extern "C" fn ZSTD_getDictID_fromFrame(
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
 ) -> core::ffi::c_uint {
     let mut zfp = ZSTD_FrameHeader::default();
 
@@ -2625,11 +2625,11 @@ pub unsafe extern "C" fn ZSTD_getDictID_fromFrame(
 pub unsafe extern "C" fn ZSTD_decompress_usingDDict(
     dctx: *mut ZSTD_DCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     ddict: *const ZSTD_DDict,
-) -> size_t {
+) -> usize {
     // It is valid for src and dst to overlap.
     let src = Reader::from_raw_parts(src.cast::<u8>(), srcSize);
     let dst = Writer::from_raw_parts(dst.cast::<u8>(), dstCapacity);
@@ -2650,7 +2650,7 @@ pub unsafe extern "C" fn ZSTD_createDStream() -> *mut ZSTD_DStream {
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_initStaticDStream))]
 pub unsafe extern "C" fn ZSTD_initStaticDStream(
     workspace: *mut core::ffi::c_void,
-    workspaceSize: size_t,
+    workspaceSize: usize,
 ) -> *mut ZSTD_DStream {
     ZSTD_initStaticDCtx(workspace, workspaceSize)
 }
@@ -2665,21 +2665,21 @@ pub unsafe extern "C" fn ZSTD_createDStream_advanced(
 
 /// Free a decompression stream created with [`ZSTD_createDStream`]
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_freeDStream))]
-pub unsafe extern "C" fn ZSTD_freeDStream(zds: *mut ZSTD_DStream) -> size_t {
+pub unsafe extern "C" fn ZSTD_freeDStream(zds: *mut ZSTD_DStream) -> usize {
     ZSTD_freeDCtx(zds)
 }
 
 /// Recommended size for input buffer
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_DStreamInSize))]
-pub const extern "C" fn ZSTD_DStreamInSize() -> size_t {
-    (ZSTD_BLOCKSIZE_MAX as size_t).wrapping_add(ZSTD_blockHeaderSize)
+pub const extern "C" fn ZSTD_DStreamInSize() -> usize {
+    (ZSTD_BLOCKSIZE_MAX as usize).wrapping_add(ZSTD_blockHeaderSize)
 }
 
 /// Recommended size for output buffer. Guarantees to successfully flush at least one complete
 /// block in all circumstances.
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_DStreamOutSize))]
-pub const extern "C" fn ZSTD_DStreamOutSize() -> size_t {
-    ZSTD_BLOCKSIZE_MAX as size_t
+pub const extern "C" fn ZSTD_DStreamOutSize() -> usize {
+    ZSTD_BLOCKSIZE_MAX as usize
 }
 
 /// Same as [`ZSTD_DCtx_loadDictionary`], but gives direct control over how to load the dictionary
@@ -2688,10 +2688,10 @@ pub const extern "C" fn ZSTD_DStreamOutSize() -> size_t {
 pub unsafe extern "C" fn ZSTD_DCtx_loadDictionary_advanced(
     dctx: *mut ZSTD_DCtx,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
     dictLoadMethod: ZSTD_dictLoadMethod_e,
     dictContentType: ZSTD_dictContentType_e,
-) -> size_t {
+) -> usize {
     if (*dctx).streamStage != StreamStage::Init {
         return Error::stage_wrong.to_error_code();
     }
@@ -2722,8 +2722,8 @@ pub unsafe extern "C" fn ZSTD_DCtx_loadDictionary_advanced(
 pub unsafe extern "C" fn ZSTD_DCtx_loadDictionary_byReference(
     dctx: *mut ZSTD_DCtx,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
-) -> size_t {
+    dictSize: usize,
+) -> usize {
     ZSTD_DCtx_loadDictionary_advanced(dctx, dict, dictSize, ZSTD_dlm_byRef, ZSTD_dct_auto)
 }
 
@@ -2749,8 +2749,8 @@ pub unsafe extern "C" fn ZSTD_DCtx_loadDictionary_byReference(
 pub unsafe extern "C" fn ZSTD_DCtx_loadDictionary(
     dctx: *mut ZSTD_DCtx,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
-) -> size_t {
+    dictSize: usize,
+) -> usize {
     ZSTD_DCtx_loadDictionary_advanced(dctx, dict, dictSize, ZSTD_dlm_byCopy, ZSTD_dct_auto)
 }
 
@@ -2760,9 +2760,9 @@ pub unsafe extern "C" fn ZSTD_DCtx_loadDictionary(
 pub unsafe extern "C" fn ZSTD_DCtx_refPrefix_advanced(
     dctx: *mut ZSTD_DCtx,
     prefix: *const core::ffi::c_void,
-    prefixSize: size_t,
+    prefixSize: usize,
     dictContentType: ZSTD_dictContentType_e,
-) -> size_t {
+) -> usize {
     let err_code = ZSTD_DCtx_loadDictionary_advanced(
         dctx,
         prefix,
@@ -2805,8 +2805,8 @@ pub unsafe extern "C" fn ZSTD_DCtx_refPrefix_advanced(
 pub unsafe extern "C" fn ZSTD_DCtx_refPrefix(
     dctx: *mut ZSTD_DCtx,
     prefix: *const core::ffi::c_void,
-    prefixSize: size_t,
-) -> size_t {
+    prefixSize: usize,
+) -> usize {
     ZSTD_DCtx_refPrefix_advanced(dctx, prefix, prefixSize, ZSTD_dct_rawContent)
 }
 
@@ -2823,8 +2823,8 @@ pub unsafe extern "C" fn ZSTD_DCtx_refPrefix(
 pub unsafe extern "C" fn ZSTD_initDStream_usingDict(
     zds: *mut ZSTD_DStream,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
-) -> size_t {
+    dictSize: usize,
+) -> usize {
     let err_code = ZSTD_DCtx_reset(zds, ZSTD_ResetDirective::ZSTD_reset_session_only);
     if ERR_isError(err_code) {
         return err_code;
@@ -2844,7 +2844,7 @@ pub unsafe extern "C" fn ZSTD_initDStream_usingDict(
 /// [`ZSTD_DCtx_reset`] to reset the session and using [`ZSTD_DCtx_refDDict`] to reset the
 /// dictionary.
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_initDStream))]
-pub unsafe extern "C" fn ZSTD_initDStream(zds: *mut ZSTD_DStream) -> size_t {
+pub unsafe extern "C" fn ZSTD_initDStream(zds: *mut ZSTD_DStream) -> usize {
     let err_code = ZSTD_DCtx_reset(zds, ZSTD_ResetDirective::ZSTD_reset_session_only);
     if ERR_isError(err_code) {
         return err_code;
@@ -2864,7 +2864,7 @@ pub unsafe extern "C" fn ZSTD_initDStream(zds: *mut ZSTD_DStream) -> size_t {
 pub unsafe extern "C" fn ZSTD_initDStream_usingDDict(
     dctx: *mut ZSTD_DStream,
     ddict: *const ZSTD_DDict,
-) -> size_t {
+) -> usize {
     let err_code = ZSTD_DCtx_reset(dctx, ZSTD_ResetDirective::ZSTD_reset_session_only);
     if ERR_isError(err_code) {
         return err_code;
@@ -2884,7 +2884,7 @@ pub unsafe extern "C" fn ZSTD_initDStream_usingDDict(
 /// - the expected size, aka [`Format::starting_input_length`]
 /// - an error code, which can be tested with [`ZSTD_isError`]
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_resetDStream))]
-pub unsafe extern "C" fn ZSTD_resetDStream(dctx: *mut ZSTD_DStream) -> size_t {
+pub unsafe extern "C" fn ZSTD_resetDStream(dctx: *mut ZSTD_DStream) -> usize {
     let err_code = ZSTD_DCtx_reset(dctx, ZSTD_ResetDirective::ZSTD_reset_session_only);
     if ERR_isError(err_code) {
         return err_code;
@@ -2919,7 +2919,7 @@ pub unsafe extern "C" fn ZSTD_resetDStream(dctx: *mut ZSTD_DStream) -> size_t {
 pub unsafe extern "C" fn ZSTD_DCtx_refDDict(
     dctx: *mut ZSTD_DCtx,
     ddict: *const ZSTD_DDict,
-) -> size_t {
+) -> usize {
     if (*dctx).streamStage != StreamStage::Init {
         return Error::stage_wrong.to_error_code();
     }
@@ -2968,8 +2968,8 @@ pub unsafe extern "C" fn ZSTD_DCtx_refDDict(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_DCtx_setMaxWindowSize))]
 pub unsafe extern "C" fn ZSTD_DCtx_setMaxWindowSize(
     dctx: *mut ZSTD_DCtx,
-    maxWindowSize: size_t,
-) -> size_t {
+    maxWindowSize: usize,
+) -> usize {
     let bounds = ZSTD_dParam_getBounds(ZSTD_dParameter::ZSTD_d_windowLogMax);
     let min = (1) << bounds.lowerBound;
     let max = (1) << bounds.upperBound;
@@ -3000,7 +3000,7 @@ pub unsafe extern "C" fn ZSTD_DCtx_setMaxWindowSize(
 pub unsafe extern "C" fn ZSTD_DCtx_setFormat(
     dctx: *mut ZSTD_DCtx,
     format: ZSTD_format_e,
-) -> size_t {
+) -> usize {
     ZSTD_DCtx_setParameter(
         dctx,
         ZSTD_dParameter::ZSTD_d_format as ZSTD_dParameter,
@@ -3094,7 +3094,7 @@ pub unsafe extern "C" fn ZSTD_DCtx_getParameter(
     dctx: *mut ZSTD_DCtx,
     param: ZSTD_dParameter,
     value: *mut core::ffi::c_int,
-) -> size_t {
+) -> usize {
     *value = match param {
         ZSTD_dParameter::ZSTD_d_windowLogMax => (*dctx).maxWindowSize.ilog2() as i32,
         ZSTD_dParameter::ZSTD_d_format => (*dctx).format as core::ffi::c_int,
@@ -3128,7 +3128,7 @@ pub unsafe extern "C" fn ZSTD_DCtx_setParameter(
     dctx: *mut ZSTD_DCtx,
     dParam: ZSTD_dParameter,
     mut value: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     if (*dctx).streamStage != StreamStage::Init {
         return Error::stage_wrong.to_error_code();
     }
@@ -3210,7 +3210,7 @@ pub unsafe extern "C" fn ZSTD_DCtx_setParameter(
 pub unsafe extern "C" fn ZSTD_DCtx_reset(
     dctx: *mut ZSTD_DCtx,
     reset: ZSTD_ResetDirective,
-) -> size_t {
+) -> usize {
     let dctx = dctx.as_mut().unwrap();
 
     match dctx.reset(reset) {
@@ -3259,17 +3259,17 @@ impl ZSTD_DCtx_s {
 
 /// Returns the _current_ memory usage of the [`ZSTD_DStream`]
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_sizeof_DStream))]
-pub unsafe extern "C" fn ZSTD_sizeof_DStream(dctx: *const ZSTD_DStream) -> size_t {
+pub unsafe extern "C" fn ZSTD_sizeof_DStream(dctx: *const ZSTD_DStream) -> usize {
     ZSTD_sizeof_DCtx(dctx)
 }
 
 fn ZSTD_decodingBufferSize_internal(
     windowSize: core::ffi::c_ulonglong,
     frameContentSize: core::ffi::c_ulonglong,
-    blockSizeMax: size_t,
-) -> size_t {
+    blockSizeMax: usize,
+) -> usize {
     let blockSize = Ord::min(
-        Ord::min(windowSize, ZSTD_BLOCKSIZE_MAX as core::ffi::c_ulonglong) as size_t,
+        Ord::min(windowSize, ZSTD_BLOCKSIZE_MAX as core::ffi::c_ulonglong) as usize,
         blockSizeMax,
     );
 
@@ -3287,7 +3287,7 @@ fn ZSTD_decodingBufferSize_internal(
     } else {
         neededRBSize
     };
-    let minRBSize = neededSize as size_t;
+    let minRBSize = neededSize as usize;
     if minRBSize as core::ffi::c_ulonglong != neededSize {
         return Error::frameParameter_windowTooLarge.to_error_code();
     }
@@ -3299,8 +3299,8 @@ fn ZSTD_decodingBufferSize_internal(
 pub extern "C" fn ZSTD_decodingBufferSize_min(
     windowSize: core::ffi::c_ulonglong,
     frameContentSize: core::ffi::c_ulonglong,
-) -> size_t {
-    ZSTD_decodingBufferSize_internal(windowSize, frameContentSize, ZSTD_BLOCKSIZE_MAX as size_t)
+) -> usize {
+    ZSTD_decodingBufferSize_internal(windowSize, frameContentSize, ZSTD_BLOCKSIZE_MAX as usize)
 }
 
 /// Get a [`ZSTD_DStream`]'s memory budget based on the `windowSize`
@@ -3312,8 +3312,8 @@ pub extern "C" fn ZSTD_decodingBufferSize_min(
 /// will be created, whose additional size is not estimated here. In this case, get total size by
 /// adding [`crate::ZSTD_estimateDDictSize`].
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_estimateDStreamSize))]
-pub extern "C" fn ZSTD_estimateDStreamSize(windowSize: size_t) -> size_t {
-    let blockSize = Ord::min(windowSize, ZSTD_BLOCKSIZE_MAX as size_t);
+pub extern "C" fn ZSTD_estimateDStreamSize(windowSize: usize) -> usize {
+    let blockSize = Ord::min(windowSize, ZSTD_BLOCKSIZE_MAX as usize);
     let inBuffSize = blockSize; // no block can be larger
     let outBuffSize = ZSTD_decodingBufferSize_min(
         windowSize as core::ffi::c_ulonglong,
@@ -3333,8 +3333,8 @@ pub extern "C" fn ZSTD_estimateDStreamSize(windowSize: size_t) -> size_t {
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_estimateDStreamSize_fromFrame))]
 pub unsafe extern "C" fn ZSTD_estimateDStreamSize_fromFrame(
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let windowSizeMax = 1 << ZSTD_WINDOWLOG_MAX; // note: should be user-selectable, but requires an additional parameter (or a dctx)
     let mut zfh = ZSTD_FrameHeader::default();
     let err = ZSTD_getFrameHeader(&mut zfh, src, srcSize);
@@ -3347,23 +3347,23 @@ pub unsafe extern "C" fn ZSTD_estimateDStreamSize_fromFrame(
     if zfh.windowSize > windowSizeMax as core::ffi::c_ulonglong {
         return Error::frameParameter_windowTooLarge.to_error_code();
     }
-    ZSTD_estimateDStreamSize(zfh.windowSize as size_t)
+    ZSTD_estimateDStreamSize(zfh.windowSize as usize)
 }
 
 fn ZSTD_DCtx_isOverflow(
     zds: &ZSTD_DStream,
-    neededInBuffSize: size_t,
-    neededOutBuffSize: size_t,
+    neededInBuffSize: usize,
+    neededOutBuffSize: usize,
 ) -> bool {
     zds.inBuffSize.wrapping_add(zds.outBuffSize)
         >= neededInBuffSize.wrapping_add(neededOutBuffSize)
-            * ZSTD_WORKSPACETOOLARGE_FACTOR as size_t
+            * ZSTD_WORKSPACETOOLARGE_FACTOR as usize
 }
 
 fn ZSTD_DCtx_updateOversizedDuration(
     zds: &mut ZSTD_DStream,
-    neededInBuffSize: size_t,
-    neededOutBuffSize: size_t,
+    neededInBuffSize: usize,
+    neededOutBuffSize: usize,
 ) {
     if ZSTD_DCtx_isOverflow(zds, neededInBuffSize, neededOutBuffSize) {
         zds.oversizedDuration = zds.oversizedDuration.wrapping_add(1);
@@ -3373,7 +3373,7 @@ fn ZSTD_DCtx_updateOversizedDuration(
 }
 
 fn ZSTD_DCtx_isOversizedTooLong(zds: &ZSTD_DStream) -> bool {
-    zds.oversizedDuration >= ZSTD_WORKSPACETOOLARGE_MAXDURATION as size_t
+    zds.oversizedDuration >= ZSTD_WORKSPACETOOLARGE_MAXDURATION as usize
 }
 
 /// Checks that the output buffer hasn't changed if [`ZSTD_obm_stable`] is used
@@ -3407,8 +3407,8 @@ unsafe fn ZSTD_decompressContinueStream(
     op: &mut *mut core::ffi::c_char,
     oend: *mut core::ffi::c_char,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     match zds.outBufferMode {
         BufferMode::Buffered => {
             let dstSize = match zds.stage {
@@ -3488,7 +3488,7 @@ pub unsafe extern "C" fn ZSTD_decompressStream(
     zds: *mut ZSTD_DStream,
     output: *mut ZSTD_outBuffer,
     input: *mut ZSTD_inBuffer,
-) -> size_t {
+) -> usize {
     let zds = zds.as_mut().unwrap();
     let output = output.as_mut().unwrap();
     let input = input.as_mut().unwrap();
@@ -3552,7 +3552,7 @@ pub unsafe extern "C" fn ZSTD_decompressStream(
                     // flush completed
                     zds.streamStage = StreamStage::Read;
                     if (zds.outBuffSize as core::ffi::c_ulonglong) < zds.fParams.frameContentSize
-                        && (zds.outStart).wrapping_add(zds.fParams.blockSizeMax as size_t)
+                        && (zds.outStart).wrapping_add(zds.fParams.blockSizeMax as usize)
                             > zds.outBuffSize
                     {
                         zds.outEnd = 0;
@@ -3767,12 +3767,12 @@ pub unsafe extern "C" fn ZSTD_decompressStream(
                 }
 
                 // Adapt buffer sizes to frame header instructions
-                let neededInBuffSize = core::cmp::max(zds.fParams.blockSizeMax, 4) as size_t;
+                let neededInBuffSize = core::cmp::max(zds.fParams.blockSizeMax, 4) as usize;
                 let neededOutBuffSize = if zds.outBufferMode == BufferMode::Buffered {
                     ZSTD_decodingBufferSize_internal(
                         zds.fParams.windowSize,
                         zds.fParams.frameContentSize,
-                        zds.fParams.blockSizeMax as size_t,
+                        zds.fParams.blockSizeMax as usize,
                     )
                 } else {
                     0
@@ -3901,8 +3901,8 @@ pub unsafe extern "C" fn ZSTD_decompressStream(
     }
 
     // result
-    input.pos = ip.byte_offset_from(input.src) as size_t;
-    output.pos = op.byte_offset_from(output.dst) as size_t;
+    input.pos = ip.byte_offset_from(input.src) as usize;
+    output.pos = op.byte_offset_from(output.dst) as usize;
 
     // Update the expected output buffer for ZSTD_obm_stable.
     zds.expectedOutBuffer = *output;
@@ -3950,7 +3950,7 @@ pub unsafe extern "C" fn ZSTD_decompressStream(
     }
     // preload header of next block
     nextSrcSizeHint = nextSrcSizeHint.wrapping_add(
-        ZSTD_blockHeaderSize * (zds.stage.to_next_input_type() == NextInputType::Block) as size_t,
+        ZSTD_blockHeaderSize * (zds.stage.to_next_input_type() == NextInputType::Block) as usize,
     );
     debug_assert!(zds.inPos <= nextSrcSizeHint);
     // part already loaded
@@ -3965,12 +3965,12 @@ pub unsafe extern "C" fn ZSTD_decompressStream(
 pub unsafe extern "C" fn ZSTD_decompressStream_simpleArgs(
     dctx: *mut ZSTD_DCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
-    dstPos: *mut size_t,
+    dstCapacity: usize,
+    dstPos: *mut usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-    srcPos: *mut size_t,
-) -> size_t {
+    srcSize: usize,
+    srcPos: *mut usize,
+) -> usize {
     let mut output = ZSTD_outBuffer_s {
         dst,
         size: dstCapacity,

--- a/lib/decompress/zstd_decompress_block.rs
+++ b/lib/decompress/zstd_decompress_block.rs
@@ -3,7 +3,7 @@ use core::ffi::c_void;
 use core::ops::Range;
 use core::ptr::{self, NonNull};
 
-use libc::{ptrdiff_t, size_t};
+use libc::ptrdiff_t;
 
 use crate::lib::common::bitstream::BIT_DStream_t;
 use crate::lib::common::entropy_common::FSE_readNCount_slice;
@@ -69,7 +69,7 @@ pub struct seqState_t<'a> {
     stateLL: ZSTD_fseState<'a>,
     stateOffb: ZSTD_fseState<'a>,
     stateML: ZSTD_fseState<'a>,
-    prevOffset: [size_t; 3],
+    prevOffset: [usize; 3],
 }
 
 impl ZSTD_DCtx {
@@ -94,14 +94,14 @@ impl ZSTD_DCtx {
             stateOffb,
             stateML,
             DStream: bit_stream,
-            prevOffset: self.entropy.rep.map(|v| v as size_t),
+            prevOffset: self.entropy.rep.map(|v| v as usize),
         }
     }
 }
 
 #[repr(C)]
 pub struct ZSTD_fseState<'a> {
-    pub state: size_t,
+    pub state: usize,
     pub table: &'a [ZSTD_seqSymbol],
 }
 
@@ -122,9 +122,9 @@ impl<'a> ZSTD_fseState<'a> {
 #[derive(Copy, Clone, Default)]
 #[repr(C)]
 pub struct seq_t {
-    pub litLength: size_t,
-    pub matchLength: size_t,
-    pub offset: size_t,
+    pub litLength: usize,
+    pub matchLength: usize,
+    pub offset: usize,
 }
 
 #[derive(Copy, Clone, Default)]
@@ -167,7 +167,7 @@ pub const STREAM_ACCUMULATOR_MIN_32: core::ffi::c_int = 25;
 pub const STREAM_ACCUMULATOR_MIN_64: core::ffi::c_int = 57;
 
 pub const ZSTD_BLOCKHEADERSIZE: core::ffi::c_int = 3;
-static ZSTD_blockHeaderSize: size_t = ZSTD_BLOCKHEADERSIZE as size_t;
+static ZSTD_blockHeaderSize: usize = ZSTD_BLOCKHEADERSIZE as usize;
 pub const LONGNBSEQ: core::ffi::c_int = 0x7f00 as core::ffi::c_int;
 
 impl ZSTD_DCtx {
@@ -183,7 +183,7 @@ impl ZSTD_DCtx {
 pub(crate) fn ZSTD_getcBlockSize(
     src: &[u8],
     bpPtr: &mut blockProperties_t,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     if src.len() < ZSTD_blockHeaderSize {
         return Err(Error::srcSize_wrong);
     }
@@ -195,7 +195,7 @@ pub(crate) fn ZSTD_getcBlockSize(
     bpPtr.origSize = cSize;
 
     match bpPtr.blockType {
-        BlockType::Raw | BlockType::Compressed => Ok(cSize as size_t),
+        BlockType::Raw | BlockType::Compressed => Ok(cSize as usize),
         BlockType::Rle => Ok(1),
         BlockType::Reserved => Err(Error::corruption_detected),
     }
@@ -216,7 +216,7 @@ pub(crate) fn getc_block_size(src: &[u8]) -> Result<(blockProperties_t, usize), 
     };
 
     match bp.blockType {
-        BlockType::Raw | BlockType::Compressed => Ok((bp, cSize as size_t)),
+        BlockType::Raw | BlockType::Compressed => Ok((bp, cSize as usize)),
         BlockType::Rle => Ok((bp, 1)),
         BlockType::Reserved => Err(Error::corruption_detected),
     }
@@ -285,7 +285,7 @@ fn ZSTD_decodeLiteralsBlock(
     src: &[u8],
     dst: Writer<'_>,
     streaming: StreamingOperation,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     // for a non-null block
     const MIN_CBLOCK_SIZE: usize = 1 /*litCSize*/ + 1/* RLE or RAW */;
     if src.len() < MIN_CBLOCK_SIZE {
@@ -867,7 +867,7 @@ fn ZSTD_buildSeqTableNew<const N: usize>(
     nbSeq: core::ffi::c_int,
     wksp: &mut Workspace,
     bmi2: bool,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     match type_0 {
         SymbolEncodingType_e::set_rle => {
             let [symbol, ..] = *src else {
@@ -930,7 +930,7 @@ fn ZSTD_decodeSeqHeaders(
     dctx: &mut ZSTD_DCtx,
     nbSeqPtr: &mut core::ffi::c_int,
     src: &[u8],
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let mut ip = 0;
     let [nbSeq, ..] = *src else {
         return Err(Error::srcSize_wrong);
@@ -1044,7 +1044,7 @@ fn ZSTD_decodeSeqHeaders(
 ///  Precondition: *ip <= *op
 ///  Postcondition: *op - *ip >= 8
 #[inline(always)]
-unsafe fn ZSTD_overlapCopy8(op: &mut *mut u8, ip: &mut *const u8, offset: size_t) {
+unsafe fn ZSTD_overlapCopy8(op: &mut *mut u8, ip: &mut *const u8, offset: usize) {
     if offset < 8 {
         /* close range match, overlap */
         *(*op).add(0) = *(*ip).add(0);
@@ -1081,7 +1081,7 @@ unsafe fn ZSTD_safecopy(
     mut op: *mut u8,
     oend_w: *const u8,
     mut ip: *const u8,
-    mut length: size_t,
+    mut length: usize,
     ovtype: Overlap,
 ) {
     let diff = op as isize - ip as isize;
@@ -1105,7 +1105,7 @@ unsafe fn ZSTD_safecopy(
         /* Copy 8 bytes and ensure the offset >= 8 when there can be overlap. */
         debug_assert!(length >= 8);
         debug_assert!(diff > 0);
-        ZSTD_overlapCopy8(&mut op, &mut ip, diff as size_t);
+        ZSTD_overlapCopy8(&mut op, &mut ip, diff as usize);
         length = length.wrapping_sub(8);
         debug_assert!(op.offset_from(ip) >= 8);
         debug_assert!(op <= oend);
@@ -1132,7 +1132,7 @@ unsafe fn ZSTD_safecopy(
 
 /// This version allows overlap with dst before src, or handles the non-overlap case with dst after src
 /// Kept separate from more common [`ZSTD_safecopy`] case to avoid performance impact to the safecopy common case */
-unsafe fn ZSTD_safecopyDstBeforeSrc(mut op: *mut u8, mut ip: *const u8, length: size_t) {
+unsafe fn ZSTD_safecopyDstBeforeSrc(mut op: *mut u8, mut ip: *const u8, length: usize) {
     let diff = op.offset_from(ip) as ptrdiff_t;
     let oend = op.add(length);
     if length < 8 || diff > -8 {
@@ -1179,7 +1179,7 @@ unsafe fn ZSTD_execSequenceEnd(
     prefixStart: *const u8,
     virtualStart: *const u8,
     dictEnd: *const u8,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let oLitEnd = op.add(sequence.litLength);
     let sequenceLength = (sequence.litLength).wrapping_add(sequence.matchLength);
     let iLitEnd = (*litPtr).add(sequence.litLength);
@@ -1243,7 +1243,7 @@ unsafe fn ZSTD_execSequenceEndSplitLitBuffer(
     prefixStart: *const u8,
     virtualStart: *const u8,
     dictEnd: *const u8,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let oLitEnd = op.as_mut_ptr().add(sequence.litLength);
     let sequenceLength = (sequence.litLength).wrapping_add(sequence.matchLength);
     let iLitEnd = (*litPtr).add(sequence.litLength);
@@ -1310,7 +1310,7 @@ unsafe fn ZSTD_execSequence(
     prefixStart: *const u8,
     virtualStart: *const u8,
     dictEnd: *const u8,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let mut op = op.as_mut_ptr();
     let oLitEnd = op.add(sequence.litLength);
     let sequenceLength = (sequence.litLength).wrapping_add(sequence.matchLength);
@@ -1435,7 +1435,7 @@ unsafe fn ZSTD_execSequenceSplitLitBuffer(
     prefixStart: *const u8,
     virtualStart: *const u8,
     dictEnd: *const u8,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let oLitEnd = op.as_mut_ptr().add(sequence.litLength);
     let sequenceLength = (sequence.litLength).wrapping_add(sequence.matchLength);
     let oMatchEnd = op.as_mut_ptr().add(sequenceLength);
@@ -1591,8 +1591,8 @@ fn ZSTD_decodeSequence(
         }
     }
 
-    seq.matchLength = mlDInfo.baseValue as size_t;
-    seq.litLength = llDInfo.baseValue as size_t;
+    seq.matchLength = mlDInfo.baseValue as usize;
+    seq.litLength = llDInfo.baseValue as usize;
     let ofBase = ofDInfo.baseValue;
 
     let llBits = llDInfo.nbAdditionalBits;
@@ -1616,7 +1616,7 @@ fn ZSTD_decodeSequence(
     // it is deliberately not a debug_assert!.
     assert!(ofBits as u32 <= MaxOff);
 
-    let mut offset: size_t = 0;
+    let mut offset: usize = 0;
     if ofBits > 1 {
         const { assert!(Offset::Long as usize == 1) };
         const { assert!(LONG_OFFSETS_MAX_EXTRA_BITS_32 == 5) };
@@ -1630,17 +1630,17 @@ fn ZSTD_decodeSequence(
             // Always read extra bits, this keeps the logic simple,
             // avoids branches, and avoids accidentally reading 0 bits.
             let extraBits = LONG_OFFSETS_MAX_EXTRA_BITS_32 as u32;
-            offset = (ofBase as size_t).wrapping_add(
+            offset = (ofBase as usize).wrapping_add(
                 (seqState
                     .DStream
-                    .read_bits_fast(u32::from(ofBits) - extraBits) as size_t)
+                    .read_bits_fast(u32::from(ofBits) - extraBits) as usize)
                     << extraBits,
             );
             seqState.DStream.reload();
-            offset = offset.wrapping_add(seqState.DStream.read_bits_fast(extraBits) as size_t);
+            offset = offset.wrapping_add(seqState.DStream.read_bits_fast(extraBits) as usize);
         } else {
-            offset = (ofBase as size_t)
-                .wrapping_add(seqState.DStream.read_bits_fast(u32::from(ofBits)) as size_t);
+            offset = (ofBase as usize)
+                .wrapping_add(seqState.DStream.read_bits_fast(u32::from(ofBits)) as usize);
             if MEM_32bits() {
                 seqState.DStream.reload();
             }
@@ -1656,8 +1656,8 @@ fn ZSTD_decodeSequence(
             seqState.prevOffset[1] = seqState.prevOffset[usize::from(ll0 == 0)];
             seqState.prevOffset[0] = offset;
         } else {
-            offset = (ofBase.wrapping_add(ll0 as u32) as size_t)
-                .wrapping_add(seqState.DStream.read_bits_fast(1) as size_t);
+            offset = (ofBase.wrapping_add(ll0 as u32) as usize)
+                .wrapping_add(seqState.DStream.read_bits_fast(1) as usize);
 
             let mut temp = match offset {
                 3 => seqState.prevOffset[0] - 1,
@@ -1678,7 +1678,7 @@ fn ZSTD_decodeSequence(
     if mlBits > 0 {
         seq.matchLength = seq
             .matchLength
-            .wrapping_add(seqState.DStream.read_bits_fast(mlBits as core::ffi::c_uint) as size_t);
+            .wrapping_add(seqState.DStream.read_bits_fast(mlBits as core::ffi::c_uint) as usize);
     }
 
     if cfg!(target_pointer_width = "32")
@@ -1696,7 +1696,7 @@ fn ZSTD_decodeSequence(
 
     if llBits > 0 {
         seq.litLength = (seq.litLength)
-            .wrapping_add(seqState.DStream.read_bits_fast(llBits as core::ffi::c_uint) as size_t);
+            .wrapping_add(seqState.DStream.read_bits_fast(llBits as core::ffi::c_uint) as usize);
     }
     if MEM_32bits() {
         seqState.DStream.reload();
@@ -1729,7 +1729,7 @@ fn ZSTD_decompressSequences_bodySplitLitBuffer(
     seq: &[u8],
     mut nbSeq: core::ffi::c_int,
     offset: Offset,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let maxDstSize = dst.capacity();
     let mut op = dst;
     let mut litPtr = dctx.litPtr;
@@ -1879,7 +1879,7 @@ unsafe fn ZSTD_decompressSequences_body(
     seq: &[u8],
     nbSeq: core::ffi::c_int,
     offset: Offset,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let capacity = dst.capacity();
 
     let oend = match dctx.litBufferLocation {
@@ -1932,7 +1932,7 @@ unsafe fn ZSTD_decompressSequences_body(
     }
 
     let lastLLSize = litEnd.offset_from_unsigned(litPtr);
-    if lastLLSize > oend.offset_from(op.as_mut_ptr()) as size_t {
+    if lastLLSize > oend.offset_from(op.as_mut_ptr()) as usize {
         return Err(Error::dstSize_tooSmall);
     }
 
@@ -1950,7 +1950,7 @@ fn ZSTD_decompressSequences_default(
     seqStart: &[u8],
     nbSeq: core::ffi::c_int,
     offset: Offset,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     unsafe { ZSTD_decompressSequences_body(dctx, dst, seqStart, nbSeq, offset) }
 }
 
@@ -1960,13 +1960,13 @@ fn ZSTD_decompressSequencesSplitLitBuffer_default(
     seqStart: &[u8],
     nbSeq: core::ffi::c_int,
     offset: Offset,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     ZSTD_decompressSequences_bodySplitLitBuffer(dctx, dst, seqStart, nbSeq, offset)
 }
 
 #[inline(always)]
 fn prefetch_area<T>(ptr: *const T, bytes: usize) {
-    for pos in (0..bytes).step_by(CACHELINE_SIZE as size_t) {
+    for pos in (0..bytes).step_by(CACHELINE_SIZE as usize) {
         prefetch_read_data(ptr.wrapping_byte_add(pos), Locality::L2);
     }
 }
@@ -1978,11 +1978,11 @@ fn prefetch_val<T>(ptr: *const T) {
 
 #[inline(always)]
 fn ZSTD_prefetchMatch(
-    prefetchPos: size_t,
+    prefetchPos: usize,
     sequence: seq_t,
     prefixStart: *const u8,
     dictEnd: *const u8,
-) -> size_t {
+) -> usize {
     let matchBase = if sequence.offset > prefetchPos.wrapping_add(sequence.litLength) {
         dictEnd
     } else {
@@ -2006,7 +2006,7 @@ unsafe fn ZSTD_decompressSequencesLong_body(
     seq: &[u8],
     nbSeq: core::ffi::c_int,
     offset: Offset,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let dst_capacity = dst.capacity();
     let oend = if dctx.litBufferLocation == LitLocation::ZSTD_in_dst {
         dctx.litBuffer
@@ -2204,7 +2204,7 @@ fn ZSTD_decompressSequencesLong_default(
     seqStart: &[u8],
     nbSeq: core::ffi::c_int,
     offset: Offset,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     unsafe { ZSTD_decompressSequencesLong_body(dctx, dst, seqStart, nbSeq, offset) }
 }
 
@@ -2215,7 +2215,7 @@ fn ZSTD_decompressSequences_bmi2(
     seqStart: &[u8],
     nbSeq: core::ffi::c_int,
     offset: Offset,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     unsafe { ZSTD_decompressSequences_body(dctx, dst, seqStart, nbSeq, offset) }
 }
 
@@ -2226,7 +2226,7 @@ fn ZSTD_decompressSequencesSplitLitBuffer_bmi2(
     seqStart: &[u8],
     nbSeq: core::ffi::c_int,
     offset: Offset,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     ZSTD_decompressSequences_bodySplitLitBuffer(dctx, dst, seqStart, nbSeq, offset)
 }
 
@@ -2237,7 +2237,7 @@ fn ZSTD_decompressSequencesLong_bmi2(
     seqStart: &[u8],
     nbSeq: core::ffi::c_int,
     offset: Offset,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     unsafe { ZSTD_decompressSequencesLong_body(dctx, dst, seqStart, nbSeq, offset) }
 }
 
@@ -2247,7 +2247,7 @@ fn ZSTD_decompressSequences(
     seqStart: &[u8],
     nbSeq: core::ffi::c_int,
     offset: Offset,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     if dctx.bmi2 {
         unsafe { ZSTD_decompressSequences_bmi2(dctx, dst, seqStart, nbSeq, offset) }
     } else {
@@ -2261,7 +2261,7 @@ fn ZSTD_decompressSequencesSplitLitBuffer(
     seqStart: &[u8],
     nbSeq: core::ffi::c_int,
     offset: Offset,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     if dctx.bmi2 {
         unsafe { ZSTD_decompressSequencesSplitLitBuffer_bmi2(dctx, dst, seqStart, nbSeq, offset) }
     } else {
@@ -2275,7 +2275,7 @@ fn ZSTD_decompressSequencesLong(
     seqStart: &[u8],
     nbSeq: core::ffi::c_int,
     offset: Offset,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     if dctx.bmi2 {
         unsafe { ZSTD_decompressSequencesLong_bmi2(dctx, dst, seqStart, nbSeq, offset) }
     } else {
@@ -2311,22 +2311,22 @@ impl<const N: usize> SymbolTable<N> {
 /// @returns The maximum offset we can decode in one read of our bitstream, without
 /// reloading more bits in the middle of the offset bits read. Any offsets larger
 /// than this must use the long offset decoder.
-const fn ZSTD_maxShortOffset() -> size_t {
+const fn ZSTD_maxShortOffset() -> usize {
     match size_of::<usize>() {
         4 => {
             // The maximum offBase is (1 << (STREAM_ACCUMULATOR_MIN + 1)) - 1.
             // This offBase would require STREAM_ACCUMULATOR_MIN extra bits.
             // Then we have to subtract ZSTD_REP_NUM to get the maximum possible offset.
-            let maxOffbase = ((1 as size_t) << (STREAM_ACCUMULATOR_MIN as u32 + 1)).wrapping_sub(1);
+            let maxOffbase = ((1 as usize) << (STREAM_ACCUMULATOR_MIN as u32 + 1)).wrapping_sub(1);
 
-            maxOffbase.wrapping_sub(ZSTD_REP_NUM as size_t)
+            maxOffbase.wrapping_sub(ZSTD_REP_NUM as usize)
         }
         8 => {
             // We can decode any offset without reloading bits.
             // This might change if the max window size grows.
             const { assert!(ZSTD_WINDOWLOG_MAX <= 31) }
 
-            -(1 as core::ffi::c_int) as size_t
+            -(1 as core::ffi::c_int) as usize
         }
         _ => unreachable!(),
     }
@@ -2337,7 +2337,7 @@ pub(crate) fn ZSTD_decompressBlock_internal_help(
     mut dst: Writer<'_>,
     src: &[u8],
     streaming: StreamingOperation,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     if src.len() > dctx.block_size_max() {
         return Err(Error::srcSize_wrong);
     }
@@ -2362,13 +2362,13 @@ pub(crate) fn ZSTD_decompressBlock_internal_help(
         return Err(Error::dstSize_tooSmall);
     }
     if size_of::<usize>() == 8
-        && size_of::<size_t>() == size_of::<*mut core::ffi::c_void>()
+        && size_of::<usize>() == size_of::<*mut core::ffi::c_void>()
         && (usize::MAX - dst.as_mut_ptr() as usize) < (1 << 20)
     {
         return Err(Error::dstSize_tooSmall);
     }
     if offset == Offset::Long
-        || !use_prefetch_decoder && totalHistorySize > ((1) << 24) as size_t && nbSeq > 8
+        || !use_prefetch_decoder && totalHistorySize > ((1) << 24) as usize && nbSeq > 8
     {
         let info = match dctx.OFTptr {
             None => OF_defaultDTable.get_offset_info(nbSeq as usize),
@@ -2410,10 +2410,10 @@ pub fn ZSTD_checkContinuity(dctx: &mut ZSTD_DCtx, range: Range<*const u8>) {
 pub unsafe extern "C" fn ZSTD_decompressBlock(
     dctx: *mut ZSTD_DCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let dst = Writer::from_raw_parts(dst.cast::<u8>(), dstCapacity);
     let src = Reader::from_raw_parts(src.cast::<u8>(), srcSize);
 

--- a/lib/dictBuilder/cover.rs
+++ b/lib/dictBuilder/cover.rs
@@ -4,7 +4,7 @@ use std::ops::Range;
 use std::sync::{Condvar, Mutex};
 use std::time::{Duration, Instant};
 
-use libc::size_t;
+
 
 use crate::lib::common::bits::ZSTD_highbit32;
 use crate::lib::common::error_private::{ERR_isError, Error};
@@ -29,7 +29,7 @@ impl COVER_map_t {
         let sizeLog = ZSTD_highbit32(size) + 2;
         let size = 1 << sizeLog;
         let sizeMask = size - 1;
-        let data = Box::from(vec![COVER_map_pair_t::EMPTY; size as size_t]);
+        let data = Box::from(vec![COVER_map_pair_t::EMPTY; size as usize]);
 
         let mut this = Self {
             data,
@@ -63,13 +63,13 @@ impl COVER_map_pair_t {
 #[repr(C)]
 struct COVER_ctx_t<'a> {
     samples: &'a [u8],
-    offsets: Box<[size_t]>,
-    samplesSizes: &'a [size_t],
-    nbSamples: size_t,
-    nbTrainSamples: size_t,
-    nbTestSamples: size_t,
+    offsets: Box<[usize]>,
+    samplesSizes: &'a [usize],
+    nbSamples: usize,
+    nbTrainSamples: usize,
+    nbTestSamples: usize,
     suffix: Box<[u32]>,
-    suffixSize: size_t,
+    suffixSize: usize,
     freqs: Box<[u32]>,
     dmerAt: Box<[u32]>,
     d: core::ffi::c_uint,
@@ -90,11 +90,11 @@ pub(super) struct COVER_epoch_info_t {
 }
 
 pub(super) struct COVER_best_t_inner {
-    pub(super) liveJobs: size_t,
+    pub(super) liveJobs: usize,
     pub(super) dict: Box<[u8]>,
-    pub(super) dictSize: size_t,
+    pub(super) dictSize: usize,
     pub(super) parameters: ZDICT_cover_params_t,
-    pub(super) compressedSize: size_t,
+    pub(super) compressedSize: usize,
 }
 
 impl COVER_best_t_inner {
@@ -103,7 +103,7 @@ impl COVER_best_t_inner {
             liveJobs: 0,
             dict: Box::default(),
             dictSize: 0,
-            compressedSize: -(1 as core::ffi::c_int) as size_t,
+            compressedSize: -(1 as core::ffi::c_int) as usize,
             parameters: ZDICT_cover_params_t::default(),
         }
     }
@@ -127,15 +127,15 @@ impl COVER_best_t {
 struct COVER_tryParameters_data_t<'a, 'b> {
     ctx: &'b COVER_ctx_t<'a>,
     best: &'b COVER_best_t,
-    dictBufferCapacity: size_t,
+    dictBufferCapacity: usize,
     parameters: ZDICT_cover_params_t,
 }
 #[derive(Clone)]
 #[repr(C)]
 pub(super) struct COVER_dictSelection_t {
     dictContent: Box<[u8]>,
-    dictSize: size_t,
-    totalCompressedSize: size_t,
+    dictSize: usize,
+    totalCompressedSize: usize,
 }
 const COVER_DEFAULT_SPLITPOINT: core::ffi::c_double = 1.0f64;
 
@@ -278,8 +278,8 @@ crate::lib::polyfill::cfg_select! {
         extern "C" {
             fn qsort_r(
                 __base: *mut core::ffi::c_void,
-                __nmemb: size_t,
-                __size: size_t,
+                __nmemb: usize,
+                __size: usize,
                 __arg: *mut core::ffi::c_void,
                 __compar: __compar_d_fn_t,
             );
@@ -289,8 +289,8 @@ crate::lib::polyfill::cfg_select! {
         extern "C" {
             fn qsort_s(
                 __base: *mut core::ffi::c_void,
-                __nmemb: size_t,
-                __size: size_t,
+                __nmemb: usize,
+                __size: usize,
                 __compar: __compar_d_fn_t,
                 __arg: *mut core::ffi::c_void,
             );
@@ -300,8 +300,8 @@ crate::lib::polyfill::cfg_select! {
         extern "C" {
             fn qsort_r(
                 __base: *mut core::ffi::c_void,
-                __nmemb: size_t,
-                __size: size_t,
+                __nmemb: usize,
+                __size: usize,
                 __compar: __compar_d_fn_t,
                 __arg: *mut core::ffi::c_void,
             );
@@ -363,8 +363,8 @@ fn stableSort(ctx: &mut COVER_ctx_t) {
         }
         _ => {
             ctx.suffix.sort_by(|lp, rp| {
-                let lhs = &ctx.samples[*lp as usize..][.. ctx.d as size_t];
-                let rhs = &ctx.samples[*rp as usize..][.. ctx.d as size_t];
+                let lhs = &ctx.samples[*lp as usize..][.. ctx.d as usize];
+                let rhs = &ctx.samples[*rp as usize..][.. ctx.d as usize];
 
                 lhs.cmp(rhs)
             });
@@ -372,7 +372,7 @@ fn stableSort(ctx: &mut COVER_ctx_t) {
     }
 }
 
-fn COVER_lower_bound(slice: &[usize], value: size_t) -> usize {
+fn COVER_lower_bound(slice: &[usize], value: usize) -> usize {
     let mut count = slice.len();
     let mut first = slice;
     while count != 0 {
@@ -505,11 +505,11 @@ fn COVER_selectSegment(
     bestSegment
 }
 
-fn COVER_checkParameters(parameters: ZDICT_cover_params_t, maxDictSize: size_t) -> bool {
+fn COVER_checkParameters(parameters: ZDICT_cover_params_t, maxDictSize: usize) -> bool {
     if parameters.d == 0 || parameters.k == 0 {
         return false;
     }
-    if parameters.k as size_t > maxDictSize {
+    if parameters.k as usize > maxDictSize {
         return false;
     }
     if parameters.d > parameters.k {
@@ -532,11 +532,11 @@ fn COVER_ctx_destroy(ctx: &mut COVER_ctx_t) {
 fn COVER_ctx_init<'a>(
     ctx: &'_ mut COVER_ctx_t<'a>,
     samples: &'a [u8],
-    samplesSizes: &'a [size_t],
+    samplesSizes: &'a [usize],
     d: core::ffi::c_uint,
     splitPoint: core::ffi::c_double,
     displayLevel: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let nbSamples = samplesSizes.len();
     let totalSamplesSize = samples.len();
     let nbTrainSamples = if splitPoint < 1.0f64 {
@@ -561,23 +561,23 @@ fn COVER_ctx_init<'a>(
     };
     ctx.displayLevel = displayLevel;
     if totalSamplesSize
-        < (if d as size_t > ::core::mem::size_of::<u64>() {
-            d as size_t
+        < (if d as usize > ::core::mem::size_of::<u64>() {
+            d as usize
         } else {
             ::core::mem::size_of::<u64>()
         })
         || totalSamplesSize
-            >= (if ::core::mem::size_of::<size_t>() == 8 {
+            >= (if ::core::mem::size_of::<usize>() == 8 {
                 -(1 as core::ffi::c_int) as core::ffi::c_uint
             } else {
                 (1 as core::ffi::c_int as core::ffi::c_uint).wrapping_mul((1) << 30)
-            }) as size_t
+            }) as usize
     {
         if displayLevel >= 1 {
             eprintln!(
                 "Total samples size is too large ({} MB), maximum size is {} MB",
                 (totalSamplesSize >> 20) as core::ffi::c_uint,
-                (if ::core::mem::size_of::<size_t>() == 8 {
+                (if ::core::mem::size_of::<usize>() == 8 {
                     -(1 as core::ffi::c_int) as core::ffi::c_uint
                 } else {
                     (1 as core::ffi::c_uint).wrapping_mul((1) << 30)
@@ -619,12 +619,12 @@ fn COVER_ctx_init<'a>(
     }
     ctx.samples = samples;
     ctx.samplesSizes = samplesSizes;
-    ctx.nbSamples = nbSamples as size_t;
-    ctx.nbTrainSamples = nbTrainSamples as size_t;
-    ctx.nbTestSamples = nbTestSamples as size_t;
+    ctx.nbSamples = nbSamples as usize;
+    ctx.nbTrainSamples = nbTrainSamples as usize;
+    ctx.nbTestSamples = nbTestSamples as usize;
     ctx.suffixSize = trainingSamplesSize
-        .wrapping_sub(if d as size_t > ::core::mem::size_of::<u64>() {
-            d as size_t
+        .wrapping_sub(if d as usize > ::core::mem::size_of::<u64>() {
+            d as usize
         } else {
             ::core::mem::size_of::<u64>()
         })
@@ -664,8 +664,8 @@ fn COVER_ctx_init<'a>(
 }
 
 pub(super) fn COVER_warnOnSmallCorpus(
-    maxDictSize: size_t,
-    nbDmers: size_t,
+    maxDictSize: usize,
+    nbDmers: usize,
     displayLevel: core::ffi::c_int,
 ) {
     let ratio = nbDmers as core::ffi::c_double / maxDictSize as core::ffi::c_double;
@@ -724,9 +724,9 @@ fn COVER_buildDictionary<'a>(
         parameters.k,
         4,
     );
-    let maxZeroScoreRun = (epochs.num >> 3).clamp(10, 100) as size_t;
-    let mut zeroScoreRun = 0 as size_t;
-    let mut epoch: size_t = 0;
+    let maxZeroScoreRun = (epochs.num >> 3).clamp(10, 100) as usize;
+    let mut zeroScoreRun = 0 as usize;
+    let mut epoch: usize = 0;
     let mut last_update_time = Instant::now();
     let displayLevel = ctx.displayLevel;
     if displayLevel >= 2 {
@@ -737,9 +737,9 @@ fn COVER_buildDictionary<'a>(
     }
     epoch = 0;
     while tail > 0 {
-        let epochBegin = (epoch * epochs.size as size_t) as u32;
+        let epochBegin = (epoch * epochs.size as usize) as u32;
         let epochEnd = epochBegin.wrapping_add(epochs.size);
-        let mut segmentSize: size_t = 0;
+        let mut segmentSize: usize = 0;
         let segment =
             COVER_selectSegment(ctx, freqs, activeDmers, epochBegin, epochEnd, parameters);
         if segment.score == 0 {
@@ -754,7 +754,7 @@ fn COVER_buildDictionary<'a>(
                 (segment.end - segment.begin + parameters.d - 1) as usize,
                 tail,
             );
-            if segmentSize < parameters.d as size_t {
+            if segmentSize < parameters.d as usize {
                 break;
             }
 
@@ -774,7 +774,7 @@ fn COVER_buildDictionary<'a>(
                 }
             }
         }
-        epoch = epoch.wrapping_add(1) % epochs.num as size_t;
+        epoch = epoch.wrapping_add(1) % epochs.num as usize;
     }
     if displayLevel >= 2 {
         println!("\r{:79 }\r", "");
@@ -837,12 +837,12 @@ pub(super) const unsafe fn assume_init_ref<T>(slice: &[MaybeUninit<T>]) -> &[T] 
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZDICT_trainFromBuffer_cover))]
 pub unsafe extern "C" fn ZDICT_trainFromBuffer_cover(
     dictBuffer: *mut core::ffi::c_void,
-    dictBufferCapacity: size_t,
+    dictBufferCapacity: usize,
     samplesBuffer: *const core::ffi::c_void,
-    samplesSizes: *const size_t,
+    samplesSizes: *const usize,
     nbSamples: core::ffi::c_uint,
     parameters: ZDICT_cover_params_t,
-) -> size_t {
+) -> usize {
     let dict = unsafe { core::slice::from_raw_parts_mut(dictBuffer.cast(), dictBufferCapacity) };
 
     let samplesSizes = if samplesSizes.is_null() || nbSamples == 0 {
@@ -865,7 +865,7 @@ fn train_from_buffer_cover(
     samples: &[u8],
     samplesSizes: &[usize],
     mut parameters: ZDICT_cover_params_t,
-) -> size_t {
+) -> usize {
     let dictBufferCapacity = dict.len();
 
     let mut ctx = COVER_ctx_t::default();
@@ -937,19 +937,19 @@ fn train_from_buffer_cover(
 
 pub(super) fn COVER_checkTotalCompressedSize(
     parameters: ZDICT_cover_params_t,
-    samplesSizes: &[size_t],
+    samplesSizes: &[usize],
     samples: &[u8],
-    offsets: &[size_t],
-    nbTrainSamples: size_t,
-    nbSamples: size_t,
+    offsets: &[usize],
+    nbTrainSamples: usize,
+    nbSamples: usize,
     dict: *mut u8,
-    dictBufferCapacity: size_t,
-) -> size_t {
+    dictBufferCapacity: usize,
+) -> usize {
     let mut totalCompressedSize = Error::GENERIC.to_error_code();
     let mut cctx = core::ptr::null_mut::<ZSTD_CCtx>();
     let mut cdict = core::ptr::null_mut::<ZSTD_CDict>();
-    let mut dstCapacity: size_t = 0;
-    let mut i: size_t = 0;
+    let mut dstCapacity: usize = 0;
+    let mut i: usize = 0;
     let mut maxSampleSize = 0;
     i = if parameters.splitPoint < 1.0f64 {
         nbTrainSamples
@@ -1029,7 +1029,7 @@ pub(super) fn COVER_best_finish(
 ) {
     let compressedSize = selection.totalCompressedSize;
     let dictSize = selection.dictSize;
-    let mut liveJobs: size_t = 0;
+    let mut liveJobs: usize = 0;
     let mut guard = best.mutex.lock().unwrap();
     guard.liveJobs = (guard.liveJobs).wrapping_sub(1);
     liveJobs = guard.liveJobs;
@@ -1049,7 +1049,7 @@ pub(super) fn COVER_best_finish(
     }
 }
 
-fn setDictSelection(buf: Box<[u8]>, s: size_t, csz: size_t) -> COVER_dictSelection_t {
+fn setDictSelection(buf: Box<[u8]>, s: usize, csz: usize) -> COVER_dictSelection_t {
     COVER_dictSelection_t {
         dictContent: buf,
         dictSize: s,
@@ -1057,7 +1057,7 @@ fn setDictSelection(buf: Box<[u8]>, s: size_t, csz: size_t) -> COVER_dictSelecti
     }
 }
 
-pub(super) fn COVER_dictSelectionError(error: size_t) -> COVER_dictSelection_t {
+pub(super) fn COVER_dictSelectionError(error: usize) -> COVER_dictSelection_t {
     setDictSelection(Box::default(), 0, error)
 }
 
@@ -1073,16 +1073,16 @@ pub(super) fn COVER_dictSelectionFree(selection: COVER_dictSelection_t) {
 
 pub(super) fn COVER_selectDict(
     customDictContent: &[u8],
-    dictBufferCapacity: size_t,
-    mut dictContentSize: size_t,
+    dictBufferCapacity: usize,
+    mut dictContentSize: usize,
     samplesBuffer: &[u8],
-    samplesSizes: &[size_t],
+    samplesSizes: &[usize],
     nbFinalizeSamples: core::ffi::c_uint,
-    nbCheckSamples: size_t,
-    nbSamples: size_t,
+    nbCheckSamples: usize,
+    nbSamples: usize,
     params: ZDICT_cover_params_t,
-    offsets: &[size_t],
-    mut totalCompressedSize: size_t,
+    offsets: &[usize],
+    mut totalCompressedSize: usize,
 ) -> COVER_dictSelection_t {
     let mut largestDict = 0;
     let mut largestCompressed = 0;
@@ -1263,12 +1263,12 @@ fn COVER_tryParameters(data: Box<COVER_tryParameters_data_t>) {
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZDICT_optimizeTrainFromBuffer_cover))]
 pub unsafe extern "C" fn ZDICT_optimizeTrainFromBuffer_cover(
     dictBuffer: *mut core::ffi::c_void,
-    dictBufferCapacity: size_t,
+    dictBufferCapacity: usize,
     samplesBuffer: *const core::ffi::c_void,
-    samplesSizes: *const size_t,
+    samplesSizes: *const usize,
     nbSamples: core::ffi::c_uint,
     parameters: *mut ZDICT_cover_params_t,
-) -> size_t {
+) -> usize {
     let dict = if dictBuffer.is_null() || nbSamples == 0 {
         &mut []
     } else {
@@ -1295,7 +1295,7 @@ pub unsafe extern "C" fn ZDICT_optimizeTrainFromBuffer_cover(
 unsafe fn optimize_train_from_buffer_cover(
     dict: &mut [MaybeUninit<u8>],
     samples: &[u8],
-    samplesSizes: &[size_t],
+    samplesSizes: &[usize],
     parameters: &mut ZDICT_cover_params_t,
 ) -> usize {
     let nbThreads = parameters.nbThreads;
@@ -1356,7 +1356,7 @@ unsafe fn optimize_train_from_buffer_cover(
         return Error::dstSize_tooSmall.to_error_code();
     }
     if nbThreads > 1 {
-        pool = POOL_create(nbThreads as size_t, 1);
+        pool = POOL_create(nbThreads as usize, 1);
         if pool.is_null() {
             return Error::memory_allocation.to_error_code();
         }

--- a/lib/dictBuilder/fastcover.rs
+++ b/lib/dictBuilder/fastcover.rs
@@ -1,7 +1,7 @@
 use std::mem::MaybeUninit;
 use std::time::{Duration, Instant};
 
-use libc::size_t;
+
 
 use crate::lib::common::error_private::{ERR_isError, Error};
 use crate::lib::common::pool::{POOL_add, POOL_create, POOL_free};
@@ -28,12 +28,12 @@ struct FASTCOVER_accel_t {
 #[derive(Debug, Default)]
 struct FASTCOVER_ctx_t<'a> {
     samples: &'a [u8],
-    offsets: Box<[size_t]>,
-    samplesSizes: &'a [size_t],
-    nbSamples: size_t,
-    nbTrainSamples: size_t,
-    nbTestSamples: size_t,
-    nbDmers: size_t,
+    offsets: Box<[usize]>,
+    samplesSizes: &'a [usize],
+    nbSamples: usize,
+    nbTrainSamples: usize,
+    nbTestSamples: usize,
+    nbDmers: usize,
     freqs: Box<[u32]>,
     d: core::ffi::c_uint,
     f: core::ffi::c_uint,
@@ -45,7 +45,7 @@ struct FASTCOVER_ctx_t<'a> {
 struct FASTCOVER_tryParameters_data_t<'a, 'b> {
     ctx: &'b FASTCOVER_ctx_t<'a>,
     best: &'b COVER_best_t,
-    dictBufferCapacity: size_t,
+    dictBufferCapacity: usize,
     parameters: ZDICT_cover_params_t,
 }
 
@@ -55,7 +55,7 @@ const FASTCOVER_DEFAULT_SPLITPOINT: core::ffi::c_double = 0.75f64;
 const DEFAULT_F: core::ffi::c_int = 20;
 const DEFAULT_ACCEL: core::ffi::c_int = 1;
 
-fn FASTCOVER_hashPtrToIndex(p: &[u8; 8], f: u32, d: core::ffi::c_uint) -> size_t {
+fn FASTCOVER_hashPtrToIndex(p: &[u8; 8], f: u32, d: core::ffi::c_uint) -> usize {
     match d {
         6 => ZSTD_hash6Ptr_array(p, f),
         _ => ZSTD_hash8Ptr_array(p, f),
@@ -164,7 +164,7 @@ fn FASTCOVER_selectSegment(
 
 fn FASTCOVER_checkParameters(
     parameters: ZDICT_cover_params_t,
-    maxDictSize: size_t,
+    maxDictSize: usize,
     f: core::ffi::c_uint,
     accel: core::ffi::c_uint,
 ) -> bool {
@@ -174,7 +174,7 @@ fn FASTCOVER_checkParameters(
     if parameters.d != 6 && parameters.d != 8 {
         return false;
     }
-    if parameters.k as size_t > maxDictSize {
+    if parameters.k as usize > maxDictSize {
         return false;
     }
     if parameters.d > parameters.k {
@@ -203,16 +203,16 @@ fn FASTCOVER_computeFrequency(ctx: &mut FASTCOVER_ctx_t) {
     let d = ctx.d;
     let skip = ctx.accelParams.skip;
     let readLength = if d > 8 { d } else { 8 };
-    let mut i: size_t = 0;
+    let mut i: usize = 0;
     i = 0;
     while i < ctx.nbTrainSamples {
         let mut start = ctx.offsets[i];
         let currSampleEnd = ctx.offsets[i + 1];
-        while start.wrapping_add(readLength as size_t) <= currSampleEnd {
+        while start.wrapping_add(readLength as usize) <= currSampleEnd {
             let dmerIndex =
                 FASTCOVER_hashPtrToIndex(ctx.samples[start..][..8].try_into().unwrap(), f, d);
             ctx.freqs[dmerIndex] += 1;
-            start = start.wrapping_add(skip as size_t).wrapping_add(1);
+            start = start.wrapping_add(skip as usize).wrapping_add(1);
         }
         i = i.wrapping_add(1);
     }
@@ -221,13 +221,13 @@ fn FASTCOVER_computeFrequency(ctx: &mut FASTCOVER_ctx_t) {
 fn FASTCOVER_ctx_init<'a>(
     ctx: &mut FASTCOVER_ctx_t<'a>,
     samples: &'a [u8],
-    samplesSizes: &'a [size_t],
+    samplesSizes: &'a [usize],
     d: core::ffi::c_uint,
     splitPoint: core::ffi::c_double,
     f: core::ffi::c_uint,
     accelParams: FASTCOVER_accel_t,
     displayLevel: core::ffi::c_int,
-) -> size_t {
+) -> usize {
     let nbSamples = samplesSizes.len() as core::ffi::c_uint;
     let totalSamplesSize = samplesSizes.iter().sum::<usize>();
     let nbTrainSamples = if splitPoint < 1.0f64 {
@@ -260,7 +260,7 @@ fn FASTCOVER_ctx_init<'a>(
     };
 
     ctx.displayLevel = displayLevel;
-    if totalSamplesSize < Ord::max(d as size_t, ::core::mem::size_of::<u64>())
+    if totalSamplesSize < Ord::max(d as usize, ::core::mem::size_of::<u64>())
         || totalSamplesSize >= FASTCOVER_MAX_SAMPLES_SIZE
     {
         if displayLevel >= 1 {
@@ -304,11 +304,11 @@ fn FASTCOVER_ctx_init<'a>(
     }
     ctx.samples = samples;
     ctx.samplesSizes = samplesSizes;
-    ctx.nbSamples = nbSamples as size_t;
-    ctx.nbTrainSamples = nbTrainSamples as size_t;
-    ctx.nbTestSamples = nbTestSamples as size_t;
+    ctx.nbSamples = nbSamples as usize;
+    ctx.nbTrainSamples = nbTrainSamples as usize;
+    ctx.nbTestSamples = nbTestSamples as usize;
     ctx.nbDmers =
-        trainingSamplesSize.wrapping_sub(Ord::max(d as size_t, ::core::mem::size_of::<u64>())) + 1;
+        trainingSamplesSize.wrapping_sub(Ord::max(d as usize, ::core::mem::size_of::<u64>())) + 1;
     ctx.d = d;
     ctx.f = f;
     ctx.accelParams = accelParams;
@@ -337,9 +337,9 @@ fn FASTCOVER_buildDictionary<'a>(
     let epochs = COVER_computeEpochs(dict.len() as u32, ctx.nbDmers as u32, parameters.k, 1);
     let maxZeroScoreRun = 10;
     let displayLevel = ctx.displayLevel;
-    let mut zeroScoreRun = 0 as size_t;
+    let mut zeroScoreRun = 0 as usize;
     let mut last_update_time = Instant::now();
-    let mut epoch: size_t = 0;
+    let mut epoch: usize = 0;
     if displayLevel >= 2 {
         eprintln!(
             "Breaking content into {} epochs of size {}",
@@ -348,9 +348,9 @@ fn FASTCOVER_buildDictionary<'a>(
     }
     epoch = 0;
     while tail > 0 {
-        let epochBegin = (epoch * epochs.size as size_t) as u32;
+        let epochBegin = (epoch * epochs.size as usize) as u32;
         let epochEnd = epochBegin.wrapping_add(epochs.size);
-        let mut segmentSize: size_t = 0;
+        let mut segmentSize: usize = 0;
         let segment =
             FASTCOVER_selectSegment(ctx, freqs, epochBegin, epochEnd, parameters, segmentFreqs);
         if segment.score == 0 {
@@ -365,7 +365,7 @@ fn FASTCOVER_buildDictionary<'a>(
                 (segment.end - segment.begin + parameters.d - 1) as usize,
                 tail,
             );
-            if segmentSize < parameters.d as size_t {
+            if segmentSize < parameters.d as usize {
                 break;
             }
             tail = tail.wrapping_sub(segmentSize);
@@ -383,7 +383,7 @@ fn FASTCOVER_buildDictionary<'a>(
                 }
             }
         }
-        epoch = epoch.wrapping_add(1) % epochs.num as size_t;
+        epoch = epoch.wrapping_add(1) % epochs.num as usize;
     }
     if displayLevel >= 2 {
         println!("\r{:79 }\r", "");
@@ -412,7 +412,7 @@ fn FASTCOVER_tryParameters(data: Box<FASTCOVER_tryParameters_data_t>) {
     let dict_tail =
         FASTCOVER_buildDictionary(ctx, &mut freqs, &mut dict, parameters, &mut segmentFreqs);
     let nbFinalizeSamples =
-        (ctx.nbTrainSamples * ctx.accelParams.finalize as size_t / 100) as core::ffi::c_uint;
+        (ctx.nbTrainSamples * ctx.accelParams.finalize as usize / 100) as core::ffi::c_uint;
     selection = COVER_selectDict(
         dict_tail,
         dictBufferCapacity,
@@ -507,12 +507,12 @@ fn FASTCOVER_convertToFastCoverParams(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZDICT_trainFromBuffer_fastCover))]
 pub unsafe extern "C" fn ZDICT_trainFromBuffer_fastCover(
     dictBuffer: *mut core::ffi::c_void,
-    dictBufferCapacity: size_t,
+    dictBufferCapacity: usize,
     samplesBuffer: *const core::ffi::c_void,
-    samplesSizes: *const size_t,
+    samplesSizes: *const usize,
     nbSamples: core::ffi::c_uint,
     parameters: ZDICT_fastCover_params_t,
-) -> size_t {
+) -> usize {
     let dict = unsafe { core::slice::from_raw_parts_mut(dictBuffer.cast(), dictBufferCapacity) };
 
     let samplesSizes = if samplesSizes.is_null() || nbSamples == 0 {
@@ -535,7 +535,7 @@ fn train_from_buffer_fastcover(
     samples: &[u8],
     samplesSizes: &[usize],
     mut parameters: ZDICT_fastCover_params_t,
-) -> size_t {
+) -> usize {
     let dictBufferCapacity = dict.len();
 
     let mut ctx = FASTCOVER_ctx_t::default();
@@ -606,7 +606,7 @@ fn train_from_buffer_fastcover(
     ctx.freqs = freqs;
 
     let nbFinalizeSamples =
-        (ctx.nbTrainSamples * ctx.accelParams.finalize as size_t / 100) as core::ffi::c_uint;
+        (ctx.nbTrainSamples * ctx.accelParams.finalize as usize / 100) as core::ffi::c_uint;
     let customDictContentSize = dict_tail.len();
     let dictBuffer = dict.as_mut_ptr() as *mut core::ffi::c_void;
     let customDictContent = dictBuffer.wrapping_add(dictBufferCapacity - customDictContentSize);
@@ -671,12 +671,12 @@ fn train_from_buffer_fastcover(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZDICT_optimizeTrainFromBuffer_fastCover))]
 pub unsafe extern "C" fn ZDICT_optimizeTrainFromBuffer_fastCover(
     dictBuffer: *mut core::ffi::c_void,
-    dictBufferCapacity: size_t,
+    dictBufferCapacity: usize,
     samplesBuffer: *const core::ffi::c_void,
-    samplesSizes: *const size_t,
+    samplesSizes: *const usize,
     nbSamples: core::ffi::c_uint,
     parameters: *mut ZDICT_fastCover_params_t,
-) -> size_t {
+) -> usize {
     let dict = unsafe { core::slice::from_raw_parts_mut(dictBuffer.cast(), dictBufferCapacity) };
 
     let samplesSizes = if samplesSizes.is_null() || nbSamples == 0 {
@@ -701,7 +701,7 @@ fn optimize_train_from_buffer_fastcover(
     samples: &[u8],
     samplesSizes: &[usize],
     parameters: &mut ZDICT_fastCover_params_t,
-) -> size_t {
+) -> usize {
     let dictBufferCapacity = dict.len();
 
     let nbThreads = parameters.nbThreads;
@@ -782,7 +782,7 @@ fn optimize_train_from_buffer_fastcover(
 
     let mut pool = core::ptr::null_mut();
     if nbThreads > 1 {
-        pool = unsafe { POOL_create(nbThreads as size_t, 1) };
+        pool = unsafe { POOL_create(nbThreads as usize, 1) };
         if pool.is_null() {
             return Error::memory_allocation.to_error_code();
         }

--- a/lib/dictBuilder/zdict.rs
+++ b/lib/dictBuilder/zdict.rs
@@ -1,7 +1,7 @@
 use std::mem::MaybeUninit;
 use std::time::{Duration, Instant};
 
-use libc::size_t;
+
 
 use crate::lib::common::bits::ZSTD_highbit32;
 use crate::lib::common::error_private::{ERR_getErrorName, ERR_isError, Error};
@@ -86,19 +86,19 @@ fn ZDICT_printHex(bytes: &[u8]) {
 }
 
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZDICT_isError))]
-pub extern "C" fn ZDICT_isError(errorCode: size_t) -> core::ffi::c_uint {
+pub extern "C" fn ZDICT_isError(errorCode: usize) -> core::ffi::c_uint {
     ERR_isError(errorCode) as _
 }
 
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZDICT_getErrorName))]
-pub extern "C" fn ZDICT_getErrorName(errorCode: size_t) -> *const core::ffi::c_char {
+pub extern "C" fn ZDICT_getErrorName(errorCode: usize) -> *const core::ffi::c_char {
     ERR_getErrorName(errorCode)
 }
 
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZDICT_getDictID))]
 pub unsafe extern "C" fn ZDICT_getDictID(
     dictBuffer: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
 ) -> core::ffi::c_uint {
     if dictSize < 8 {
         return 0;
@@ -112,8 +112,8 @@ pub unsafe extern "C" fn ZDICT_getDictID(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZDICT_getDictHeaderSize))]
 pub unsafe extern "C" fn ZDICT_getDictHeaderSize(
     dictBuffer: *const core::ffi::c_void,
-    dictSize: size_t,
-) -> size_t {
+    dictSize: usize,
+) -> usize {
     if dictSize <= 8 || MEM_readLE32(dictBuffer) != ZSTD_MAGIC_DICTIONARY {
         return Error::dictionary_corrupted.to_error_code();
     }
@@ -132,7 +132,7 @@ pub unsafe extern "C" fn ZDICT_getDictHeaderSize(
     )
 }
 
-fn ZDICT_count(pIn: &[u8], pMatch: &[u8]) -> size_t {
+fn ZDICT_count(pIn: &[u8], pMatch: &[u8]) -> usize {
     pIn.iter()
         .zip(pMatch)
         .position(|(a, b)| a != b)
@@ -161,7 +161,7 @@ fn ZDICT_analyzePos(
         }
     };
 
-    let mut pos = suffix(start as usize) as size_t;
+    let mut pos = suffix(start as usize) as usize;
     let mut end = start;
     let mut solution = DictItem::default();
 
@@ -186,7 +186,7 @@ fn ZDICT_analyzePos(
     }
 
     // look forward
-    let mut length: size_t = 0;
+    let mut length: usize = 0;
     loop {
         end = end.wrapping_add(1);
         length = ZDICT_count(&buffer[pos..], &buffer[suffix(end as usize) as usize..]);
@@ -196,7 +196,7 @@ fn ZDICT_analyzePos(
     }
 
     // look backward
-    let mut length_0: size_t = 0;
+    let mut length_0: usize = 0;
     loop {
         length_0 = ZDICT_count(
             &buffer[pos..],
@@ -269,7 +269,7 @@ fn ZDICT_analyzePos(
 
     // evaluate gain based on new dict
     start = refinedStart;
-    pos = suffix(refinedStart as usize) as size_t;
+    pos = suffix(refinedStart as usize) as usize;
     end = start;
 
     // look forward
@@ -318,7 +318,7 @@ fn ZDICT_analyzePos(
         }
         u_0 = u_0.wrapping_sub(1);
     }
-    maxLength = u_0 as size_t;
+    maxLength = u_0 as usize;
 
     // reduce maxLength in case of final into repetitive data
     let mut l = maxLength as u32;
@@ -326,7 +326,7 @@ fn ZDICT_analyzePos(
     while buffer[pos + l as usize - 2] == c {
         l = l.wrapping_sub(1);
     }
-    maxLength = l as size_t;
+    maxLength = l as usize;
     if maxLength < MINMATCHLENGTH {
         return solution; // skip: no long-enough solution available
     }
@@ -359,7 +359,7 @@ fn ZDICT_analyzePos(
         let mut pEnd: u32 = 0;
         let mut length_3: u32 = 0;
         let testedPos = suffix(id_0 as usize);
-        if testedPos as size_t == pos {
+        if testedPos as usize == pos {
             length_3 = solution.length;
         } else {
             length_3 = ZDICT_count(&buffer[pos..], &buffer[testedPos as usize..]) as u32;
@@ -374,7 +374,7 @@ fn ZDICT_analyzePos(
     solution
 }
 
-fn isIncluded(ip: &[u8], into: &[u8], length: size_t) -> bool {
+fn isIncluded(ip: &[u8], into: &[u8], length: usize) -> bool {
     // NOTE: the slices may not actually have `length` elements,
     // that is OK if there is an unequal value before that.
     let a = ip.iter().take(length);
@@ -518,12 +518,12 @@ fn ZDICT_dictSize(dictList: &[DictItem]) -> usize {
 fn ZDICT_trainBuffer_legacy(
     dictList: &mut [DictItem],
     buffer: &[u8],
-    mut bufferSize: size_t,
-    fileSizes: &[size_t],
+    mut bufferSize: usize,
+    fileSizes: &[usize],
     mut nbFiles: usize,
     mut minRatio: usize,
     notificationLevel: u32,
-) -> size_t {
+) -> usize {
     let mut displayClock = Instant::now();
     let refresh_rate = Duration::from_millis(300);
 
@@ -576,9 +576,9 @@ fn ZDICT_trainBuffer_legacy(
     // It's not used at this stage, but planned to become useful in a later update
     let mut filePos = vec![0u32; nbFiles];
     // filePos[0] is intentionally left 0
-    for pos in 1..nbFiles as size_t {
+    for pos in 1..nbFiles as usize {
         filePos[pos] =
-            (filePos[pos - 1] as size_t).wrapping_add(fileSizes[pos.wrapping_sub(1)]) as u32;
+            (filePos[pos - 1] as usize).wrapping_add(fileSizes[pos.wrapping_sub(1)]) as u32;
     }
 
     if notificationLevel >= 2 {
@@ -660,7 +660,7 @@ unsafe fn ZDICT_countEStats(
     let cSize = ZSTD_compressBlock_deprecated(
         esr.zc,
         esr.workPlace.as_mut_ptr().cast(),
-        ZSTD_BLOCKSIZE_MAX as size_t,
+        ZSTD_BLOCKSIZE_MAX as usize,
         src.as_ptr().cast::<core::ffi::c_void>(),
         srcSize,
     );
@@ -745,14 +745,14 @@ fn ZDICT_flatLit(countLit: &mut [core::ffi::c_uint; 256]) {
 const OFFCODE_MAX: u32 = 30; // only applicable to first block
 unsafe fn ZDICT_analyzeEntropy(
     dstBuffer: *mut core::ffi::c_void,
-    maxDstSize: size_t,
+    maxDstSize: usize,
     compressionLevel: core::ffi::c_int,
     src: &[u8],
     fileSizes: &[usize],
     dictBuffer: *const core::ffi::c_void,
-    dictBufferSize: size_t,
+    dictBufferSize: usize,
     notificationLevel: core::ffi::c_uint,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let mut esr = EStats_ress_t {
         dict: core::ptr::null_mut(),
         zc: core::ptr::null_mut(),
@@ -779,15 +779,15 @@ unsafe fn ZDICT_analyzeEntropy(
 
 unsafe fn analyze_entropy_internal(
     mut dstPtr: *mut u8,
-    mut maxDstSize: size_t,
+    mut maxDstSize: usize,
     mut compressionLevel: core::ffi::c_int,
     src: &[u8],
     fileSizes: &[usize],
     dictBuffer: *const core::ffi::c_void,
-    dictBufferSize: size_t,
+    dictBufferSize: usize,
     notificationLevel: core::ffi::c_uint,
     esr: &mut EStats_ress_t,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let mut hufTable: [HUF_CElt; 257] = [0; 257];
 
     const KB: usize = 1 << 10;
@@ -834,7 +834,7 @@ unsafe fn analyze_entropy_internal(
         ZSTD_customMem::default(),
     );
     esr.zc = ZSTD_createCCtx();
-    esr.workPlace = Box::new_uninit_slice(ZSTD_BLOCKSIZE_MAX as size_t);
+    esr.workPlace = Box::new_uninit_slice(ZSTD_BLOCKSIZE_MAX as usize);
     if (esr.dict).is_null() || (esr.zc).is_null() {
         if notificationLevel >= 1 {
             eprintln!("Not enough memory");
@@ -909,7 +909,7 @@ unsafe fn analyze_entropy_internal(
         offcodeNCount.as_mut_ptr(),
         OffFSELog,
         offcodeCount.as_mut_ptr(),
-        total as size_t,
+        total as usize,
         offcodeMax,
         1,
     );
@@ -926,7 +926,7 @@ unsafe fn analyze_entropy_internal(
         matchLengthNCount.as_mut_ptr(),
         MLFSELog,
         matchLengthCount.as_mut_ptr(),
-        total as size_t,
+        total as usize,
         MaxML,
         1,
     );
@@ -943,7 +943,7 @@ unsafe fn analyze_entropy_internal(
         litLengthNCount.as_mut_ptr(),
         LLFSELog,
         litLengthCount.as_mut_ptr(),
-        total as size_t,
+        total as usize,
         MaxLL,
         1,
     );
@@ -1043,14 +1043,14 @@ unsafe fn analyze_entropy_internal(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZDICT_finalizeDictionary))]
 pub unsafe extern "C" fn ZDICT_finalizeDictionary(
     dictBuffer: *mut core::ffi::c_void,
-    dictBufferCapacity: size_t,
+    dictBufferCapacity: usize,
     customDictContent: *const core::ffi::c_void,
-    dictContentSize: size_t,
+    dictContentSize: usize,
     samplesBuffer: *const core::ffi::c_void,
-    samplesSizes: *const size_t,
+    samplesSizes: *const usize,
     nbSamples: core::ffi::c_uint,
     params: ZDICT_params_t,
-) -> size_t {
+) -> usize {
     let samplesSizes = if samplesSizes.is_null() || nbSamples == 0 {
         &[]
     } else {
@@ -1080,9 +1080,9 @@ const HBUFFSIZE: usize = 256; // should be large enough for all entropy headers
 
 unsafe fn finalize_dictionary(
     dictBuffer: *mut core::ffi::c_void,
-    dictBufferCapacity: size_t,
+    dictBufferCapacity: usize,
     customDictContent: *const core::ffi::c_void,
-    mut dictContentSize: size_t,
+    mut dictContentSize: usize,
     samples: &[u8],
     samplesSizes: &[usize],
     params: ZDICT_params_t,
@@ -1095,7 +1095,7 @@ unsafe fn finalize_dictionary(
     };
     let notificationLevel = params.notificationLevel;
     // the final dictionary content must be at least as large as the largest repcode
-    let minContentSize = *repStartValue.iter().max().unwrap() as size_t;
+    let minContentSize = *repStartValue.iter().max().unwrap() as usize;
 
     // check conditions
     if dictBufferCapacity < dictContentSize {
@@ -1178,11 +1178,11 @@ unsafe fn finalize_dictionary(
 
 unsafe fn ZDICT_addEntropyTablesFromBuffer_advanced(
     dictBuffer: &mut [MaybeUninit<u8>],
-    dictContentSize: size_t,
+    dictContentSize: usize,
     samples: &[u8],
     samplesSizes: &[usize],
     params: ZDICT_params_t,
-) -> size_t {
+) -> usize {
     let dictBufferCapacity = dictBuffer.len();
     let dictBuffer = dictBuffer.as_mut_ptr().cast::<core::ffi::c_void>();
 
@@ -1254,14 +1254,14 @@ unsafe fn ZDICT_addEntropyTablesFromBuffer_advanced(
 /// - an error code, which can be tested with [`ZDICT_isError`]
 fn ZDICT_trainFromBuffer_unsafe_legacy(
     dictBuffer: *mut core::ffi::c_void,
-    maxDictSize: size_t,
+    maxDictSize: usize,
     samples: &[u8],
     samplesSizes: &[usize],
     params: ZDICT_legacy_params_t,
-) -> size_t {
+) -> usize {
     let nbSamples = samplesSizes.len();
     let dictListSize = Ord::max(Ord::max(10000, nbSamples), maxDictSize / 16);
-    let mut dictList = vec![DictItem::default(); dictListSize as size_t];
+    let mut dictList = vec![DictItem::default(); dictListSize as usize];
     let selectivity = if params.selectivityLevel == 0 {
         g_selectivity_default
     } else {
@@ -1484,19 +1484,19 @@ fn uninit_slice<T>(slice: &[T]) -> &[MaybeUninit<T>] {
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZDICT_trainFromBuffer_legacy))]
 pub unsafe extern "C" fn ZDICT_trainFromBuffer_legacy(
     dictBuffer: *mut core::ffi::c_void,
-    dictBufferCapacity: size_t,
+    dictBufferCapacity: usize,
     samplesBuffer: *const core::ffi::c_void,
-    samplesSizes: *const size_t,
+    samplesSizes: *const usize,
     nbSamples: core::ffi::c_uint,
     params: ZDICT_legacy_params_t,
-) -> size_t {
+) -> usize {
     let samplesSizes = if samplesSizes.is_null() || nbSamples == 0 {
         &[]
     } else {
         core::slice::from_raw_parts(samplesSizes, nbSamples as usize)
     };
 
-    let sBuffSize: size_t = samplesSizes.iter().sum();
+    let sBuffSize: usize = samplesSizes.iter().sum();
     if sBuffSize < ZDICT_MIN_SAMPLES_SIZE {
         // not enough content => no dictionary
         return 0;
@@ -1553,11 +1553,11 @@ pub unsafe extern "C" fn ZDICT_trainFromBuffer_legacy(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZDICT_trainFromBuffer))]
 pub unsafe extern "C" fn ZDICT_trainFromBuffer(
     dictBuffer: *mut core::ffi::c_void,
-    dictBufferCapacity: size_t,
+    dictBufferCapacity: usize,
     samplesBuffer: *const core::ffi::c_void,
-    samplesSizes: *const size_t,
+    samplesSizes: *const usize,
     nbSamples: core::ffi::c_uint,
-) -> size_t {
+) -> usize {
     let mut params = ZDICT_fastCover_params_t {
         d: 8,
         steps: 4,
@@ -1581,12 +1581,12 @@ pub unsafe extern "C" fn ZDICT_trainFromBuffer(
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZDICT_addEntropyTablesFromBuffer))]
 pub unsafe extern "C" fn ZDICT_addEntropyTablesFromBuffer(
     dictBuffer: *mut core::ffi::c_void,
-    dictContentSize: size_t,
-    dictBufferCapacity: size_t,
+    dictContentSize: usize,
+    dictBufferCapacity: usize,
     samplesBuffer: *const core::ffi::c_void,
-    samplesSizes: *const size_t,
+    samplesSizes: *const usize,
     nbSamples: core::ffi::c_uint,
-) -> size_t {
+) -> usize {
     let dictBuffer = if dictBuffer.is_null() || dictBufferCapacity == 0 {
         &mut []
     } else {

--- a/lib/legacy/zstd_v05.rs
+++ b/lib/legacy/zstd_v05.rs
@@ -1,7 +1,7 @@
 use core::{mem, ptr};
 use std::marker::PhantomData;
 
-use libc::{free, malloc, ptrdiff_t, size_t};
+use libc::{free, malloc, ptrdiff_t};
 
 use crate::lib::common::error_private::Error;
 use crate::lib::common::mem::{MEM_32bits, MEM_64bits, MEM_readLE16, MEM_readLE32, MEM_readLEST};
@@ -19,14 +19,14 @@ pub(crate) struct ZSTDv05_DCtx {
     base: *const core::ffi::c_void,
     vBase: *const core::ffi::c_void,
     dictEnd: *const core::ffi::c_void,
-    expected: size_t,
-    headerSize: size_t,
+    expected: usize,
+    headerSize: usize,
     params: ZSTDv05_parameters,
     bType: blockType_t,
     stage: ZSTDv05_dStage,
     flagStaticTables: u32,
     litPtr: *const u8,
-    litSize: size_t,
+    litSize: usize,
     litBuffer: [u8; 131080],
     headerBuffer: [u8; ZSTDv05_frameHeaderSize_min],
 }
@@ -60,9 +60,9 @@ struct blockProperties_t {
 #[derive(Copy, Clone)]
 #[repr(C)]
 struct seq_t {
-    litLength: size_t,
-    matchLength: size_t,
-    offset: size_t,
+    litLength: usize,
+    matchLength: usize,
+    offset: usize,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -71,13 +71,13 @@ struct seqState_t<'a> {
     stateLL: FSEv05_DState_t<'a, 1024>,
     stateOffb: FSEv05_DState_t<'a, 512>,
     stateML: FSEv05_DState_t<'a, 1024>,
-    prevOffset: size_t,
+    prevOffset: usize,
     dumps: &'a [u8],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
 struct FSEv05_DState_t<'a, const N: usize> {
-    state: size_t,
+    state: usize,
     table: &'a [FSEv05_decode_t; N],
 }
 #[derive(Copy, Clone)]
@@ -134,13 +134,13 @@ pub(crate) struct ZBUFFv05_DCtx {
     zc: *mut ZSTDv05_DCtx,
     params: ZSTDv05_parameters,
     inBuff: *mut core::ffi::c_char,
-    inBuffSize: size_t,
-    inPos: size_t,
+    inBuffSize: usize,
+    inPos: usize,
     outBuff: *mut core::ffi::c_char,
-    outBuffSize: size_t,
-    outStart: size_t,
-    outEnd: size_t,
-    hPos: size_t,
+    outBuffSize: usize,
+    outStart: usize,
+    outEnd: usize,
+    hPos: usize,
     stage: ZBUFFv05_dStage,
     headerBuffer: [core::ffi::c_uchar; 5],
 }
@@ -156,8 +156,8 @@ const ZSTDv05_MAGICNUMBER: core::ffi::c_uint = 0xfd2fb525 as core::ffi::c_uint;
 const ZSTDv05_WINDOWLOG_ABSOLUTEMIN: u8 = 11;
 const ZSTDv05_DICT_MAGIC: core::ffi::c_uint = 0xec30a435 as core::ffi::c_uint;
 const BLOCKSIZE: core::ffi::c_int = 128 * ((1) << 10);
-static ZSTDv05_blockHeaderSize: size_t = 3;
-static ZSTDv05_frameHeaderSize_min: size_t = 5;
+static ZSTDv05_blockHeaderSize: usize = 3;
+static ZSTDv05_frameHeaderSize_min: usize = 5;
 const ZSTDv05_frameHeaderSize_max: core::ffi::c_int = 5;
 const IS_HUFv05: core::ffi::c_int = 0;
 const IS_PCH: core::ffi::c_int = 1;
@@ -385,7 +385,7 @@ fn FSEv05_decodeSymbol<const N: usize>(
     let nbBits = DInfo.nbBits as u32;
     let symbol = DInfo.symbol;
     let lowBits = bitD.read_bits(nbBits);
-    DStatePtr.state = (DInfo.newState as size_t).wrapping_add(lowBits);
+    DStatePtr.state = (DInfo.newState as usize).wrapping_add(lowBits);
     symbol
 }
 #[inline]
@@ -397,7 +397,7 @@ fn FSEv05_decodeSymbolFast<const N: usize>(
     let nbBits = DInfo.nbBits as u32;
     let symbol = DInfo.symbol;
     let lowBits = bitD.read_bits_fast(nbBits);
-    DStatePtr.state = (DInfo.newState as size_t).wrapping_add(lowBits);
+    DStatePtr.state = (DInfo.newState as usize).wrapping_add(lowBits);
     symbol
 }
 #[inline]
@@ -498,7 +498,7 @@ unsafe fn FSEv05_readNCount(
     maxSVPtr: &mut core::ffi::c_uint,
     tableLogPtr: &mut core::ffi::c_uint,
     headerBuffer: &[u8],
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let istart = headerBuffer.as_ptr();
     let iend = istart.add(headerBuffer.len());
     let mut ip = istart;
@@ -597,7 +597,7 @@ unsafe fn FSEv05_readNCount(
     }
     Ok(ip.offset_from_unsigned(istart))
 }
-fn FSEv05_buildDTable_rle<const N: usize>(dt: &mut FSEv05_DTable<N>, symbolValue: u8) -> size_t {
+fn FSEv05_buildDTable_rle<const N: usize>(dt: &mut FSEv05_DTable<N>, symbolValue: u8) -> usize {
     dt.header.tableLog = 0;
     dt.header.fastMode = 0;
     dt.data[0].newState = 0;
@@ -632,7 +632,7 @@ fn FSEv05_decompress_usingDTable_generic<const N: usize>(
     cSrc: &[u8],
     dt: &FSEv05_DTable<N>,
     fast: core::ffi::c_uint,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let dst_len = dst.len();
     let mut op = dst;
     let mut bitD = BITv05_DStream_t::new(cSrc)?;
@@ -644,8 +644,8 @@ fn FSEv05_decompress_usingDTable_generic<const N: usize>(
         } else {
             FSEv05_decodeSymbol(&mut state1, &mut bitD) as core::ffi::c_int
         }) as u8;
-        if (FSEv05_MAX_TABLELOG * 2 + 7) as size_t
-            > (::core::mem::size_of::<size_t>()).wrapping_mul(8)
+        if (FSEv05_MAX_TABLELOG * 2 + 7) as usize
+            > (::core::mem::size_of::<usize>()).wrapping_mul(8)
         {
             bitD.reload();
         }
@@ -654,8 +654,8 @@ fn FSEv05_decompress_usingDTable_generic<const N: usize>(
         } else {
             FSEv05_decodeSymbol(&mut state2, &mut bitD) as core::ffi::c_int
         }) as u8;
-        if (FSEv05_MAX_TABLELOG * 4 + 7) as size_t
-            > (::core::mem::size_of::<size_t>()).wrapping_mul(8)
+        if (FSEv05_MAX_TABLELOG * 4 + 7) as usize
+            > (::core::mem::size_of::<usize>()).wrapping_mul(8)
             && bitD.reload() > StreamStatus::Unfinished
         {
             op = &mut op[2..];
@@ -666,8 +666,8 @@ fn FSEv05_decompress_usingDTable_generic<const N: usize>(
         } else {
             FSEv05_decodeSymbol(&mut state1, &mut bitD) as core::ffi::c_int
         }) as u8;
-        if (FSEv05_MAX_TABLELOG * 2 + 7) as size_t
-            > (::core::mem::size_of::<size_t>()).wrapping_mul(8)
+        if (FSEv05_MAX_TABLELOG * 2 + 7) as usize
+            > (::core::mem::size_of::<usize>()).wrapping_mul(8)
         {
             bitD.reload();
         }
@@ -715,14 +715,14 @@ fn FSEv05_decompress_usingDTable(
     dst: &mut [u8],
     cSrc: &[u8],
     dt: &FSEv05_DTable<4096>,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let fastMode = dt.header.fastMode as u32;
     if fastMode != 0 {
         return FSEv05_decompress_usingDTable_generic(dst, cSrc, dt, 1);
     }
     FSEv05_decompress_usingDTable_generic(dst, cSrc, dt, 0)
 }
-fn FSEv05_decompress(dst: &mut [u8], cSrc: &[u8]) -> Result<size_t, Error> {
+fn FSEv05_decompress(dst: &mut [u8], cSrc: &[u8]) -> Result<usize, Error> {
     let mut counting: [core::ffi::c_short; 256] = [0; 256];
     let mut dt = FSEv05_DTable {
         header: FSEv05_DTableHeader {
@@ -757,18 +757,18 @@ fn HUFv05_readStats(
     nbSymbolsPtr: &mut u32,
     tableLogPtr: &mut u32,
     src: &[u8],
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let mut ip = src;
-    let mut iSize: size_t = 0;
-    let mut oSize: size_t = 0;
+    let mut iSize: usize = 0;
+    let mut oSize: usize = 0;
     if src.is_empty() {
         return Err(Error::srcSize_wrong);
     }
-    iSize = ip[0] as size_t;
+    iSize = ip[0] as usize;
     if iSize >= 128 {
         if iSize >= 242 {
             static l: [core::ffi::c_int; 14] = [1, 2, 3, 4, 7, 8, 15, 16, 31, 32, 63, 64, 127, 128];
-            oSize = l[iSize.wrapping_sub(242)] as size_t;
+            oSize = l[iSize.wrapping_sub(242)] as usize;
             huffWeight.fill(1);
             iSize = 0;
         } else {
@@ -829,7 +829,7 @@ fn HUFv05_readStats(
     *tableLogPtr = tableLog;
     Ok(iSize.wrapping_add(1))
 }
-unsafe fn HUFv05_readDTableX2(DTable: *mut u16, src: &[u8]) -> Result<size_t, Error> {
+unsafe fn HUFv05_readDTableX2(DTable: *mut u16, src: &[u8]) -> Result<usize, Error> {
     let mut huffWeight = [0; HUFv05_MAX_SYMBOL_VALUE as usize + 1];
     let mut rankVal: [u32; 17] = [0; 17];
     let mut tableLog = 0;
@@ -891,7 +891,7 @@ unsafe fn HUFv05_decodeStreamX2(
     pEnd: *mut u8,
     dt: *const HUFv05_DEltX2,
     dtLog: u32,
-) -> size_t {
+) -> usize {
     let pStart = p;
     while bitDPtr.reload() == StreamStatus::Unfinished && p <= pEnd.sub(4) {
         if MEM_64bits() {
@@ -929,7 +929,7 @@ unsafe fn HUFv05_decompress1X2_usingDTable(
     mut dst: Writer<'_>,
     cSrc: &[u8],
     DTable: *const u16,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let op = dst.as_mut_ptr();
     let oend = op.add(dst.capacity());
     let dtLog = *DTable.add(0) as u32;
@@ -944,7 +944,7 @@ unsafe fn HUFv05_decompress1X2_usingDTable(
     }
     Ok(dst.capacity())
 }
-unsafe fn HUFv05_decompress1X2(dst: Writer<'_>, cSrc: &[u8]) -> Result<size_t, Error> {
+unsafe fn HUFv05_decompress1X2(dst: Writer<'_>, cSrc: &[u8]) -> Result<usize, Error> {
     let mut DTable: [core::ffi::c_ushort; 4097] = [12; 4097];
     let mut ip = cSrc;
     let amount = HUFv05_readDTableX2(DTable.as_mut_ptr(), cSrc)?;
@@ -958,7 +958,7 @@ unsafe fn HUFv05_decompress4X2_usingDTable(
     mut dst: Writer<'_>,
     cSrc: &[u8],
     DTable: *const u16,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     if cSrc.len() < 10 {
         return Err(Error::corruption_detected);
     }
@@ -967,9 +967,9 @@ unsafe fn HUFv05_decompress4X2_usingDTable(
     let oend = ostart.add(dst.capacity());
     let dt = (DTable as *const HUFv05_DEltX2).add(1);
     let dtLog = *DTable as u32;
-    let length1 = MEM_readLE16(istart as *const core::ffi::c_void) as size_t;
-    let length2 = MEM_readLE16(istart.add(2) as *const core::ffi::c_void) as size_t;
-    let length3 = MEM_readLE16(istart.add(4) as *const core::ffi::c_void) as size_t;
+    let length1 = MEM_readLE16(istart as *const core::ffi::c_void) as usize;
+    let length2 = MEM_readLE16(istart.add(2) as *const core::ffi::c_void) as usize;
+    let length3 = MEM_readLE16(istart.add(4) as *const core::ffi::c_void) as usize;
     let istart1 = istart.add(6);
     let istart2 = istart1.add(length1);
     let istart3 = istart2.add(length2);
@@ -1096,7 +1096,7 @@ unsafe fn HUFv05_decompress4X2_usingDTable(
     }
     Ok(dst.capacity())
 }
-fn HUFv05_decompress4X2(dst: Writer<'_>, cSrc: &[u8]) -> Result<size_t, Error> {
+fn HUFv05_decompress4X2(dst: Writer<'_>, cSrc: &[u8]) -> Result<usize, Error> {
     let mut DTable: [core::ffi::c_ushort; 4097] = [12; 4097];
     let amount = unsafe { HUFv05_readDTableX2(DTable.as_mut_ptr(), cSrc)? };
     if amount >= cSrc.len() {
@@ -1211,7 +1211,7 @@ fn HUFv05_fillDTableX4(
         s = s.wrapping_add(1);
     }
 }
-unsafe fn HUFv05_readDTableX4(DTable: &mut [u32; 4097], src: &[u8]) -> Result<size_t, Error> {
+unsafe fn HUFv05_readDTableX4(DTable: &mut [u32; 4097], src: &[u8]) -> Result<usize, Error> {
     let mut weightList = [0; HUFv05_MAX_SYMBOL_VALUE as usize + 1];
     let mut sortedSymbol: [sortedSymbol_t; 256] = [sortedSymbol_t {
         symbol: 0,
@@ -1338,7 +1338,7 @@ unsafe fn HUFv05_decodeStreamX4(
     pEnd: *mut u8,
     dt: *const HUFv05_DEltX4,
     dtLog: u32,
-) -> size_t {
+) -> usize {
     let pStart = p;
     while bitDPtr.reload() == StreamStatus::Unfinished && p < pEnd.sub(7) {
         if MEM_64bits() {
@@ -1384,7 +1384,7 @@ unsafe fn HUFv05_decompress4X4_usingDTable(
     mut dst: Writer<'_>,
     cSrc: &[u8],
     DTable: *const core::ffi::c_uint,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     if cSrc.len() < 10 {
         return Err(Error::corruption_detected);
     }
@@ -1394,9 +1394,9 @@ unsafe fn HUFv05_decompress4X4_usingDTable(
     let dtPtr = DTable as *const core::ffi::c_void;
     let dt = (dtPtr as *const HUFv05_DEltX4).add(1);
     let dtLog = *DTable;
-    let length1 = MEM_readLE16(istart as *const core::ffi::c_void) as size_t;
-    let length2 = MEM_readLE16(istart.add(2) as *const core::ffi::c_void) as size_t;
-    let length3 = MEM_readLE16(istart.add(4) as *const core::ffi::c_void) as size_t;
+    let length1 = MEM_readLE16(istart as *const core::ffi::c_void) as usize;
+    let length2 = MEM_readLE16(istart.add(2) as *const core::ffi::c_void) as usize;
+    let length3 = MEM_readLE16(istart.add(4) as *const core::ffi::c_void) as usize;
     let istart1 = istart.add(6);
     let istart2 = istart1.add(length1);
     let istart3 = istart2.add(length2);
@@ -1507,7 +1507,7 @@ unsafe fn HUFv05_decompress4X4_usingDTable(
     }
     Ok(dst.capacity())
 }
-fn HUFv05_decompress4X4(dst: Writer<'_>, cSrc: &[u8]) -> Result<size_t, Error> {
+fn HUFv05_decompress4X4(dst: Writer<'_>, cSrc: &[u8]) -> Result<usize, Error> {
     let mut DTable: [core::ffi::c_uint; 4097] = [12; 4097];
     let hSize = unsafe { HUFv05_readDTableX4(&mut DTable, cSrc)? };
     if hSize >= cSrc.len() {
@@ -1837,11 +1837,11 @@ static algoTime: [[algo_time_t; 3]; 16] = [
         },
     ],
 ];
-unsafe fn HUFv05_decompress(mut dst: Writer<'_>, cSrc: &[u8]) -> Result<size_t, Error> {
+unsafe fn HUFv05_decompress(mut dst: Writer<'_>, cSrc: &[u8]) -> Result<usize, Error> {
     #[allow(clippy::type_complexity)]
-    static decompress: [fn(Writer<'_>, &[u8]) -> Result<size_t, Error>; 2] = [
-        HUFv05_decompress4X2 as fn(Writer<'_>, &[u8]) -> Result<size_t, Error>,
-        HUFv05_decompress4X4 as fn(Writer<'_>, &[u8]) -> Result<size_t, Error>,
+    static decompress: [fn(Writer<'_>, &[u8]) -> Result<usize, Error>; 2] = [
+        HUFv05_decompress4X2 as fn(Writer<'_>, &[u8]) -> Result<usize, Error>,
+        HUFv05_decompress4X4 as fn(Writer<'_>, &[u8]) -> Result<usize, Error>,
     ];
     let D256 = (dst.capacity() >> 8) as u32;
     if dst.capacity() == 0 {
@@ -1899,14 +1899,14 @@ pub(crate) unsafe fn ZSTDv05_createDCtx() -> *mut ZSTDv05_DCtx {
     ZSTDv05_decompressBegin(dctx);
     dctx
 }
-pub(crate) unsafe fn ZSTDv05_freeDCtx(dctx: *mut ZSTDv05_DCtx) -> size_t {
+pub(crate) unsafe fn ZSTDv05_freeDCtx(dctx: *mut ZSTDv05_DCtx) -> usize {
     free(dctx as *mut core::ffi::c_void);
     0
 }
 fn ZSTDv05_decodeFrameHeader_Part1(
     zc: &mut ZSTDv05_DCtx,
     src: Reader<'_>,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     if src.len() != ZSTDv05_frameHeaderSize_min {
         return Err(Error::srcSize_wrong);
     }
@@ -1920,9 +1920,9 @@ fn ZSTDv05_decodeFrameHeader_Part1(
 pub(crate) fn ZSTDv05_getFrameParams(
     params: &mut ZSTDv05_parameters,
     src: &[u8],
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     if src.len() < ZSTDv05_frameHeaderSize_min {
-        return Ok(ZSTDv05_frameHeaderSize_max as size_t);
+        return Ok(ZSTDv05_frameHeaderSize_max as usize);
     }
     let magicNumber = u32::from_le_bytes(src[..4].try_into().unwrap());
     if magicNumber != ZSTDv05_MAGICNUMBER {
@@ -1944,7 +1944,7 @@ pub(crate) fn ZSTDv05_getFrameParams(
 unsafe fn ZSTDv05_decodeFrameHeader_Part2(
     zc: *mut ZSTDv05_DCtx,
     src: &[u8],
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     if src.len() != (*zc).headerSize {
         return Err(Error::srcSize_wrong);
     }
@@ -1954,7 +1954,7 @@ unsafe fn ZSTDv05_decodeFrameHeader_Part2(
     }
     result
 }
-fn ZSTDv05_getcBlockSize(src: &[u8], bpPtr: &mut blockProperties_t) -> Result<size_t, Error> {
+fn ZSTDv05_getcBlockSize(src: &[u8], bpPtr: &mut blockProperties_t) -> Result<usize, Error> {
     if src.len() < 3 {
         return Err(Error::srcSize_wrong);
     }
@@ -1970,13 +1970,13 @@ fn ZSTDv05_getcBlockSize(src: &[u8], bpPtr: &mut blockProperties_t) -> Result<si
     if bpPtr.blockType == bt_rle {
         return Ok(1);
     }
-    Ok(cSize as size_t)
+    Ok(cSize as usize)
 }
 unsafe fn ZSTDv05_copyRawBlock(
     dst: *mut core::ffi::c_void,
-    maxDstSize: size_t,
+    maxDstSize: usize,
     src: Reader<'_>,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     if dst.is_null() {
         return Err(Error::dstSize_tooSmall);
     }
@@ -1989,15 +1989,15 @@ unsafe fn ZSTDv05_copyRawBlock(
 unsafe fn ZSTDv05_decodeLiteralsBlock(
     dctx: &mut ZSTDv05_DCtx,
     src: Reader<'_>,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let istart = src.as_ptr();
-    if src.len() < MIN_CBLOCK_SIZE as size_t {
+    if src.len() < MIN_CBLOCK_SIZE as usize {
         return Err(Error::corruption_detected);
     }
     match *istart as core::ffi::c_int >> 6 {
         IS_HUFv05 => {
-            let mut litSize: size_t = 0;
-            let mut litCSize: size_t = 0;
+            let mut litSize: usize = 0;
+            let mut litCSize: usize = 0;
             let mut singleStream = 0;
             let mut lhSize = (*istart.add(0) as core::ffi::c_int >> 4 & 3) as u32;
             if src.len() < 5 {
@@ -2009,38 +2009,38 @@ unsafe fn ZSTDv05_decodeLiteralsBlock(
                     litSize = (((*istart as core::ffi::c_int & 15) << 10)
                         + ((*istart.add(1) as core::ffi::c_int) << 2)
                         + (*istart.add(2) as core::ffi::c_int >> 6))
-                        as size_t;
+                        as usize;
                     litCSize = (((*istart.add(2) as core::ffi::c_int & 63) << 8)
                         + *istart.add(3) as core::ffi::c_int)
-                        as size_t;
+                        as usize;
                 }
                 3 => {
                     lhSize = 5;
                     litSize = (((*istart as core::ffi::c_int & 15) << 14)
                         + ((*istart.add(1) as core::ffi::c_int) << 6)
                         + (*istart.add(2) as core::ffi::c_int >> 2))
-                        as size_t;
+                        as usize;
                     litCSize = (((*istart.add(2) as core::ffi::c_int & 3) << 16)
                         + ((*istart.add(3) as core::ffi::c_int) << 8)
                         + *istart.add(4) as core::ffi::c_int)
-                        as size_t;
+                        as usize;
                 }
                 0 | 1 => {
                     lhSize = 3;
-                    singleStream = (*istart as core::ffi::c_int & 16) as size_t;
+                    singleStream = (*istart as core::ffi::c_int & 16) as usize;
                     litSize = (((*istart as core::ffi::c_int & 15) << 6)
                         + (*istart.add(1) as core::ffi::c_int >> 2))
-                        as size_t;
+                        as usize;
                     litCSize = (((*istart.add(1) as core::ffi::c_int & 3) << 8)
                         + *istart.add(2) as core::ffi::c_int)
-                        as size_t;
+                        as usize;
                 }
                 _ => unreachable!(),
             }
-            if litSize > BLOCKSIZE as size_t {
+            if litSize > BLOCKSIZE as usize {
                 return Err(Error::corruption_detected);
             }
-            if litCSize.wrapping_add(lhSize as size_t) > src.len() {
+            if litCSize.wrapping_add(lhSize as usize) > src.len() {
                 return Err(Error::corruption_detected);
             }
             if singleStream != 0 {
@@ -2063,11 +2063,11 @@ unsafe fn ZSTDv05_decodeLiteralsBlock(
                 0,
                 WILDCOPY_OVERLENGTH as usize,
             );
-            Ok(litCSize.wrapping_add(lhSize as size_t))
+            Ok(litCSize.wrapping_add(lhSize as usize))
         }
         IS_PCH => {
-            let mut litSize_0: size_t = 0;
-            let mut litCSize_0: size_t = 0;
+            let mut litSize_0: usize = 0;
+            let mut litCSize_0: usize = 0;
             let mut lhSize = (*istart as core::ffi::c_int >> 4 & 3) as u32;
             if lhSize != 1 {
                 return Err(Error::corruption_detected);
@@ -2077,10 +2077,10 @@ unsafe fn ZSTDv05_decodeLiteralsBlock(
             }
             lhSize = 3;
             litSize_0 = (((*istart.add(0) as core::ffi::c_int & 15) << 6)
-                + (*istart.add(1) as core::ffi::c_int >> 2)) as size_t;
+                + (*istart.add(1) as core::ffi::c_int >> 2)) as usize;
             litCSize_0 = (((*istart.add(1) as core::ffi::c_int & 3) << 8)
-                + *istart.add(2) as core::ffi::c_int) as size_t;
-            if litCSize_0.wrapping_add(lhSize as size_t) > src.len() {
+                + *istart.add(2) as core::ffi::c_int) as usize;
+            if litCSize_0.wrapping_add(lhSize as usize) > src.len() {
                 return Err(Error::corruption_detected);
             }
             HUFv05_decompress1X4_usingDTable(
@@ -2096,35 +2096,35 @@ unsafe fn ZSTDv05_decodeLiteralsBlock(
                 0,
                 WILDCOPY_OVERLENGTH as usize,
             );
-            Ok(litCSize_0.wrapping_add(lhSize as size_t))
+            Ok(litCSize_0.wrapping_add(lhSize as usize))
         }
         IS_RAW => {
-            let mut litSize_1: size_t = 0;
+            let mut litSize_1: usize = 0;
             let mut lhSize_1 = (*istart as core::ffi::c_int >> 4 & 3) as u32;
             match lhSize_1 {
                 2 => {
                     litSize_1 = (((*istart as core::ffi::c_int & 15) << 8)
                         + *istart.add(1) as core::ffi::c_int)
-                        as size_t;
+                        as usize;
                 }
                 3 => {
                     litSize_1 = (((*istart as core::ffi::c_int & 15) << 16)
                         + ((*istart.add(1) as core::ffi::c_int) << 8)
                         + *istart.add(2) as core::ffi::c_int)
-                        as size_t;
+                        as usize;
                 }
                 0 | 1 => {
                     lhSize_1 = 1;
-                    litSize_1 = (*istart as core::ffi::c_int & 31) as size_t;
+                    litSize_1 = (*istart as core::ffi::c_int & 31) as usize;
                 }
                 _ => unreachable!(),
             }
-            if (lhSize_1 as size_t)
+            if (lhSize_1 as usize)
                 .wrapping_add(litSize_1)
-                .wrapping_add(WILDCOPY_OVERLENGTH as size_t)
+                .wrapping_add(WILDCOPY_OVERLENGTH as usize)
                 > src.len()
             {
-                if litSize_1.wrapping_add(lhSize_1 as size_t) > src.len() {
+                if litSize_1.wrapping_add(lhSize_1 as usize) > src.len() {
                     return Err(Error::corruption_detected);
                 }
                 ptr::copy_nonoverlapping(
@@ -2139,47 +2139,47 @@ unsafe fn ZSTDv05_decodeLiteralsBlock(
                     0,
                     WILDCOPY_OVERLENGTH as usize,
                 );
-                return Ok((lhSize_1 as size_t).wrapping_add(litSize_1));
+                return Ok((lhSize_1 as usize).wrapping_add(litSize_1));
             }
             dctx.litPtr = istart.offset(lhSize_1 as isize);
             dctx.litSize = litSize_1;
-            Ok((lhSize_1 as size_t).wrapping_add(litSize_1))
+            Ok((lhSize_1 as usize).wrapping_add(litSize_1))
         }
         IS_RLE => {
-            let mut litSize_2: size_t = 0;
+            let mut litSize_2: usize = 0;
             let mut lhSize_2 = (*istart as core::ffi::c_int >> 4 & 3) as u32;
             match lhSize_2 {
                 2 => {
                     litSize_2 = (((*istart as core::ffi::c_int & 15) << 8)
                         + *istart.add(1) as core::ffi::c_int)
-                        as size_t;
+                        as usize;
                 }
                 3 => {
                     litSize_2 = (((*istart as core::ffi::c_int & 15) << 16)
                         + ((*istart.add(1) as core::ffi::c_int) << 8)
                         + *istart.add(2) as core::ffi::c_int)
-                        as size_t;
+                        as usize;
                     if src.len() < 4 {
                         return Err(Error::corruption_detected);
                     }
                 }
                 0 | 1 => {
                     lhSize_2 = 1;
-                    litSize_2 = (*istart as core::ffi::c_int & 31) as size_t;
+                    litSize_2 = (*istart as core::ffi::c_int & 31) as usize;
                 }
                 _ => unreachable!(),
             }
-            if litSize_2 > BLOCKSIZE as size_t {
+            if litSize_2 > BLOCKSIZE as usize {
                 return Err(Error::corruption_detected);
             }
             core::ptr::write_bytes(
                 dctx.litBuffer.as_mut_ptr(),
                 *istart.offset(lhSize_2 as isize),
-                litSize_2.wrapping_add(WILDCOPY_OVERLENGTH as size_t),
+                litSize_2.wrapping_add(WILDCOPY_OVERLENGTH as usize),
             );
             dctx.litPtr = (&raw mut dctx.litBuffer).cast();
             dctx.litSize = litSize_2;
-            Ok(lhSize_2.wrapping_add(1) as size_t)
+            Ok(lhSize_2.wrapping_add(1) as usize)
         }
         _ => Err(Error::corruption_detected),
     }
@@ -2192,7 +2192,7 @@ unsafe fn ZSTDv05_decodeSeqHeaders(
     DTableOffb: &mut FSEv05_DTable<512>,
     src: Reader<'_>,
     flagStaticTable: u32,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let istart = src.as_ptr();
     let mut ip = istart;
     let iend = istart.add(src.len());
@@ -2202,8 +2202,8 @@ unsafe fn ZSTDv05_decodeSeqHeaders(
     let mut LLlog: core::ffi::c_uint = 0;
     let mut Offlog: core::ffi::c_uint = 0;
     let mut MLlog: core::ffi::c_uint = 0;
-    let mut dumpsLength: size_t = 0;
-    if src.len() < MIN_SEQUENCES_SIZE as size_t {
+    let mut dumpsLength: usize = 0;
+    if src.len() < MIN_SEQUENCES_SIZE as usize {
         return Err(Error::srcSize_wrong);
     }
     let fresh39 = ip;
@@ -2230,15 +2230,15 @@ unsafe fn ZSTDv05_decodeSeqHeaders(
         if ip.add(3) > iend {
             return Err(Error::srcSize_wrong);
         }
-        dumpsLength = *ip.add(2) as size_t;
-        dumpsLength = dumpsLength.wrapping_add(((*ip.add(1) as core::ffi::c_int) << 8) as size_t);
+        dumpsLength = *ip.add(2) as usize;
+        dumpsLength = dumpsLength.wrapping_add(((*ip.add(1) as core::ffi::c_int) << 8) as usize);
         ip = ip.add(3);
     } else {
         if ip.add(2) > iend {
             return Err(Error::srcSize_wrong);
         }
-        dumpsLength = *ip.add(1) as size_t;
-        dumpsLength = dumpsLength.wrapping_add(((*ip as core::ffi::c_int & 1) << 8) as size_t);
+        dumpsLength = *ip.add(1) as usize;
+        dumpsLength = dumpsLength.wrapping_add(((*ip as core::ffi::c_int & 1) << 8) as usize);
         ip = ip.add(2);
     }
     *dumpsPtr = core::slice::from_raw_parts(ip, dumpsLength);
@@ -2247,7 +2247,7 @@ unsafe fn ZSTDv05_decodeSeqHeaders(
         return Err(Error::srcSize_wrong);
     }
     let mut norm: [i16; 128] = [0; 128];
-    let mut headerSize: size_t = 0;
+    let mut headerSize: usize = 0;
     match LLtype {
         1 => {
             LLlog = 0;
@@ -2359,29 +2359,29 @@ unsafe fn ZSTDv05_decodeSeqHeaders(
     Ok(ip.offset_from_unsigned(istart))
 }
 unsafe fn ZSTDv05_decodeSequence(seq: &mut seq_t, seqState: &mut seqState_t) {
-    let mut litLength: size_t = 0;
-    let mut prevOffset: size_t = 0;
-    let mut offset: size_t = 0;
-    let mut matchLength: size_t = 0;
+    let mut litLength: usize = 0;
+    let mut prevOffset: usize = 0;
+    let mut offset: usize = 0;
+    let mut matchLength: usize = 0;
     let mut dumps = seqState.dumps.as_ptr();
     let de = dumps.add(seqState.dumps.len());
-    litLength = FSEv05_peakSymbol(&mut seqState.stateLL) as size_t;
+    litLength = FSEv05_peakSymbol(&mut seqState.stateLL) as usize;
     prevOffset = if litLength != 0 {
         seq.offset
     } else {
         seqState.prevOffset
     };
-    if litLength == MaxLL as size_t {
+    if litLength == MaxLL as usize {
         let fresh44 = dumps;
         dumps = dumps.add(1);
         let add = *fresh44 as u32;
         if add < 255 {
-            litLength = litLength.wrapping_add(add as size_t);
+            litLength = litLength.wrapping_add(add as usize);
         } else if dumps.add(2) <= de {
-            litLength = MEM_readLE16(dumps as *const core::ffi::c_void) as size_t;
+            litLength = MEM_readLE16(dumps as *const core::ffi::c_void) as usize;
             dumps = dumps.add(2);
             if litLength & 1 != 0 && dumps < de {
-                litLength = litLength.wrapping_add(((*dumps as core::ffi::c_int) << 16) as size_t);
+                litLength = litLength.wrapping_add(((*dumps as core::ffi::c_int) << 16) as usize);
                 dumps = dumps.add(1);
             }
             litLength >>= 1;
@@ -2400,7 +2400,7 @@ unsafe fn ZSTDv05_decodeSequence(seq: &mut seq_t, seqState: &mut seqState_t) {
     if offsetCode == 0 {
         nbBits = 0;
     }
-    offset = (*offsetPrefix.as_ptr().offset(offsetCode as isize) as size_t)
+    offset = (*offsetPrefix.as_ptr().offset(offsetCode as isize) as usize)
         .wrapping_add(seqState.DStream.read_bits(nbBits));
     if MEM_32bits() {
         seqState.DStream.reload();
@@ -2416,8 +2416,8 @@ unsafe fn ZSTDv05_decodeSequence(seq: &mut seq_t, seqState: &mut seqState_t) {
     if MEM_32bits() {
         seqState.DStream.reload();
     }
-    matchLength = FSEv05_decodeSymbol(&mut seqState.stateML, &mut seqState.DStream) as size_t;
-    if matchLength == MaxML as size_t {
+    matchLength = FSEv05_decodeSymbol(&mut seqState.stateML, &mut seqState.DStream) as usize;
+    if matchLength == MaxML as usize {
         let add_0 = (if dumps < de {
             let fresh45 = dumps;
             dumps = dumps.add(1);
@@ -2426,13 +2426,13 @@ unsafe fn ZSTDv05_decodeSequence(seq: &mut seq_t, seqState: &mut seqState_t) {
             0
         }) as u32;
         if add_0 < 255 {
-            matchLength = matchLength.wrapping_add(add_0 as size_t);
+            matchLength = matchLength.wrapping_add(add_0 as usize);
         } else if dumps.add(2) <= de {
-            matchLength = MEM_readLE16(dumps as *const core::ffi::c_void) as size_t;
+            matchLength = MEM_readLE16(dumps as *const core::ffi::c_void) as usize;
             dumps = dumps.add(2);
             if matchLength & 1 != 0 && dumps < de {
                 matchLength =
-                    matchLength.wrapping_add(((*dumps as core::ffi::c_int) << 16) as size_t);
+                    matchLength.wrapping_add(((*dumps as core::ffi::c_int) << 16) as usize);
                 dumps = dumps.add(1);
             }
             matchLength >>= 1;
@@ -2441,7 +2441,7 @@ unsafe fn ZSTDv05_decodeSequence(seq: &mut seq_t, seqState: &mut seqState_t) {
             dumps = de.sub(1);
         }
     }
-    matchLength = matchLength.wrapping_add(MINMATCH as size_t);
+    matchLength = matchLength.wrapping_add(MINMATCH as usize);
     seq.litLength = litLength;
     seq.offset = offset;
     seq.matchLength = matchLength;
@@ -2456,7 +2456,7 @@ unsafe fn ZSTDv05_execSequence(
     base: *const u8,
     vBase: *const u8,
     dictEnd: *const u8,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     static dec32table: [core::ffi::c_int; 8] = [0, 1, 2, 1, 4, 4, 4, 4];
     static dec64table: [core::ffi::c_int; 8] = [8, 8, 8, 7, 8, 9, 10, 11];
     let oLitEnd = op.add(sequence.litLength);
@@ -2498,7 +2498,7 @@ unsafe fn ZSTDv05_execSequence(
         op = oLitEnd.add(length1);
         sequence.matchLength = (sequence.matchLength).wrapping_sub(length1);
         match_0 = base;
-        if op > oend_8 || sequence.matchLength < MINMATCH as size_t {
+        if op > oend_8 || sequence.matchLength < MINMATCH as usize {
             while op < oMatchEnd {
                 let fresh46 = match_0;
                 match_0 = match_0.add(1);
@@ -2546,9 +2546,9 @@ unsafe fn ZSTDv05_execSequence(
 unsafe fn ZSTDv05_decompressSequences(
     dctx: &mut ZSTDv05_DCtx,
     dst: *mut core::ffi::c_void,
-    maxDstSize: size_t,
+    maxDstSize: usize,
     mut seq: Reader<'_>,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let ostart = dst as *mut u8;
     let mut op = ostart;
     let oend = ostart.add(maxDstSize);
@@ -2582,17 +2582,17 @@ unsafe fn ZSTDv05_decompressSequences(
             stateOffb: FSEv05_initDState(&mut DStream, DTableOffb),
             stateML: FSEv05_initDState(&mut DStream, DTableML),
             DStream,
-            prevOffset: REPCODE_STARTVALUE as size_t,
+            prevOffset: REPCODE_STARTVALUE as usize,
             dumps,
         };
 
         let mut sequence = seq_t {
             litLength: 0,
             matchLength: 0,
-            offset: REPCODE_STARTVALUE as size_t,
+            offset: REPCODE_STARTVALUE as usize,
         };
         while seqState.DStream.reload() <= StreamStatus::Completed && nbSeq != 0 {
-            let mut oneSeqSize: size_t = 0;
+            let mut oneSeqSize: usize = 0;
             nbSeq -= 1;
             ZSTDv05_decodeSequence(&mut sequence, &mut seqState);
             oneSeqSize = ZSTDv05_execSequence(
@@ -2638,11 +2638,11 @@ unsafe fn ZSTDv05_checkContinuity(dctx: &mut ZSTDv05_DCtx, dst: *const core::ffi
 unsafe fn ZSTDv05_decompressBlock_internal(
     dctx: &mut ZSTDv05_DCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: Reader<'_>,
-) -> Result<size_t, Error> {
-    let mut litCSize: size_t = 0;
-    if src.len() >= BLOCKSIZE as size_t {
+) -> Result<usize, Error> {
+    let mut litCSize: usize = 0;
+    if src.len() >= BLOCKSIZE as usize {
         return Err(Error::srcSize_wrong);
     }
     litCSize = ZSTDv05_decodeLiteralsBlock(dctx, src.subslice(..))?;
@@ -2651,9 +2651,9 @@ unsafe fn ZSTDv05_decompressBlock_internal(
 unsafe fn ZSTDv05_decompress_continueDCtx(
     dctx: &mut ZSTDv05_DCtx,
     dst: *mut core::ffi::c_void,
-    maxDstSize: size_t,
+    maxDstSize: usize,
     src: Reader<'_>,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let mut ip = src.as_ptr();
     let iend = ip.add(src.len());
     let ostart = dst as *mut u8;
@@ -2669,7 +2669,7 @@ unsafe fn ZSTDv05_decompress_continueDCtx(
         0,
         ::core::mem::size_of::<blockProperties_t>(),
     );
-    let mut frameHeaderSize: size_t = 0;
+    let mut frameHeaderSize: usize = 0;
     if src.len() < ZSTDv05_frameHeaderSize_min.wrapping_add(ZSTDv05_blockHeaderSize) {
         return Err(Error::srcSize_wrong);
     }
@@ -2730,16 +2730,16 @@ unsafe fn ZSTDv05_decompress_continueDCtx(
 pub(crate) unsafe fn ZSTDv05_decompress_usingDict(
     dctx: &mut ZSTDv05_DCtx,
     dst: *mut core::ffi::c_void,
-    maxDstSize: size_t,
+    maxDstSize: usize,
     src: Reader<'_>,
     dict: &[u8],
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     let _ = ZSTDv05_decompressBegin_usingDict(dctx, dict);
     ZSTDv05_checkContinuity(dctx, dst);
     ZSTDv05_decompress_continueDCtx(dctx, dst, maxDstSize, src)
 }
 fn ZSTD_errorFrameSizeInfoLegacy(
-    cSize: &mut size_t,
+    cSize: &mut usize,
     dBound: &mut core::ffi::c_ulonglong,
     ret: Error,
 ) {
@@ -2748,11 +2748,11 @@ fn ZSTD_errorFrameSizeInfoLegacy(
 }
 pub(crate) fn ZSTDv05_findFrameSizeInfoLegacy(
     src: &[u8],
-    cSize: &mut size_t,
+    cSize: &mut usize,
     dBound: &mut core::ffi::c_ulonglong,
 ) {
     let mut ip = src;
-    let mut nbBlocks = 0 as size_t;
+    let mut nbBlocks = 0 as usize;
     let mut blockProperties = blockProperties_t {
         blockType: bt_compressed,
         origSize: 0,
@@ -2786,17 +2786,17 @@ pub(crate) fn ZSTDv05_findFrameSizeInfoLegacy(
         nbBlocks = nbBlocks.wrapping_add(1);
     }
     *cSize = src.len() - ip.len();
-    *dBound = (nbBlocks * BLOCKSIZE as size_t) as core::ffi::c_ulonglong;
+    *dBound = (nbBlocks * BLOCKSIZE as usize) as core::ffi::c_ulonglong;
 }
-fn ZSTDv05_nextSrcSizeToDecompress(dctx: &mut ZSTDv05_DCtx) -> size_t {
+fn ZSTDv05_nextSrcSizeToDecompress(dctx: &mut ZSTDv05_DCtx) -> usize {
     dctx.expected
 }
 unsafe fn ZSTDv05_decompressContinue(
     dctx: &mut ZSTDv05_DCtx,
     dst: *mut core::ffi::c_void,
-    maxDstSize: size_t,
+    maxDstSize: usize,
     src: Reader<'_>,
-) -> Result<size_t, Error> {
+) -> Result<usize, Error> {
     if src.len() != dctx.expected {
         return Err(Error::srcSize_wrong);
     }
@@ -2867,7 +2867,7 @@ unsafe fn ZSTDv05_refDictContent(dctx: &mut ZSTDv05_DCtx, dict: &[u8]) {
     dctx.base = dict.as_ptr().cast();
     dctx.previousDstEnd = dict.as_ptr().add(dict.len()) as *const core::ffi::c_void;
 }
-unsafe fn ZSTDv05_loadEntropy(dctx: &mut ZSTDv05_DCtx, mut dict: &[u8]) -> Result<size_t, Error> {
+unsafe fn ZSTDv05_loadEntropy(dctx: &mut ZSTDv05_DCtx, mut dict: &[u8]) -> Result<usize, Error> {
     let hSize =
         HUFv05_readDTableX4(&mut dctx.hufTableX4, dict).map_err(|_| Error::dictionary_corrupted)?;
     dict = &dict[hSize..];
@@ -2970,12 +2970,12 @@ unsafe fn ZSTDv05_decompressBegin_usingDict(
     }
     Ok(())
 }
-static ZBUFFv05_blockHeaderSize: size_t = 3;
+static ZBUFFv05_blockHeaderSize: usize = 3;
 unsafe fn ZBUFFv05_limitCopy(
     dst: *mut core::ffi::c_void,
-    maxDstSize: size_t,
+    maxDstSize: usize,
     src: &[u8],
-) -> size_t {
+) -> usize {
     let length = Ord::min(maxDstSize, src.len());
     ptr::copy_nonoverlapping(src.as_ptr(), dst.cast::<u8>(), length);
     length
@@ -2991,7 +2991,7 @@ pub(crate) unsafe fn ZBUFFv05_createDCtx() -> *mut ZBUFFv05_DCtx {
     (*zbc).stage = ZBUFFv05ds_init;
     zbc
 }
-pub(crate) unsafe fn ZBUFFv05_freeDCtx(zbc: *mut ZBUFFv05_DCtx) -> size_t {
+pub(crate) unsafe fn ZBUFFv05_freeDCtx(zbc: *mut ZBUFFv05_DCtx) -> usize {
     if zbc.is_null() {
         return 0;
     }
@@ -3017,10 +3017,10 @@ pub(crate) unsafe fn ZBUFFv05_decompressInitDictionary(
 pub(crate) unsafe fn ZBUFFv05_decompressContinue(
     zbc: &mut ZBUFFv05_DCtx,
     dst: *mut core::ffi::c_void,
-    maxDstSizePtr: *mut size_t,
+    maxDstSizePtr: *mut usize,
     src: *const u8,
-    srcSizePtr: *mut size_t,
-) -> Result<size_t, Error> {
+    srcSizePtr: *mut usize,
+) -> Result<usize, Error> {
     let istart = src;
     let mut ip = istart;
     let iend = istart.add(*srcSizePtr);
@@ -3065,7 +3065,7 @@ pub(crate) unsafe fn ZBUFFv05_decompressContinue(
                 // complete header from src
                 let mut headerSize_0 = ZBUFFv05_limitCopy(
                     (zbc.headerBuffer).as_mut_ptr().add(zbc.hPos) as *mut core::ffi::c_void,
-                    (ZSTDv05_frameHeaderSize_max_0 as size_t).wrapping_sub(zbc.hPos),
+                    (ZSTDv05_frameHeaderSize_max_0 as usize).wrapping_sub(zbc.hPos),
                     core::slice::from_raw_parts(src, *srcSizePtr),
                 );
                 zbc.hPos = (zbc.hPos).wrapping_add(headerSize_0);
@@ -3098,7 +3098,7 @@ pub(crate) unsafe fn ZBUFFv05_decompressContinue(
 
             // apply header to create / resize buffers
             let neededOutSize = 1 << zbc.params.windowLog;
-            let neededInSize = BLOCKSIZE as size_t; // a block is never > BLOCKSIZE
+            let neededInSize = BLOCKSIZE as usize; // a block is never > BLOCKSIZE
             if zbc.inBuffSize < neededInSize {
                 free(zbc.inBuff as *mut core::ffi::c_void);
                 zbc.inBuffSize = neededInSize;
@@ -3171,7 +3171,7 @@ pub(crate) unsafe fn ZBUFFv05_decompressContinue(
             let neededInSize = ZSTDv05_nextSrcSizeToDecompress(&mut *zbc.zc);
             // should always be <= remaining space within inBuff
             let toLoad = neededInSize.wrapping_sub(zbc.inPos);
-            let mut loadedSize: size_t = 0;
+            let mut loadedSize: usize = 0;
             if toLoad > (zbc.inBuffSize).wrapping_sub(zbc.inPos) {
                 return Err(Error::corruption_detected); // should never happen
             }
@@ -3218,7 +3218,7 @@ pub(crate) unsafe fn ZBUFFv05_decompressContinue(
             zbc.outStart = (zbc.outStart).wrapping_add(flushedSize);
             if flushedSize == toFlushSize {
                 zbc.stage = ZBUFFv05ds_read;
-                if (zbc.outStart).wrapping_add(BLOCKSIZE as size_t) > zbc.outBuffSize {
+                if (zbc.outStart).wrapping_add(BLOCKSIZE as usize) > zbc.outBuffSize {
                     zbc.outEnd = 0;
                     zbc.outStart = zbc.outEnd;
                 }

--- a/lib/legacy/zstd_v06.rs
+++ b/lib/legacy/zstd_v06.rs
@@ -1,6 +1,6 @@
 use core::ptr;
 
-use libc::{free, malloc, memcpy, ptrdiff_t, size_t};
+use libc::{free, malloc, memcpy, ptrdiff_t};
 
 use crate::lib::common::error_private::{ERR_isError, Error};
 use crate::lib::common::mem::{
@@ -18,14 +18,14 @@ pub(crate) struct ZSTDv06_DCtx {
     base: *const core::ffi::c_void,
     vBase: *const core::ffi::c_void,
     dictEnd: *const core::ffi::c_void,
-    expected: size_t,
-    headerSize: size_t,
+    expected: usize,
+    headerSize: usize,
     fParams: ZSTDv06_frameParams,
     bType: blockType_t,
     stage: ZSTDv06_dStage,
     flagRepeatTable: u32,
     litPtr: *const u8,
-    litSize: size_t,
+    litSize: usize,
     litBuffer: [u8; 131080],
     headerBuffer: [u8; 13],
 }
@@ -55,9 +55,9 @@ struct blockProperties_t {
 #[derive(Copy, Clone)]
 #[repr(C)]
 struct seq_t {
-    litLength: size_t,
-    matchLength: size_t,
-    offset: size_t,
+    litLength: usize,
+    matchLength: usize,
+    offset: usize,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -66,18 +66,18 @@ struct seqState_t {
     stateLL: FSEv06_DState_t,
     stateOffb: FSEv06_DState_t,
     stateML: FSEv06_DState_t,
-    prevOffset: [size_t; 3],
+    prevOffset: [usize; 3],
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
 struct FSEv06_DState_t {
-    state: size_t,
+    state: usize,
     table: *const core::ffi::c_void,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
 struct BITv06_DStream_t {
-    bitContainer: size_t,
+    bitContainer: usize,
     bitsConsumed: core::ffi::c_uint,
     ptr: *const core::ffi::c_char,
     start: *const core::ffi::c_char,
@@ -109,7 +109,7 @@ struct HUFv06_DEltX4 {
     length: u8,
 }
 type decompressionAlgo =
-    Option<unsafe fn(*mut core::ffi::c_void, size_t, *const core::ffi::c_void, size_t) -> size_t>;
+    Option<unsafe fn(*mut core::ffi::c_void, usize, *const core::ffi::c_void, usize) -> usize>;
 type rankVal_t = [[u32; 17]; 16];
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -136,15 +136,15 @@ pub(crate) struct ZBUFFv06_DCtx_s {
     fParams: ZSTDv06_frameParams,
     stage: ZBUFFv06_dStage,
     inBuff: *mut core::ffi::c_char,
-    inBuffSize: size_t,
-    inPos: size_t,
+    inBuffSize: usize,
+    inPos: usize,
     outBuff: *mut core::ffi::c_char,
-    outBuffSize: size_t,
-    outStart: size_t,
-    outEnd: size_t,
-    blockSize: size_t,
+    outBuffSize: usize,
+    outStart: usize,
+    outEnd: usize,
+    blockSize: usize,
     headerBuffer: [u8; 13],
-    lhSize: size_t,
+    lhSize: usize,
 }
 type ZBUFFv06_dStage = core::ffi::c_uint;
 const ZBUFFds_flush: ZBUFFv06_dStage = 4;
@@ -154,16 +154,16 @@ const ZBUFFds_loadHeader: ZBUFFv06_dStage = 1;
 const ZBUFFds_init: ZBUFFv06_dStage = 0;
 type ZBUFFv06_DCtx = ZBUFFv06_DCtx_s;
 const ZSTDv06_MAGICNUMBER: core::ffi::c_uint = 0xfd2fb526 as core::ffi::c_uint;
-static ZSTDv06_frameHeaderSize_min: size_t = 5;
+static ZSTDv06_frameHeaderSize_min: usize = 5;
 const ZSTDv06_BLOCKSIZE_MAX: core::ffi::c_int = 128 * 1024;
 const ZSTDv06_DICT_MAGIC: core::ffi::c_uint = 0xec30a436 as core::ffi::c_uint;
 const ZSTDv06_REP_NUM: core::ffi::c_int = 3;
 const ZSTDv06_REP_INIT: core::ffi::c_int = 3;
 const ZSTDv06_REP_MOVE: core::ffi::c_int = ZSTDv06_REP_NUM - 1;
 const ZSTDv06_WINDOWLOG_ABSOLUTEMIN: core::ffi::c_int = 12;
-static ZSTDv06_fcs_fieldSize: [size_t; 4] = [0, 1, 2, 8];
+static ZSTDv06_fcs_fieldSize: [usize; 4] = [0, 1, 2, 8];
 const ZSTDv06_BLOCKHEADERSIZE: core::ffi::c_int = 3;
-static ZSTDv06_blockHeaderSize: size_t = ZSTDv06_BLOCKHEADERSIZE as size_t;
+static ZSTDv06_blockHeaderSize: usize = ZSTDv06_BLOCKHEADERSIZE as usize;
 const MIN_SEQUENCES_SIZE: core::ffi::c_int = 1;
 const MIN_CBLOCK_SIZE: core::ffi::c_int = 1 + 1 + MIN_SEQUENCES_SIZE;
 const ZSTD_HUFFDTABLE_CAPACITY_LOG: core::ffi::c_int = 12;
@@ -233,8 +233,8 @@ unsafe fn BITv06_highbit32(val: u32) -> core::ffi::c_uint {
 unsafe fn BITv06_initDStream(
     bitD: *mut BITv06_DStream_t,
     srcBuffer: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     if srcSize < 1 {
         ptr::write_bytes(
             bitD as *mut u8,
@@ -246,12 +246,12 @@ unsafe fn BITv06_initDStream(
 
     let bitD = &mut *bitD;
 
-    if srcSize >= ::core::mem::size_of::<size_t>() {
+    if srcSize >= ::core::mem::size_of::<usize>() {
         // normal case
         bitD.start = srcBuffer as *const core::ffi::c_char;
         bitD.ptr = (srcBuffer as *const core::ffi::c_char)
             .add(srcSize)
-            .sub(::core::mem::size_of::<size_t>());
+            .sub(::core::mem::size_of::<usize>());
         bitD.bitContainer = MEM_readLEST(bitD.ptr as *const core::ffi::c_void);
         let lastByte = *(srcBuffer as *const u8).add(srcSize.wrapping_sub(1));
         if lastByte == 0 {
@@ -261,33 +261,33 @@ unsafe fn BITv06_initDStream(
     } else {
         bitD.start = srcBuffer as *const core::ffi::c_char;
         bitD.ptr = bitD.start;
-        bitD.bitContainer = *(bitD.start as *const u8) as size_t;
+        bitD.bitContainer = *(bitD.start as *const u8) as usize;
 
         if srcSize == 7 {
-            bitD.bitContainer += (*(bitD.start as *const u8).add(6) as size_t)
-                << (::core::mem::size_of::<size_t>() * 8 - 16);
+            bitD.bitContainer += (*(bitD.start as *const u8).add(6) as usize)
+                << (::core::mem::size_of::<usize>() * 8 - 16);
         }
 
         if srcSize >= 6 {
-            bitD.bitContainer += (*(bitD.start as *const u8).add(5) as size_t)
-                << (::core::mem::size_of::<size_t>() * 8 - 24);
+            bitD.bitContainer += (*(bitD.start as *const u8).add(5) as usize)
+                << (::core::mem::size_of::<usize>() * 8 - 24);
         }
 
         if srcSize >= 5 {
-            bitD.bitContainer += (*(bitD.start as *const u8).add(4) as size_t)
-                << (::core::mem::size_of::<size_t>() * 8 - 32);
+            bitD.bitContainer += (*(bitD.start as *const u8).add(4) as usize)
+                << (::core::mem::size_of::<usize>() * 8 - 32);
         }
 
         if srcSize >= 4 {
-            bitD.bitContainer += (*(bitD.start as *const u8).add(3) as size_t) << 24;
+            bitD.bitContainer += (*(bitD.start as *const u8).add(3) as usize) << 24;
         }
 
         if srcSize >= 3 {
-            bitD.bitContainer += (*(bitD.start as *const u8).add(2) as size_t) << 16;
+            bitD.bitContainer += (*(bitD.start as *const u8).add(2) as usize) << 16;
         }
 
         if srcSize >= 2 {
-            bitD.bitContainer += (*(bitD.start as *const u8).add(1) as size_t) << 8;
+            bitD.bitContainer += (*(bitD.start as *const u8).add(1) as usize) << 8;
         }
 
         let lastByte = *(srcBuffer as *const u8).add(srcSize - 1);
@@ -296,14 +296,14 @@ unsafe fn BITv06_initDStream(
             return Error::GENERIC.to_error_code();
         }
         bitD.bitsConsumed = (8 as core::ffi::c_uint) - BITv06_highbit32(lastByte as u32);
-        bitD.bitsConsumed += (::core::mem::size_of::<size_t>() - srcSize) as u32 * 8;
+        bitD.bitsConsumed += (::core::mem::size_of::<usize>() - srcSize) as u32 * 8;
     }
     srcSize
 }
 
 #[inline]
-unsafe fn BITv06_lookBits(bitD: *const BITv06_DStream_t, nbBits: u32) -> size_t {
-    let bitMask = (::core::mem::size_of::<size_t>())
+unsafe fn BITv06_lookBits(bitD: *const BITv06_DStream_t, nbBits: u32) -> usize {
+    let bitMask = (::core::mem::size_of::<usize>())
         .wrapping_mul(8)
         .wrapping_sub(1) as u32;
     (*bitD).bitContainer << ((*bitD).bitsConsumed & bitMask)
@@ -311,8 +311,8 @@ unsafe fn BITv06_lookBits(bitD: *const BITv06_DStream_t, nbBits: u32) -> size_t 
         >> (bitMask.wrapping_sub(nbBits) & bitMask)
 }
 #[inline]
-unsafe fn BITv06_lookBitsFast(bitD: *const BITv06_DStream_t, nbBits: u32) -> size_t {
-    let bitMask = (::core::mem::size_of::<size_t>())
+unsafe fn BITv06_lookBitsFast(bitD: *const BITv06_DStream_t, nbBits: u32) -> usize {
+    let bitMask = (::core::mem::size_of::<usize>())
         .wrapping_mul(8)
         .wrapping_sub(1) as u32;
     (*bitD).bitContainer << ((*bitD).bitsConsumed & bitMask)
@@ -323,30 +323,30 @@ unsafe fn BITv06_skipBits(bitD: *mut BITv06_DStream_t, nbBits: u32) {
     (*bitD).bitsConsumed = ((*bitD).bitsConsumed).wrapping_add(nbBits);
 }
 #[inline]
-unsafe fn BITv06_readBits(bitD: *mut BITv06_DStream_t, nbBits: u32) -> size_t {
+unsafe fn BITv06_readBits(bitD: *mut BITv06_DStream_t, nbBits: u32) -> usize {
     let value = BITv06_lookBits(bitD, nbBits);
     BITv06_skipBits(bitD, nbBits);
     value
 }
 #[inline]
-unsafe fn BITv06_readBitsFast(bitD: *mut BITv06_DStream_t, nbBits: u32) -> size_t {
+unsafe fn BITv06_readBitsFast(bitD: *mut BITv06_DStream_t, nbBits: u32) -> usize {
     let value = BITv06_lookBitsFast(bitD, nbBits);
     BITv06_skipBits(bitD, nbBits);
     value
 }
 #[inline]
 unsafe fn BITv06_reloadDStream(bitD: *mut BITv06_DStream_t) -> BITv06_DStream_status {
-    if (*bitD).bitsConsumed as size_t > (::core::mem::size_of::<size_t>()).wrapping_mul(8) {
+    if (*bitD).bitsConsumed as usize > (::core::mem::size_of::<usize>()).wrapping_mul(8) {
         return BITv06_DStream_overflow;
     }
-    if (*bitD).ptr >= ((*bitD).start).add(::core::mem::size_of::<size_t>()) {
+    if (*bitD).ptr >= ((*bitD).start).add(::core::mem::size_of::<usize>()) {
         (*bitD).ptr = ((*bitD).ptr).offset(-(((*bitD).bitsConsumed >> 3) as isize));
         (*bitD).bitsConsumed &= 7;
         (*bitD).bitContainer = MEM_readLEST((*bitD).ptr as *const core::ffi::c_void);
         return BITv06_DStream_unfinished;
     }
     if (*bitD).ptr == (*bitD).start {
-        if ((*bitD).bitsConsumed as size_t) < (::core::mem::size_of::<size_t>()).wrapping_mul(8) {
+        if ((*bitD).bitsConsumed as usize) < (::core::mem::size_of::<usize>()).wrapping_mul(8) {
             return BITv06_DStream_endOfBuffer;
         }
         return BITv06_DStream_completed;
@@ -365,7 +365,7 @@ unsafe fn BITv06_reloadDStream(bitD: *mut BITv06_DStream_t) -> BITv06_DStream_st
 #[inline]
 unsafe fn BITv06_endOfDStream(DStream: *const BITv06_DStream_t) -> core::ffi::c_uint {
     ((*DStream).ptr == (*DStream).start
-        && (*DStream).bitsConsumed as size_t == (::core::mem::size_of::<size_t>()).wrapping_mul(8))
+        && (*DStream).bitsConsumed as usize == (::core::mem::size_of::<usize>()).wrapping_mul(8))
         as core::ffi::c_int as core::ffi::c_uint
 }
 #[inline]
@@ -390,7 +390,7 @@ unsafe fn FSEv06_updateState(DStatePtr: *mut FSEv06_DState_t, bitD: *mut BITv06_
     let DInfo = *((*DStatePtr).table as *const FSEv06_decode_t).add((*DStatePtr).state);
     let nbBits = DInfo.nbBits as u32;
     let lowBits = BITv06_readBits(bitD, nbBits);
-    (*DStatePtr).state = (DInfo.newState as size_t).wrapping_add(lowBits);
+    (*DStatePtr).state = (DInfo.newState as usize).wrapping_add(lowBits);
 }
 #[inline]
 unsafe fn FSEv06_decodeSymbol(
@@ -401,7 +401,7 @@ unsafe fn FSEv06_decodeSymbol(
     let nbBits = DInfo.nbBits as u32;
     let symbol = DInfo.symbol;
     let lowBits = BITv06_readBits(bitD, nbBits);
-    (*DStatePtr).state = (DInfo.newState as size_t).wrapping_add(lowBits);
+    (*DStatePtr).state = (DInfo.newState as usize).wrapping_add(lowBits);
     symbol
 }
 #[inline]
@@ -413,7 +413,7 @@ unsafe fn FSEv06_decodeSymbolFast(
     let nbBits = DInfo.nbBits as u32;
     let symbol = DInfo.symbol;
     let lowBits = BITv06_readBitsFast(bitD, nbBits);
-    (*DStatePtr).state = (DInfo.newState as size_t).wrapping_add(lowBits);
+    (*DStatePtr).state = (DInfo.newState as usize).wrapping_add(lowBits);
     symbol
 }
 const FSEv06_MAX_MEMORY_USAGE: core::ffi::c_int = 14;
@@ -421,7 +421,7 @@ const FSEv06_MAX_SYMBOL_VALUE: core::ffi::c_int = 255;
 const FSEv06_MAX_TABLELOG: core::ffi::c_int = FSEv06_MAX_MEMORY_USAGE - 2;
 const FSEv06_MIN_TABLELOG: core::ffi::c_int = 5;
 const FSEv06_TABLELOG_ABSOLUTE_MAX: core::ffi::c_int = 15;
-unsafe fn HUFv06_isError(code: size_t) -> core::ffi::c_uint {
+unsafe fn HUFv06_isError(code: usize) -> core::ffi::c_uint {
     ERR_isError(code) as _
 }
 unsafe fn FSEv06_abs(a: core::ffi::c_short) -> core::ffi::c_short {
@@ -436,8 +436,8 @@ unsafe fn FSEv06_readNCount(
     maxSVPtr: *mut core::ffi::c_uint,
     tableLogPtr: *mut core::ffi::c_uint,
     headerBuffer: *const core::ffi::c_void,
-    hbSize: size_t,
-) -> size_t {
+    hbSize: usize,
+) -> usize {
     let istart = headerBuffer as *const u8;
     let iend = istart.add(hbSize);
     let mut ip = istart;
@@ -546,7 +546,7 @@ unsafe fn FSEv06_buildDTable(
     normalizedCounter: *const core::ffi::c_short,
     maxSymbolValue: core::ffi::c_uint,
     tableLog: core::ffi::c_uint,
-) -> size_t {
+) -> usize {
     let tdPtr = dt.add(1) as *mut core::ffi::c_void;
     let tableDecode = tdPtr as *mut FSEv06_decode_t;
     let mut symbolNext: [u16; 256] = [0; 256];
@@ -631,7 +631,7 @@ unsafe fn FSEv06_buildDTable(
     }
     0
 }
-unsafe fn FSEv06_buildDTable_rle(dt: *mut FSEv06_DTable, symbolValue: u8) -> size_t {
+unsafe fn FSEv06_buildDTable_rle(dt: *mut FSEv06_DTable, symbolValue: u8) -> usize {
     let ptr = dt as *mut core::ffi::c_void;
     let DTableH = ptr as *mut FSEv06_DTableHeader;
     let dPtr = dt.add(1) as *mut core::ffi::c_void;
@@ -646,12 +646,12 @@ unsafe fn FSEv06_buildDTable_rle(dt: *mut FSEv06_DTable, symbolValue: u8) -> siz
 #[inline(always)]
 unsafe fn FSEv06_decompress_usingDTable_generic(
     dst: *mut core::ffi::c_void,
-    maxDstSize: size_t,
+    maxDstSize: usize,
     cSrc: *const core::ffi::c_void,
-    cSrcSize: size_t,
+    cSrcSize: usize,
     dt: *const FSEv06_DTable,
     fast: core::ffi::c_uint,
-) -> size_t {
+) -> usize {
     let ostart = dst as *mut u8;
     let mut op = ostart;
     let omax = op.add(maxDstSize);
@@ -685,8 +685,8 @@ unsafe fn FSEv06_decompress_usingDTable_generic(
         } else {
             FSEv06_decodeSymbol(&mut state1, &mut bitD) as core::ffi::c_int
         }) as u8;
-        if (FSEv06_MAX_TABLELOG * 2 + 7) as size_t
-            > (::core::mem::size_of::<size_t>()).wrapping_mul(8)
+        if (FSEv06_MAX_TABLELOG * 2 + 7) as usize
+            > (::core::mem::size_of::<usize>()).wrapping_mul(8)
         {
             BITv06_reloadDStream(&mut bitD);
         }
@@ -695,8 +695,8 @@ unsafe fn FSEv06_decompress_usingDTable_generic(
         } else {
             FSEv06_decodeSymbol(&mut state2, &mut bitD) as core::ffi::c_int
         }) as u8;
-        if (FSEv06_MAX_TABLELOG * 4 + 7) as size_t
-            > (::core::mem::size_of::<size_t>()).wrapping_mul(8)
+        if (FSEv06_MAX_TABLELOG * 4 + 7) as usize
+            > (::core::mem::size_of::<usize>()).wrapping_mul(8)
             && BITv06_reloadDStream(&mut bitD) as core::ffi::c_uint
                 > BITv06_DStream_unfinished as core::ffi::c_int as core::ffi::c_uint
         {
@@ -708,8 +708,8 @@ unsafe fn FSEv06_decompress_usingDTable_generic(
         } else {
             FSEv06_decodeSymbol(&mut state1, &mut bitD) as core::ffi::c_int
         }) as u8;
-        if (FSEv06_MAX_TABLELOG * 2 + 7) as size_t
-            > (::core::mem::size_of::<size_t>()).wrapping_mul(8)
+        if (FSEv06_MAX_TABLELOG * 2 + 7) as usize
+            > (::core::mem::size_of::<usize>()).wrapping_mul(8)
         {
             BITv06_reloadDStream(&mut bitD);
         }
@@ -772,11 +772,11 @@ unsafe fn FSEv06_decompress_usingDTable_generic(
 }
 unsafe fn FSEv06_decompress_usingDTable(
     dst: *mut core::ffi::c_void,
-    originalSize: size_t,
+    originalSize: usize,
     cSrc: *const core::ffi::c_void,
-    cSrcSize: size_t,
+    cSrcSize: usize,
     dt: *const FSEv06_DTable,
-) -> size_t {
+) -> usize {
     let ptr = dt as *const core::ffi::c_void;
     let DTableH = ptr as *const FSEv06_DTableHeader;
     let fastMode = (*DTableH).fastMode as u32;
@@ -787,10 +787,10 @@ unsafe fn FSEv06_decompress_usingDTable(
 }
 unsafe fn FSEv06_decompress(
     dst: *mut core::ffi::c_void,
-    maxDstSize: size_t,
+    maxDstSize: usize,
     cSrc: *const core::ffi::c_void,
-    mut cSrcSize: size_t,
-) -> size_t {
+    mut cSrcSize: usize,
+) -> usize {
     let istart = cSrc as *const u8;
     let mut ip = istart;
     let mut counting: [core::ffi::c_short; 256] = [0; 256];
@@ -838,25 +838,25 @@ const HUFv06_MAX_SYMBOL_VALUE: core::ffi::c_int = 255;
 #[inline]
 unsafe fn HUFv06_readStats(
     huffWeight: *mut u8,
-    hwSize: size_t,
+    hwSize: usize,
     rankStats: *mut u32,
     nbSymbolsPtr: *mut u32,
     tableLogPtr: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let mut weightTotal: u32 = 0;
     let mut ip = src as *const u8;
-    let mut iSize: size_t = 0;
-    let mut oSize: size_t = 0;
+    let mut iSize: usize = 0;
+    let mut oSize: usize = 0;
     if srcSize == 0 {
         return Error::srcSize_wrong.to_error_code();
     }
-    iSize = *ip as size_t;
+    iSize = *ip as usize;
     if iSize >= 128 {
         if iSize >= 242 {
             static l: [u32; 14] = [1, 2, 3, 4, 7, 8, 15, 16, 31, 32, 63, 64, 127, 128];
-            oSize = l[iSize.wrapping_sub(242)] as size_t;
+            oSize = l[iSize.wrapping_sub(242)] as usize;
             core::ptr::write_bytes(huffWeight, 1, hwSize);
             iSize = 0;
         } else {
@@ -871,7 +871,7 @@ unsafe fn HUFv06_readStats(
             ip = ip.add(1);
             let mut n: u32 = 0;
             n = 0;
-            while (n as size_t) < oSize {
+            while (n as usize) < oSize {
                 *huffWeight.offset(n as isize) =
                     (*ip.offset((n / 2) as isize) as core::ffi::c_int >> 4) as u8;
                 *huffWeight.offset(n.wrapping_add(1) as isize) =
@@ -893,11 +893,11 @@ unsafe fn HUFv06_readStats(
             return oSize;
         }
     }
-    core::ptr::write_bytes(rankStats, 0, (HUFv06_ABSOLUTEMAX_TABLELOG + 1) as size_t);
+    core::ptr::write_bytes(rankStats, 0, (HUFv06_ABSOLUTEMAX_TABLELOG + 1) as usize);
     weightTotal = 0;
     let mut n_0: u32 = 0;
     n_0 = 0;
-    while (n_0 as size_t) < oSize {
+    while (n_0 as usize) < oSize {
         if *huffWeight.offset(n_0 as isize) as core::ffi::c_int >= HUFv06_ABSOLUTEMAX_TABLELOG {
             return Error::corruption_detected.to_error_code();
         }
@@ -935,12 +935,12 @@ unsafe fn HUFv06_readStats(
 unsafe fn HUFv06_readDTableX2(
     DTable: *mut u16,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let mut huffWeight: [u8; 256] = [0; 256];
     let mut rankVal: [u32; 17] = [0; 17];
     let mut tableLog = 0;
-    let mut iSize: size_t = 0;
+    let mut iSize: usize = 0;
     let mut nbSymbols = 0;
     let mut n: u32 = 0;
     let mut nextRankStart: u32 = 0;
@@ -948,7 +948,7 @@ unsafe fn HUFv06_readDTableX2(
     let dt = dtPtr as *mut HUFv06_DEltX2;
     iSize = HUFv06_readStats(
         huffWeight.as_mut_ptr(),
-        (HUFv06_MAX_SYMBOL_VALUE + 1) as size_t,
+        (HUFv06_MAX_SYMBOL_VALUE + 1) as usize,
         rankVal.as_mut_ptr(),
         &mut nbSymbols,
         &mut tableLog,
@@ -1007,7 +1007,7 @@ unsafe fn HUFv06_decodeStreamX2(
     pEnd: *mut u8,
     dt: *const HUFv06_DEltX2,
     dtLog: u32,
-) -> size_t {
+) -> usize {
     let pStart = p;
     while BITv06_reloadDStream(bitDPtr) as core::ffi::c_uint
         == BITv06_DStream_unfinished as core::ffi::c_int as core::ffi::c_uint
@@ -1049,11 +1049,11 @@ unsafe fn HUFv06_decodeStreamX2(
 }
 unsafe fn HUFv06_decompress1X2_usingDTable(
     dst: *mut core::ffi::c_void,
-    dstSize: size_t,
+    dstSize: usize,
     cSrc: *const core::ffi::c_void,
-    cSrcSize: size_t,
+    cSrcSize: usize,
     DTable: *const u16,
-) -> size_t {
+) -> usize {
     let op = dst as *mut u8;
     let oend = op.add(dstSize);
     let dtLog = *DTable as u32;
@@ -1077,10 +1077,10 @@ unsafe fn HUFv06_decompress1X2_usingDTable(
 }
 unsafe fn HUFv06_decompress1X2(
     dst: *mut core::ffi::c_void,
-    dstSize: size_t,
+    dstSize: usize,
     cSrc: *const core::ffi::c_void,
-    mut cSrcSize: size_t,
-) -> size_t {
+    mut cSrcSize: usize,
+) -> usize {
     let mut DTable: [core::ffi::c_ushort; 4097] = [12; 4097];
     let mut ip = cSrc as *const u8;
     let errorCode = HUFv06_readDTableX2(DTable.as_mut_ptr(), cSrc, cSrcSize);
@@ -1102,11 +1102,11 @@ unsafe fn HUFv06_decompress1X2(
 }
 unsafe fn HUFv06_decompress4X2_usingDTable(
     dst: *mut core::ffi::c_void,
-    dstSize: size_t,
+    dstSize: usize,
     cSrc: *const core::ffi::c_void,
-    cSrcSize: size_t,
+    cSrcSize: usize,
     DTable: *const u16,
-) -> size_t {
+) -> usize {
     if cSrcSize < 10 {
         return Error::corruption_detected.to_error_code();
     }
@@ -1116,7 +1116,7 @@ unsafe fn HUFv06_decompress4X2_usingDTable(
     let dtPtr = DTable as *const core::ffi::c_void;
     let dt = (dtPtr as *const HUFv06_DEltX2).add(1);
     let dtLog = *DTable as u32;
-    let mut errorCode: size_t = 0;
+    let mut errorCode: usize = 0;
     let mut bitD1 = BITv06_DStream_t {
         bitContainer: 0,
         bitsConsumed: 0,
@@ -1141,10 +1141,10 @@ unsafe fn HUFv06_decompress4X2_usingDTable(
         ptr: core::ptr::null::<core::ffi::c_char>(),
         start: core::ptr::null::<core::ffi::c_char>(),
     };
-    let length1 = MEM_readLE16(istart as *const core::ffi::c_void) as size_t;
-    let length2 = MEM_readLE16(istart.add(2) as *const core::ffi::c_void) as size_t;
-    let length3 = MEM_readLE16(istart.add(4) as *const core::ffi::c_void) as size_t;
-    let mut length4: size_t = 0;
+    let length1 = MEM_readLE16(istart as *const core::ffi::c_void) as usize;
+    let length2 = MEM_readLE16(istart.add(2) as *const core::ffi::c_void) as usize;
+    let length3 = MEM_readLE16(istart.add(4) as *const core::ffi::c_void) as usize;
+    let mut length4: usize = 0;
     let istart1 = istart.add(6);
     let istart2 = istart1.add(length1);
     let istart3 = istart2.add(length2);
@@ -1289,10 +1289,10 @@ unsafe fn HUFv06_decompress4X2_usingDTable(
 }
 unsafe fn HUFv06_decompress4X2(
     dst: *mut core::ffi::c_void,
-    dstSize: size_t,
+    dstSize: usize,
     cSrc: *const core::ffi::c_void,
-    mut cSrcSize: size_t,
-) -> size_t {
+    mut cSrcSize: usize,
+) -> usize {
     let mut DTable: [core::ffi::c_ushort; 4097] = [12; 4097];
     let mut ip = cSrc as *const u8;
     let errorCode = HUFv06_readDTableX2(DTable.as_mut_ptr(), cSrc, cSrcSize);
@@ -1450,8 +1450,8 @@ unsafe fn HUFv06_fillDTableX4(
 unsafe fn HUFv06_readDTableX4(
     DTable: *mut u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let mut weightList: [u8; 256] = [0; 256];
     let mut sortedSymbol: [sortedSymbol_t; 256] = [sortedSymbol_t {
         symbol: 0,
@@ -1466,7 +1466,7 @@ unsafe fn HUFv06_readDTableX4(
     let mut sizeOfSort: u32 = 0;
     let mut nbSymbols: u32 = 0;
     let memLog = *DTable;
-    let mut iSize: size_t = 0;
+    let mut iSize: usize = 0;
     let dtPtr = DTable as *mut core::ffi::c_void;
     let dt = (dtPtr as *mut HUFv06_DEltX4).add(1);
     if memLog > HUFv06_ABSOLUTEMAX_TABLELOG as u32 {
@@ -1474,7 +1474,7 @@ unsafe fn HUFv06_readDTableX4(
     }
     iSize = HUFv06_readStats(
         weightList.as_mut_ptr(),
-        (HUFv06_MAX_SYMBOL_VALUE + 1) as size_t,
+        (HUFv06_MAX_SYMBOL_VALUE + 1) as usize,
         rankStats.as_mut_ptr(),
         &mut nbSymbols,
         &mut tableLog,
@@ -1574,13 +1574,13 @@ unsafe fn HUFv06_decodeLastSymbolX4(
     memcpy(op, dt.add(val) as *const core::ffi::c_void, 1);
     if (*dt.add(val)).length as core::ffi::c_int == 1 {
         BITv06_skipBits(DStream, (*dt.add(val)).nbBits as u32);
-    } else if ((*DStream).bitsConsumed as size_t)
-        < (::core::mem::size_of::<size_t>()).wrapping_mul(8)
+    } else if ((*DStream).bitsConsumed as usize)
+        < (::core::mem::size_of::<usize>()).wrapping_mul(8)
     {
         BITv06_skipBits(DStream, (*dt.add(val)).nbBits as u32);
-        if (*DStream).bitsConsumed as size_t > (::core::mem::size_of::<size_t>()).wrapping_mul(8) {
+        if (*DStream).bitsConsumed as usize > (::core::mem::size_of::<usize>()).wrapping_mul(8) {
             (*DStream).bitsConsumed =
-                (::core::mem::size_of::<size_t>()).wrapping_mul(8) as core::ffi::c_uint;
+                (::core::mem::size_of::<usize>()).wrapping_mul(8) as core::ffi::c_uint;
         }
     }
     1
@@ -1592,7 +1592,7 @@ unsafe fn HUFv06_decodeStreamX4(
     pEnd: *mut u8,
     dt: *const HUFv06_DEltX4,
     dtLog: u32,
-) -> size_t {
+) -> usize {
     let pStart = p;
     while BITv06_reloadDStream(bitDPtr) as core::ffi::c_uint
         == BITv06_DStream_unfinished as core::ffi::c_int as core::ffi::c_uint
@@ -1639,11 +1639,11 @@ unsafe fn HUFv06_decodeStreamX4(
 }
 unsafe fn HUFv06_decompress1X4_usingDTable(
     dst: *mut core::ffi::c_void,
-    dstSize: size_t,
+    dstSize: usize,
     cSrc: *const core::ffi::c_void,
-    cSrcSize: size_t,
+    cSrcSize: usize,
     DTable: *const u32,
-) -> size_t {
+) -> usize {
     let istart = cSrc as *const u8;
     let ostart = dst as *mut u8;
     let oend = ostart.add(dstSize);
@@ -1668,11 +1668,11 @@ unsafe fn HUFv06_decompress1X4_usingDTable(
 }
 unsafe fn HUFv06_decompress4X4_usingDTable(
     dst: *mut core::ffi::c_void,
-    dstSize: size_t,
+    dstSize: usize,
     cSrc: *const core::ffi::c_void,
-    cSrcSize: size_t,
+    cSrcSize: usize,
     DTable: *const u32,
-) -> size_t {
+) -> usize {
     if cSrcSize < 10 {
         return Error::corruption_detected.to_error_code();
     }
@@ -1682,7 +1682,7 @@ unsafe fn HUFv06_decompress4X4_usingDTable(
     let dtPtr = DTable as *const core::ffi::c_void;
     let dt = (dtPtr as *const HUFv06_DEltX4).add(1);
     let dtLog = *DTable;
-    let mut errorCode: size_t = 0;
+    let mut errorCode: usize = 0;
     let mut bitD1 = BITv06_DStream_t {
         bitContainer: 0,
         bitsConsumed: 0,
@@ -1707,10 +1707,10 @@ unsafe fn HUFv06_decompress4X4_usingDTable(
         ptr: core::ptr::null::<core::ffi::c_char>(),
         start: core::ptr::null::<core::ffi::c_char>(),
     };
-    let length1 = MEM_readLE16(istart as *const core::ffi::c_void) as size_t;
-    let length2 = MEM_readLE16(istart.add(2) as *const core::ffi::c_void) as size_t;
-    let length3 = MEM_readLE16(istart.add(4) as *const core::ffi::c_void) as size_t;
-    let mut length4: size_t = 0;
+    let length1 = MEM_readLE16(istart as *const core::ffi::c_void) as usize;
+    let length2 = MEM_readLE16(istart.add(2) as *const core::ffi::c_void) as usize;
+    let length3 = MEM_readLE16(istart.add(4) as *const core::ffi::c_void) as usize;
+    let mut length4: usize = 0;
     let istart1 = istart.add(6);
     let istart2 = istart1.add(length1);
     let istart3 = istart2.add(length2);
@@ -1891,10 +1891,10 @@ unsafe fn HUFv06_decompress4X4_usingDTable(
 }
 unsafe fn HUFv06_decompress4X4(
     dst: *mut core::ffi::c_void,
-    dstSize: size_t,
+    dstSize: usize,
     cSrc: *const core::ffi::c_void,
-    mut cSrcSize: size_t,
-) -> size_t {
+    mut cSrcSize: usize,
+) -> usize {
     let mut DTable: [core::ffi::c_uint; 4097] = [12; 4097];
     let mut ip = cSrc as *const u8;
     let hSize = HUFv06_readDTableX4(DTable.as_mut_ptr(), cSrc, cSrcSize);
@@ -2238,28 +2238,28 @@ static algoTime: [[algo_time_t; 3]; 16] = [
 ];
 unsafe fn HUFv06_decompress(
     dst: *mut core::ffi::c_void,
-    dstSize: size_t,
+    dstSize: usize,
     cSrc: *const core::ffi::c_void,
-    cSrcSize: size_t,
-) -> size_t {
+    cSrcSize: usize,
+) -> usize {
     static decompress: [decompressionAlgo; 3] = [
         Some(
             HUFv06_decompress4X2
                 as unsafe fn(
                     *mut core::ffi::c_void,
-                    size_t,
+                    usize,
                     *const core::ffi::c_void,
-                    size_t,
-                ) -> size_t,
+                    usize,
+                ) -> usize,
         ),
         Some(
             HUFv06_decompress4X4
                 as unsafe fn(
                     *mut core::ffi::c_void,
-                    size_t,
+                    usize,
                     *const core::ffi::c_void,
-                    size_t,
-                ) -> size_t,
+                    usize,
+                ) -> usize,
         ),
         None,
     ];
@@ -2309,7 +2309,7 @@ unsafe fn HUFv06_decompress(
 unsafe fn ZSTDv06_copy4(dst: *mut core::ffi::c_void, src: *const core::ffi::c_void) {
     memcpy(dst, src, 4);
 }
-unsafe fn ZSTDv06_decompressBegin(dctx: *mut ZSTDv06_DCtx) -> size_t {
+unsafe fn ZSTDv06_decompressBegin(dctx: *mut ZSTDv06_DCtx) -> usize {
     (*dctx).expected = ZSTDv06_frameHeaderSize_min;
     (*dctx).stage = ZSTDds_getFrameHeaderSize;
     (*dctx).previousDstEnd = core::ptr::null();
@@ -2328,11 +2328,11 @@ pub(crate) unsafe fn ZSTDv06_createDCtx() -> *mut ZSTDv06_DCtx {
     ZSTDv06_decompressBegin(dctx);
     dctx
 }
-pub(crate) unsafe fn ZSTDv06_freeDCtx(dctx: *mut ZSTDv06_DCtx) -> size_t {
+pub(crate) unsafe fn ZSTDv06_freeDCtx(dctx: *mut ZSTDv06_DCtx) -> usize {
     free(dctx as *mut core::ffi::c_void);
     0
 }
-unsafe fn ZSTDv06_frameHeaderSize(src: *const core::ffi::c_void, srcSize: size_t) -> size_t {
+unsafe fn ZSTDv06_frameHeaderSize(src: *const core::ffi::c_void, srcSize: usize) -> usize {
     if srcSize < ZSTDv06_frameHeaderSize_min {
         return Error::srcSize_wrong.to_error_code();
     }
@@ -2348,8 +2348,8 @@ unsafe fn ZSTDv06_frameHeaderSize(src: *const core::ffi::c_void, srcSize: size_t
 pub(crate) unsafe fn ZSTDv06_getFrameParams(
     fparamsPtr: *mut ZSTDv06_frameParams,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let ip = src as *const u8;
 
     if srcSize < ZSTDv06_frameHeaderSize_min {
@@ -2398,8 +2398,8 @@ pub(crate) unsafe fn ZSTDv06_getFrameParams(
 unsafe fn ZSTDv06_decodeFrameHeader(
     zc: *mut ZSTDv06_DCtx,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let result = ZSTDv06_getFrameParams(&mut (*zc).fParams, src, srcSize);
     if MEM_32bits() && (*zc).fParams.windowLog > 25 {
         return Error::frameParameter_unsupported.to_error_code();
@@ -2408,9 +2408,9 @@ unsafe fn ZSTDv06_decodeFrameHeader(
 }
 unsafe fn ZSTDv06_getcBlockSize(
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     bpPtr: *mut blockProperties_t,
-) -> size_t {
+) -> usize {
     let in_0 = src as *const u8;
     let mut cSize: u32 = 0;
     if srcSize < ZSTDv06_blockHeaderSize {
@@ -2433,14 +2433,14 @@ unsafe fn ZSTDv06_getcBlockSize(
     if (*bpPtr).blockType as core::ffi::c_uint == bt_rle as core::ffi::c_int as core::ffi::c_uint {
         return 1;
     }
-    cSize as size_t
+    cSize as usize
 }
 unsafe fn ZSTDv06_copyRawBlock(
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     if dst.is_null() {
         return Error::dstSize_tooSmall.to_error_code();
     }
@@ -2453,16 +2453,16 @@ unsafe fn ZSTDv06_copyRawBlock(
 unsafe fn ZSTDv06_decodeLiteralsBlock(
     dctx: *mut ZSTDv06_DCtx,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let istart = src as *const u8;
-    if srcSize < MIN_CBLOCK_SIZE as size_t {
+    if srcSize < MIN_CBLOCK_SIZE as usize {
         return Error::corruption_detected.to_error_code();
     }
     match *istart as core::ffi::c_int >> 6 {
         IS_HUF => {
-            let mut litSize: size_t = 0;
-            let mut litCSize: size_t = 0;
+            let mut litSize: usize = 0;
+            let mut litCSize: usize = 0;
             let mut singleStream = 0;
             let mut lhSize = (*istart as core::ffi::c_int >> 4 & 3) as u32;
             if srcSize < 5 {
@@ -2474,38 +2474,38 @@ unsafe fn ZSTDv06_decodeLiteralsBlock(
                     litSize = (((*istart as core::ffi::c_int & 15) << 10)
                         + ((*istart.add(1) as core::ffi::c_int) << 2)
                         + (*istart.add(2) as core::ffi::c_int >> 6))
-                        as size_t;
+                        as usize;
                     litCSize = (((*istart.add(2) as core::ffi::c_int & 63) << 8)
                         + *istart.add(3) as core::ffi::c_int)
-                        as size_t;
+                        as usize;
                 }
                 3 => {
                     lhSize = 5;
                     litSize = (((*istart as core::ffi::c_int & 15) << 14)
                         + ((*istart.add(1) as core::ffi::c_int) << 6)
                         + (*istart.add(2) as core::ffi::c_int >> 2))
-                        as size_t;
+                        as usize;
                     litCSize = (((*istart.add(2) as core::ffi::c_int & 3) << 16)
                         + ((*istart.add(3) as core::ffi::c_int) << 8)
                         + *istart.add(4) as core::ffi::c_int)
-                        as size_t;
+                        as usize;
                 }
                 0 | 1 => {
                     lhSize = 3;
-                    singleStream = (*istart as core::ffi::c_int & 16) as size_t;
+                    singleStream = (*istart as core::ffi::c_int & 16) as usize;
                     litSize = (((*istart as core::ffi::c_int & 15) << 6)
                         + (*istart.add(1) as core::ffi::c_int >> 2))
-                        as size_t;
+                        as usize;
                     litCSize = (((*istart.add(1) as core::ffi::c_int & 3) << 8)
                         + *istart.add(2) as core::ffi::c_int)
-                        as size_t;
+                        as usize;
                 }
                 _ => unreachable!(),
             }
-            if litSize > ZSTDv06_BLOCKSIZE_MAX as size_t {
+            if litSize > ZSTDv06_BLOCKSIZE_MAX as usize {
                 return Error::corruption_detected.to_error_code();
             }
-            if litCSize.wrapping_add(lhSize as size_t) > srcSize {
+            if litCSize.wrapping_add(lhSize as usize) > srcSize {
                 return Error::corruption_detected.to_error_code();
             }
             if ERR_isError(if singleStream != 0 {
@@ -2532,11 +2532,11 @@ unsafe fn ZSTDv06_decodeLiteralsBlock(
                 0,
                 WILDCOPY_OVERLENGTH as usize,
             );
-            litCSize.wrapping_add(lhSize as size_t)
+            litCSize.wrapping_add(lhSize as usize)
         }
         IS_PCH => {
-            let mut litSize_0: size_t = 0;
-            let mut litCSize_0: size_t = 0;
+            let mut litSize_0: usize = 0;
+            let mut litCSize_0: usize = 0;
             let mut lhSize_0 = (*istart as core::ffi::c_int >> 4 & 3) as u32;
             if lhSize_0 != 1 {
                 return Error::corruption_detected.to_error_code();
@@ -2546,10 +2546,10 @@ unsafe fn ZSTDv06_decodeLiteralsBlock(
             }
             lhSize_0 = 3;
             litSize_0 = (((*istart as core::ffi::c_int & 15) << 6)
-                + (*istart.add(1) as core::ffi::c_int >> 2)) as size_t;
+                + (*istart.add(1) as core::ffi::c_int >> 2)) as usize;
             litCSize_0 = (((*istart.add(1) as core::ffi::c_int & 3) << 8)
-                + *istart.add(2) as core::ffi::c_int) as size_t;
-            if litCSize_0.wrapping_add(lhSize_0 as size_t) > srcSize {
+                + *istart.add(2) as core::ffi::c_int) as usize;
+            if litCSize_0.wrapping_add(lhSize_0 as usize) > srcSize {
                 return Error::corruption_detected.to_error_code();
             }
             let errorCode = HUFv06_decompress1X4_usingDTable(
@@ -2569,35 +2569,35 @@ unsafe fn ZSTDv06_decodeLiteralsBlock(
                 0,
                 WILDCOPY_OVERLENGTH as usize,
             );
-            litCSize_0.wrapping_add(lhSize_0 as size_t)
+            litCSize_0.wrapping_add(lhSize_0 as usize)
         }
         IS_RAW => {
-            let mut litSize_1: size_t = 0;
+            let mut litSize_1: usize = 0;
             let mut lhSize_1 = (*istart as core::ffi::c_int >> 4 & 3) as u32;
             match lhSize_1 {
                 2 => {
                     litSize_1 = (((*istart as core::ffi::c_int & 15) << 8)
                         + *istart.add(1) as core::ffi::c_int)
-                        as size_t;
+                        as usize;
                 }
                 3 => {
                     litSize_1 = (((*istart as core::ffi::c_int & 15) << 16)
                         + ((*istart.add(1) as core::ffi::c_int) << 8)
                         + *istart.add(2) as core::ffi::c_int)
-                        as size_t;
+                        as usize;
                 }
                 0 | 1 => {
                     lhSize_1 = 1;
-                    litSize_1 = (*istart as core::ffi::c_int & 31) as size_t;
+                    litSize_1 = (*istart as core::ffi::c_int & 31) as usize;
                 }
                 _ => unreachable!(),
             }
-            if (lhSize_1 as size_t)
+            if (lhSize_1 as usize)
                 .wrapping_add(litSize_1)
-                .wrapping_add(WILDCOPY_OVERLENGTH as size_t)
+                .wrapping_add(WILDCOPY_OVERLENGTH as usize)
                 > srcSize
             {
-                if litSize_1.wrapping_add(lhSize_1 as size_t) > srcSize {
+                if litSize_1.wrapping_add(lhSize_1 as usize) > srcSize {
                     return Error::corruption_detected.to_error_code();
                 }
                 memcpy(
@@ -2612,47 +2612,47 @@ unsafe fn ZSTDv06_decodeLiteralsBlock(
                     0,
                     WILDCOPY_OVERLENGTH as usize,
                 );
-                return (lhSize_1 as size_t).wrapping_add(litSize_1);
+                return (lhSize_1 as usize).wrapping_add(litSize_1);
             }
             (*dctx).litPtr = istart.offset(lhSize_1 as isize);
             (*dctx).litSize = litSize_1;
-            (lhSize_1 as size_t).wrapping_add(litSize_1)
+            (lhSize_1 as usize).wrapping_add(litSize_1)
         }
         IS_RLE => {
-            let mut litSize_2: size_t = 0;
+            let mut litSize_2: usize = 0;
             let mut lhSize_2 = (*istart as core::ffi::c_int >> 4 & 3) as u32;
             match lhSize_2 {
                 2 => {
                     litSize_2 = (((*istart as core::ffi::c_int & 15) << 8)
                         + *istart.add(1) as core::ffi::c_int)
-                        as size_t;
+                        as usize;
                 }
                 3 => {
                     litSize_2 = (((*istart as core::ffi::c_int & 15) << 16)
                         + ((*istart.add(1) as core::ffi::c_int) << 8)
                         + *istart.add(2) as core::ffi::c_int)
-                        as size_t;
+                        as usize;
                     if srcSize < 4 {
                         return Error::corruption_detected.to_error_code();
                     }
                 }
                 0 | 1 => {
                     lhSize_2 = 1;
-                    litSize_2 = (*istart as core::ffi::c_int & 31) as size_t;
+                    litSize_2 = (*istart as core::ffi::c_int & 31) as usize;
                 }
                 _ => unreachable!(),
             }
-            if litSize_2 > ZSTDv06_BLOCKSIZE_MAX as size_t {
+            if litSize_2 > ZSTDv06_BLOCKSIZE_MAX as usize {
                 return Error::corruption_detected.to_error_code();
             }
             core::ptr::write_bytes(
                 ((*dctx).litBuffer).as_mut_ptr(),
                 *istart.offset(lhSize_2 as isize),
-                litSize_2.wrapping_add(WILDCOPY_OVERLENGTH as size_t),
+                litSize_2.wrapping_add(WILDCOPY_OVERLENGTH as usize),
             );
             (*dctx).litPtr = ((*dctx).litBuffer).as_mut_ptr();
             (*dctx).litSize = litSize_2;
-            lhSize_2.wrapping_add(1) as size_t
+            lhSize_2.wrapping_add(1) as usize
         }
         _ => Error::corruption_detected.to_error_code(),
     }
@@ -2663,11 +2663,11 @@ unsafe fn ZSTDv06_buildSeqTable(
     mut max: u32,
     maxLog: u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     defaultNorm: *const i16,
     defaultLog: u32,
     flagRepeatTable: u32,
-) -> size_t {
+) -> usize {
     match type_0 {
         1 => {
             if srcSize == 0 {
@@ -2713,12 +2713,12 @@ unsafe fn ZSTDv06_decodeSeqHeaders(
     DTableOffb: *mut FSEv06_DTable,
     flagRepeatTable: u32,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let istart = src as *const u8;
     let iend = istart.add(srcSize);
     let mut ip = istart;
-    if srcSize < MIN_SEQUENCES_SIZE as size_t {
+    if srcSize < MIN_SEQUENCES_SIZE as usize {
         return Error::srcSize_wrong.to_error_code();
     }
     let fresh41 = ip;
@@ -2931,19 +2931,19 @@ unsafe fn ZSTDv06_decodeSequence(seq: *mut seq_t, seqState: *mut seqState_t) {
         1,
         1,
     ];
-    let mut offset: size_t = 0;
+    let mut offset: usize = 0;
     if ofCode == 0 {
         offset = 0;
     } else {
-        offset = (*OF_base.as_ptr().offset(ofCode as isize) as size_t)
+        offset = (*OF_base.as_ptr().offset(ofCode as isize) as usize)
             .wrapping_add(BITv06_readBits(&mut (*seqState).DStream, ofBits));
         if MEM_32bits() {
             BITv06_reloadDStream(&mut (*seqState).DStream);
         }
     }
-    if offset < ZSTDv06_REP_NUM as size_t {
+    if offset < ZSTDv06_REP_NUM as usize {
         if llCode == 0 && offset <= 1 {
-            offset = (1 as size_t).wrapping_sub(offset);
+            offset = (1 as usize).wrapping_sub(offset);
         }
         if offset != 0 {
             let temp = *((*seqState).prevOffset).as_mut_ptr().add(offset);
@@ -2958,7 +2958,7 @@ unsafe fn ZSTDv06_decodeSequence(seq: *mut seq_t, seqState: *mut seqState_t) {
             offset = *((*seqState).prevOffset).as_mut_ptr();
         }
     } else {
-        offset = offset.wrapping_sub(ZSTDv06_REP_MOVE as size_t);
+        offset = offset.wrapping_sub(ZSTDv06_REP_MOVE as usize);
         *((*seqState).prevOffset).as_mut_ptr().add(2) =
             *((*seqState).prevOffset).as_mut_ptr().add(1);
         *((*seqState).prevOffset).as_mut_ptr().add(1) = *((*seqState).prevOffset).as_mut_ptr();
@@ -2966,7 +2966,7 @@ unsafe fn ZSTDv06_decodeSequence(seq: *mut seq_t, seqState: *mut seqState_t) {
     }
     (*seq).offset = offset;
     (*seq).matchLength = ((*ML_base.as_ptr().offset(mlCode as isize)).wrapping_add(MINMATCH as u32)
-        as size_t)
+        as usize)
         .wrapping_add(if mlCode > 31 {
             BITv06_readBits(&mut (*seqState).DStream, mlBits)
         } else {
@@ -2976,7 +2976,7 @@ unsafe fn ZSTDv06_decodeSequence(seq: *mut seq_t, seqState: *mut seqState_t) {
         BITv06_reloadDStream(&mut (*seqState).DStream);
     }
     (*seq).litLength =
-        (*LL_base.as_ptr().offset(llCode as isize) as size_t).wrapping_add(if llCode > 15 {
+        (*LL_base.as_ptr().offset(llCode as isize) as usize).wrapping_add(if llCode > 15 {
             BITv06_readBits(&mut (*seqState).DStream, llBits)
         } else {
             0
@@ -3000,7 +3000,7 @@ unsafe fn ZSTDv06_execSequence(
     base: *const u8,
     vBase: *const u8,
     dictEnd: *const u8,
-) -> size_t {
+) -> usize {
     let oLitEnd = op.add(sequence.litLength);
     let sequenceLength = (sequence.litLength).wrapping_add(sequence.matchLength);
     let oMatchEnd = op.add(sequenceLength);
@@ -3044,7 +3044,7 @@ unsafe fn ZSTDv06_execSequence(
         op = oLitEnd.add(length1);
         sequence.matchLength = (sequence.matchLength).wrapping_sub(length1);
         match_0 = base;
-        if op > oend_8 || sequence.matchLength < MINMATCH as size_t {
+        if op > oend_8 || sequence.matchLength < MINMATCH as usize {
             while op < oMatchEnd {
                 let fresh43 = match_0;
                 match_0 = match_0.add(1);
@@ -3106,10 +3106,10 @@ unsafe fn ZSTDv06_execSequence(
 unsafe fn ZSTDv06_decompressSequences(
     dctx: *mut ZSTDv06_DCtx,
     dst: *mut core::ffi::c_void,
-    maxDstSize: size_t,
+    maxDstSize: usize,
     seqStart: *const core::ffi::c_void,
-    seqSize: size_t,
-) -> size_t {
+    seqSize: usize,
+) -> usize {
     let mut ip = seqStart as *const u8;
     let iend = ip.add(seqSize);
     let ostart = dst as *mut u8;
@@ -3170,11 +3170,11 @@ unsafe fn ZSTDv06_decompressSequences(
             0,
             ::core::mem::size_of::<seq_t>(),
         );
-        sequence.offset = REPCODE_STARTVALUE as size_t;
+        sequence.offset = REPCODE_STARTVALUE as usize;
         let mut i: u32 = 0;
         i = 0;
         while i < ZSTDv06_REP_INIT as u32 {
-            *(seqState.prevOffset).as_mut_ptr().offset(i as isize) = REPCODE_STARTVALUE as size_t;
+            *(seqState.prevOffset).as_mut_ptr().offset(i as isize) = REPCODE_STARTVALUE as usize;
             i = i.wrapping_add(1);
         }
         let errorCode = BITv06_initDStream(
@@ -3245,12 +3245,12 @@ unsafe fn ZSTDv06_checkContinuity(dctx: *mut ZSTDv06_DCtx, dst: *const core::ffi
 unsafe fn ZSTDv06_decompressBlock_internal(
     dctx: *mut ZSTDv06_DCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    mut srcSize: size_t,
-) -> size_t {
+    mut srcSize: usize,
+) -> usize {
     let mut ip = src as *const u8;
-    if srcSize >= ZSTDv06_BLOCKSIZE_MAX as size_t {
+    if srcSize >= ZSTDv06_BLOCKSIZE_MAX as usize {
         return Error::srcSize_wrong.to_error_code();
     }
     let litCSize = ZSTDv06_decodeLiteralsBlock(dctx, src, srcSize);
@@ -3270,10 +3270,10 @@ unsafe fn ZSTDv06_decompressBlock_internal(
 unsafe fn ZSTDv06_decompressFrame(
     dctx: *mut ZSTDv06_DCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let mut ip = src as *const u8;
     let iend = ip.add(srcSize);
     let ostart = dst as *mut u8;
@@ -3357,33 +3357,33 @@ unsafe fn ZSTDv06_decompressFrame(
 pub(crate) unsafe fn ZSTDv06_decompress_usingDict(
     dctx: *mut ZSTDv06_DCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
+    srcSize: usize,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
-) -> size_t {
+    dictSize: usize,
+) -> usize {
     ZSTDv06_decompressBegin_usingDict(dctx, dict, dictSize);
     ZSTDv06_checkContinuity(dctx, dst);
     ZSTDv06_decompressFrame(dctx, dst, dstCapacity, src, srcSize)
 }
 unsafe fn ZSTD_errorFrameSizeInfoLegacy(
-    cSize: *mut size_t,
+    cSize: *mut usize,
     dBound: *mut core::ffi::c_ulonglong,
-    ret: size_t,
+    ret: usize,
 ) {
     *cSize = ret;
     *dBound = ZSTD_CONTENTSIZE_ERROR;
 }
 pub(crate) unsafe fn ZSTDv06_findFrameSizeInfoLegacy(
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-    cSize: *mut size_t,
+    srcSize: usize,
+    cSize: *mut usize,
     dBound: *mut core::ffi::c_ulonglong,
 ) {
     let mut ip = src as *const u8;
     let mut remainingSize = srcSize;
-    let mut nbBlocks = 0 as size_t;
+    let mut nbBlocks = 0 as usize;
     let mut blockProperties = {
         blockProperties_t {
             blockType: bt_compressed,
@@ -3429,18 +3429,18 @@ pub(crate) unsafe fn ZSTDv06_findFrameSizeInfoLegacy(
         nbBlocks = nbBlocks.wrapping_add(1);
     }
     *cSize = ip.offset_from_unsigned(src as *const u8);
-    *dBound = (nbBlocks * ZSTDv06_BLOCKSIZE_MAX as size_t) as core::ffi::c_ulonglong;
+    *dBound = (nbBlocks * ZSTDv06_BLOCKSIZE_MAX as usize) as core::ffi::c_ulonglong;
 }
-unsafe fn ZSTDv06_nextSrcSizeToDecompress(dctx: *mut ZSTDv06_DCtx) -> size_t {
+unsafe fn ZSTDv06_nextSrcSizeToDecompress(dctx: *mut ZSTDv06_DCtx) -> usize {
     (*dctx).expected
 }
 unsafe fn ZSTDv06_decompressContinue(
     dctx: *mut ZSTDv06_DCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     if srcSize != (*dctx).expected {
         return Error::srcSize_wrong.to_error_code();
     }
@@ -3490,7 +3490,7 @@ unsafe fn ZSTDv06_decompressContinue(
             return 0;
         }
         3 => {
-            let mut rSize: size_t = 0;
+            let mut rSize: usize = 0;
             match (*dctx).bType as core::ffi::c_uint {
                 0 => {
                     rSize = ZSTDv06_decompressBlock_internal(dctx, dst, dstCapacity, src, srcSize);
@@ -3515,7 +3515,7 @@ unsafe fn ZSTDv06_decompressContinue(
         }
         _ => return Error::GENERIC.to_error_code(),
     }
-    let mut result: size_t = 0;
+    let mut result: usize = 0;
     memcpy(
         ((*dctx).headerBuffer)
             .as_mut_ptr()
@@ -3538,7 +3538,7 @@ unsafe fn ZSTDv06_decompressContinue(
 unsafe fn ZSTDv06_refDictContent(
     dctx: *mut ZSTDv06_DCtx,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
+    dictSize: usize,
 ) {
     (*dctx).dictEnd = (*dctx).previousDstEnd;
     (*dctx).vBase = (dict as *const core::ffi::c_char).offset(
@@ -3553,12 +3553,12 @@ unsafe fn ZSTDv06_refDictContent(
 unsafe fn ZSTDv06_loadEntropy(
     dctx: *mut ZSTDv06_DCtx,
     mut dict: *const core::ffi::c_void,
-    mut dictSize: size_t,
-) -> size_t {
-    let mut hSize: size_t = 0;
-    let mut offcodeHeaderSize: size_t = 0;
-    let mut matchlengthHeaderSize: size_t = 0;
-    let mut litlengthHeaderSize: size_t = 0;
+    mut dictSize: usize,
+) -> usize {
+    let mut hSize: usize = 0;
+    let mut offcodeHeaderSize: usize = 0;
+    let mut matchlengthHeaderSize: usize = 0;
+    let mut litlengthHeaderSize: usize = 0;
     hSize = HUFv06_readDTableX4(((*dctx).hufTableX4).as_mut_ptr(), dict, dictSize);
     if ERR_isError(hSize) {
         return Error::dictionary_corrupted.to_error_code();
@@ -3654,9 +3654,9 @@ unsafe fn ZSTDv06_loadEntropy(
 unsafe fn ZSTDv06_decompress_insertDictionary(
     dctx: *mut ZSTDv06_DCtx,
     mut dict: *const core::ffi::c_void,
-    mut dictSize: size_t,
-) -> size_t {
-    let mut eSize: size_t = 0;
+    mut dictSize: usize,
+) -> usize {
+    let mut eSize: usize = 0;
     let magic = MEM_readLE32(dict);
     if magic != ZSTDv06_DICT_MAGIC {
         ZSTDv06_refDictContent(dctx, dict, dictSize);
@@ -3676,8 +3676,8 @@ unsafe fn ZSTDv06_decompress_insertDictionary(
 unsafe fn ZSTDv06_decompressBegin_usingDict(
     dctx: *mut ZSTDv06_DCtx,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
-) -> size_t {
+    dictSize: usize,
+) -> usize {
     let errorCode = ZSTDv06_decompressBegin(dctx);
     if ERR_isError(errorCode) {
         return errorCode;
@@ -3704,7 +3704,7 @@ pub(crate) unsafe fn ZBUFFv06_createDCtx() -> *mut ZBUFFv06_DCtx {
     (*zbd).stage = ZBUFFds_init;
     zbd
 }
-pub(crate) unsafe fn ZBUFFv06_freeDCtx(zbd: *mut ZBUFFv06_DCtx) -> size_t {
+pub(crate) unsafe fn ZBUFFv06_freeDCtx(zbd: *mut ZBUFFv06_DCtx) -> usize {
     if zbd.is_null() {
         return 0;
     }
@@ -3717,8 +3717,8 @@ pub(crate) unsafe fn ZBUFFv06_freeDCtx(zbd: *mut ZBUFFv06_DCtx) -> size_t {
 pub(crate) unsafe fn ZBUFFv06_decompressInitDictionary(
     zbd: *mut ZBUFFv06_DCtx,
     dict: *const core::ffi::c_void,
-    dictSize: size_t,
-) -> size_t {
+    dictSize: usize,
+) -> usize {
     (*zbd).stage = ZBUFFds_loadHeader;
     (*zbd).outEnd = 0;
     (*zbd).outStart = (*zbd).outEnd;
@@ -3729,10 +3729,10 @@ pub(crate) unsafe fn ZBUFFv06_decompressInitDictionary(
 #[inline]
 unsafe fn ZBUFFv06_limitCopy(
     dst: *mut core::ffi::c_void,
-    dstCapacity: size_t,
+    dstCapacity: usize,
     src: *const core::ffi::c_void,
-    srcSize: size_t,
-) -> size_t {
+    srcSize: usize,
+) -> usize {
     let length = if dstCapacity < srcSize {
         dstCapacity
     } else {
@@ -3748,10 +3748,10 @@ unsafe fn ZBUFFv06_limitCopy(
 pub(crate) unsafe fn ZBUFFv06_decompressContinue(
     zbd: *mut ZBUFFv06_DCtx,
     dst: *mut core::ffi::c_void,
-    dstCapacityPtr: *mut size_t,
+    dstCapacityPtr: *mut usize,
     src: *const core::ffi::c_void,
-    srcSizePtr: *mut size_t,
-) -> size_t {
+    srcSizePtr: *mut usize,
+) -> usize {
     let istart = src as *const core::ffi::c_char;
     let iend = istart.add(*srcSizePtr);
     let mut ip = istart;
@@ -3839,7 +3839,7 @@ pub(crate) unsafe fn ZBUFFv06_decompressContinue(
 
                     // Frame header instruct buffer sizes
                     let blockSize =
-                        core::cmp::min(1 << (*zbd).fParams.windowLog, 128 * 1024) as size_t;
+                        core::cmp::min(1 << (*zbd).fParams.windowLog, 128 * 1024) as usize;
                     (*zbd).blockSize = blockSize;
                     if (*zbd).inBuffSize < blockSize {
                         free((*zbd).inBuff as *mut core::ffi::c_void);
@@ -3850,9 +3850,9 @@ pub(crate) unsafe fn ZBUFFv06_decompressContinue(
                         }
                     }
 
-                    let neededOutSize = ((1 as size_t) << (*zbd).fParams.windowLog)
+                    let neededOutSize = ((1 as usize) << (*zbd).fParams.windowLog)
                         .wrapping_add(blockSize)
-                        .wrapping_add((WILDCOPY_OVERLENGTH * 2) as size_t);
+                        .wrapping_add((WILDCOPY_OVERLENGTH * 2) as usize);
                     if (*zbd).outBuffSize < neededOutSize {
                         free((*zbd).outBuff as *mut core::ffi::c_void);
                         (*zbd).outBuffSize = neededOutSize;
@@ -3922,7 +3922,7 @@ pub(crate) unsafe fn ZBUFFv06_decompressContinue(
             let neededInSize_0 = ZSTDv06_nextSrcSizeToDecompress((*zbd).zd);
             // should always be <= remaining space within inBuff
             let toLoad_0 = neededInSize_0.wrapping_sub((*zbd).inPos);
-            let mut loadedSize: size_t = 0;
+            let mut loadedSize: usize = 0;
             if toLoad_0 > ((*zbd).inBuffSize).wrapping_sub((*zbd).inPos) {
                 return Error::corruption_detected.to_error_code();
             }

--- a/lib/zstd.rs
+++ b/lib/zstd.rs
@@ -1,5 +1,5 @@
 use core::ffi::{c_int, c_uint, c_ulonglong};
-use libc::size_t;
+
 
 #[cfg(doc)]
 use crate::{
@@ -151,7 +151,7 @@ pub struct ZSTD_customMem {
 pub type ZSTD_freeFunction =
     Option<unsafe extern "C" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> ()>;
 pub type ZSTD_allocFunction =
-    Option<unsafe extern "C" fn(*mut core::ffi::c_void, size_t) -> *mut core::ffi::c_void>;
+    Option<unsafe extern "C" fn(*mut core::ffi::c_void, usize) -> *mut core::ffi::c_void>;
 
 #[derive(PartialEq)]
 #[repr(transparent)]
@@ -235,9 +235,9 @@ pub struct ZSTD_inBuffer_s {
     /// Pointer to start of input buffer
     pub src: *const core::ffi::c_void,
     /// Size of input buffer
-    pub size: size_t,
+    pub size: usize,
     /// Position where reading stopped. Will be updated. Necessarily `0 <= pos <= size`.
-    pub pos: size_t,
+    pub pos: usize,
 }
 
 pub type ZSTD_outBuffer = ZSTD_outBuffer_s;
@@ -247,9 +247,9 @@ pub struct ZSTD_outBuffer_s {
     /// Pointer to start of output buffer
     pub dst: *mut core::ffi::c_void,
     /// Size of output buffer
-    pub size: size_t,
+    pub size: usize,
     /// Position where writing stopped. Will be updated. Necessarily `0 <= pos <= size`.
-    pub pos: size_t,
+    pub pos: usize,
 }
 
 pub type ZSTD_bufferMode_e = core::ffi::c_uint;


### PR DESCRIPTION
I've marked this as a draft since I don't know how to handle the eprintln calls yet - those need proper error handling. I did not run cargo fmt as it seems it wasn't previously ran, so it would introduce other unrelated formatting changes.