### PR TITLE
Remove `::core::mem::` path to `size_of`

### DIFF
--- a/lib/common/entropy_common.rs
+++ b/lib/common/entropy_common.rs
@@ -586,7 +586,7 @@ mod tests {
                         src.as_ptr().cast::<core::ffi::c_void>(),
                         src.len(),
                         &mut workspace,
-                        core::mem::size_of::<Workspace>(),
+                        size_of::<Workspace>(),
                         if bmi2 { HUF_flags_bmi2 as core::ffi::c_int } else { 0 },
                     );
 

--- a/lib/common/fse_decompress.rs
+++ b/lib/common/fse_decompress.rs
@@ -84,7 +84,7 @@ fn FSE_buildDTable_internal(
     let tableSize = ((1) << tableLog) as u32;
     let mut highThreshold = tableSize.wrapping_sub(1);
 
-    if ((::core::mem::size_of::<core::ffi::c_short>() as core::ffi::c_ulong)
+    if ((size_of::<core::ffi::c_short>() as core::ffi::c_ulong)
         .wrapping_mul(maxSymbolValue.wrapping_add(1) as core::ffi::c_ulong)
         as core::ffi::c_ulonglong)
         .wrapping_add((1) << tableLog)
@@ -233,7 +233,7 @@ fn FSE_decompress_usingDTable_generic(
         };
 
         if (FSE_MAX_TABLELOG * 2 + 7) as core::ffi::c_ulong
-            > (::core::mem::size_of::<usize>() as core::ffi::c_ulong).wrapping_mul(8)
+            > (size_of::<usize>() as core::ffi::c_ulong).wrapping_mul(8)
         {
             let _ = bitD.reload();
         }
@@ -257,7 +257,7 @@ fn FSE_decompress_usingDTable_generic(
         };
 
         if (FSE_MAX_TABLELOG * 2 + 7) as core::ffi::c_ulong
-            > (::core::mem::size_of::<usize>() as core::ffi::c_ulong).wrapping_mul(8)
+            > (size_of::<usize>() as core::ffi::c_ulong).wrapping_mul(8)
         {
             let _ = bitD.reload();
         }
@@ -329,7 +329,7 @@ fn FSE_decompress_wksp_body(
 
     let mut tableLog: core::ffi::c_uint = 0;
     let mut maxSymbolValue = FSE_MAX_SYMBOL_VALUE as core::ffi::c_uint;
-    if wkspSize < ::core::mem::size_of::<FSE_DecompressWksp>() {
+    if wkspSize < size_of::<FSE_DecompressWksp>() {
         return Err(Error::GENERIC);
     }
     let NCountLength = FSE_readNCount_bmi2(
@@ -346,34 +346,35 @@ fn FSE_decompress_wksp_body(
     let ip = &cSrc[NCountLength as usize..];
     if ((1 + ((1) << tableLog) + 1) as core::ffi::c_ulonglong)
         .wrapping_add(
-            ((::core::mem::size_of::<core::ffi::c_short>() as core::ffi::c_ulong)
+            ((size_of::<core::ffi::c_short>() as core::ffi::c_ulong)
                 .wrapping_mul(maxSymbolValue.wrapping_add(1) as core::ffi::c_ulong)
                 as core::ffi::c_ulonglong)
                 .wrapping_add((1) << tableLog)
                 .wrapping_add(8)
                 .wrapping_add(
-                    ::core::mem::size_of::<core::ffi::c_uint>() as core::ffi::c_ulong
+                    size_of::<core::ffi::c_uint>() as core::ffi::c_ulong
                         as core::ffi::c_ulonglong,
                 )
                 .wrapping_sub(1)
                 .wrapping_div(
-                    ::core::mem::size_of::<core::ffi::c_uint>() as core::ffi::c_ulong
+                    size_of::<core::ffi::c_uint>() as core::ffi::c_ulong
                         as core::ffi::c_ulonglong,
                 ),
         )
         .wrapping_add(FSE_MAX_SYMBOL_VALUE.div_ceil(2) as core::ffi::c_ulonglong)
         .wrapping_add(1)
         .wrapping_mul(
-            ::core::mem::size_of::<core::ffi::c_uint>() as core::ffi::c_ulong
+            size_of::<core::ffi::c_uint>() as core::ffi::c_ulong
                 as core::ffi::c_ulonglong,
         )
         > wkspSize as core::ffi::c_ulonglong
     {
         return Err(Error::tableLog_tooLarge);
     }
-    wkspSize = wkspSize.wrapping_sub((::core::mem::size_of::<FSE_DecompressWksp>()).wrapping_add(
-        (1usize + (1 << tableLog)).wrapping_mul(::core::mem::size_of::<FSE_DTable>()),
-    ));
+    wkspSize = wkspSize.wrapping_sub(
+        (size_of::<FSE_DecompressWksp>())
+            .wrapping_add((1usize + (1 << tableLog)).wrapping_mul(size_of::<FSE_DTable>())),
+    );
 
     let () = FSE_buildDTable_internal(
         &mut workspace.dtable,

--- a/lib/common/fse_decompress.rs
+++ b/lib/common/fse_decompress.rs
@@ -372,7 +372,7 @@ fn FSE_decompress_wksp_body(
         return Err(Error::tableLog_tooLarge);
     }
     wkspSize = wkspSize.wrapping_sub(
-        (size_of::<FSE_DecompressWksp>())
+        size_of::<FSE_DecompressWksp>()
             .wrapping_add((1usize + (1 << tableLog)).wrapping_mul(size_of::<FSE_DTable>())),
     );
 

--- a/lib/common/huf.rs
+++ b/lib/common/huf.rs
@@ -17,7 +17,7 @@ pub(crate) const HUF_CTABLE_WORKSPACE_SIZE_U32: usize =
     (4 * (HUF_SYMBOLVALUE_MAX as usize + 1)) + 192;
 
 pub(crate) const HUF_CTABLE_WORKSPACE_SIZE: usize =
-    HUF_CTABLE_WORKSPACE_SIZE_U32 * core::mem::size_of::<u32>();
+    HUF_CTABLE_WORKSPACE_SIZE_U32 * size_of::<u32>();
 
 /// Absolute limit of [`HUF_MAX_TABLELOG`]. Beyond that value, code does not work
 pub(crate) const HUF_TABLELOG_ABSOLUTEMAX: usize = 12;
@@ -63,5 +63,5 @@ pub(crate) const HUF_READ_STATS_WORKSPACE_SIZE_U32: usize =
 pub(crate) struct HUF_CTableHeader {
     pub(crate) tableLog: u8,
     pub(crate) maxSymbolValue: u8,
-    pub(crate) unused: [u8; core::mem::size_of::<usize>() - 2],
+    pub(crate) unused: [u8; size_of::<usize>() - 2],
 }

--- a/lib/common/pool.rs
+++ b/lib/common/pool.rs
@@ -77,15 +77,13 @@ pub(crate) unsafe fn POOL_create_advanced(
     if numThreads == 0 {
         return core::ptr::null_mut();
     }
-    ctx = ZSTD_customCalloc(::core::mem::size_of::<POOL_ctx>(), customMem) as *mut POOL_ctx;
+    ctx = ZSTD_customCalloc(size_of::<POOL_ctx>(), customMem) as *mut POOL_ctx;
     if ctx.is_null() {
         return core::ptr::null_mut();
     }
     (*ctx).queueSize = queueSize.wrapping_add(1);
-    (*ctx).queue = ZSTD_customCalloc(
-        (*ctx).queueSize * ::core::mem::size_of::<POOL_job>(),
-        customMem,
-    ) as *mut POOL_job;
+    (*ctx).queue =
+        ZSTD_customCalloc((*ctx).queueSize * size_of::<POOL_job>(), customMem) as *mut POOL_job;
     (*ctx).queueHead = 0;
     (*ctx).queueTail = 0;
     (*ctx).numThreadsBusy = 0;
@@ -94,10 +92,8 @@ pub(crate) unsafe fn POOL_create_advanced(
     ptr::write(ptr::addr_of_mut!((*ctx).queuePushCond), Condvar::new());
     ptr::write(ptr::addr_of_mut!((*ctx).queuePopCond), Condvar::new());
     (*ctx).shutdown = 0;
-    (*ctx).threads = ZSTD_customCalloc(
-        numThreads * ::core::mem::size_of::<JoinHandle<()>>(),
-        customMem,
-    ) as *mut JoinHandle<()>;
+    (*ctx).threads = ZSTD_customCalloc(numThreads * size_of::<JoinHandle<()>>(), customMem)
+        as *mut JoinHandle<()>;
     (*ctx).threadCapacity = 0;
     (*ctx).customMem = customMem;
     if (*ctx).threads.is_null() || (*ctx).queue.is_null() {
@@ -138,17 +134,17 @@ pub unsafe fn POOL_free(ctx: *mut POOL_ctx) {
     ptr::drop_in_place(ptr::addr_of_mut!((*ctx).queuePopCond));
     ZSTD_customFree(
         (*ctx).queue as *mut core::ffi::c_void,
-        (*ctx).queueSize * ::core::mem::size_of::<POOL_job>(),
+        (*ctx).queueSize * size_of::<POOL_job>(),
         (*ctx).customMem,
     );
     ZSTD_customFree(
         (*ctx).threads as *mut core::ffi::c_void,
-        (*ctx).threadCapacity * ::core::mem::size_of::<JoinHandle<()>>(),
+        (*ctx).threadCapacity * size_of::<JoinHandle<()>>(),
         (*ctx).customMem,
     );
     ZSTD_customFree(
         ctx as *mut core::ffi::c_void,
-        ::core::mem::size_of::<POOL_ctx>(),
+        size_of::<POOL_ctx>(),
         (*ctx).customMem,
     );
 }
@@ -167,9 +163,9 @@ pub(crate) unsafe fn POOL_sizeof(ctx: *const POOL_ctx) -> size_t {
     if ctx.is_null() {
         return 0;
     }
-    ::core::mem::size_of::<POOL_ctx>()
-        + (*ctx).queueSize * ::core::mem::size_of::<POOL_job>()
-        + (*ctx).threadCapacity * ::core::mem::size_of::<JoinHandle<()>>()
+    size_of::<POOL_ctx>()
+        + (*ctx).queueSize * size_of::<POOL_job>()
+        + (*ctx).threadCapacity * size_of::<JoinHandle<()>>()
 }
 unsafe fn POOL_resize_internal(ctx: *mut POOL_ctx, numThreads: size_t) -> core::ffi::c_int {
     if numThreads <= (*ctx).threadCapacity {
@@ -180,7 +176,7 @@ unsafe fn POOL_resize_internal(ctx: *mut POOL_ctx, numThreads: size_t) -> core::
         return 0;
     }
     let threadPool = ZSTD_customCalloc(
-        numThreads.wrapping_mul(::core::mem::size_of::<JoinHandle<()>>()),
+        numThreads.wrapping_mul(size_of::<JoinHandle<()>>()),
         (*ctx).customMem,
     ) as *mut JoinHandle<()>;
     if threadPool.is_null() {
@@ -189,11 +185,11 @@ unsafe fn POOL_resize_internal(ctx: *mut POOL_ctx, numThreads: size_t) -> core::
     libc::memcpy(
         threadPool as *mut core::ffi::c_void,
         (*ctx).threads as *const core::ffi::c_void,
-        (*ctx).threadCapacity * ::core::mem::size_of::<JoinHandle<()>>(),
+        (*ctx).threadCapacity * size_of::<JoinHandle<()>>(),
     );
     ZSTD_customFree(
         (*ctx).threads as *mut core::ffi::c_void,
-        (*ctx).threadCapacity * ::core::mem::size_of::<JoinHandle<()>>(),
+        (*ctx).threadCapacity * size_of::<JoinHandle<()>>(),
         (*ctx).customMem,
     );
     (*ctx).threads = threadPool;

--- a/lib/compress/fse_compress.rs
+++ b/lib/compress/fse_compress.rs
@@ -73,14 +73,14 @@ pub(crate) unsafe fn FSE_buildCTable_wksp(
     let cumul = workSpace as *mut u16;
     let tableSymbol = cumul.offset(maxSV1.wrapping_add(1) as isize) as *mut u8;
     let mut highThreshold = tableSize.wrapping_sub(1);
-    if (::core::mem::size_of::<core::ffi::c_uint>() as core::ffi::c_ulong as core::ffi::c_ulonglong)
+    if (size_of::<core::ffi::c_uint>() as core::ffi::c_ulong as core::ffi::c_ulonglong)
         .wrapping_mul(
             (maxSymbolValue.wrapping_add(2) as core::ffi::c_ulonglong)
                 .wrapping_add((1) << tableLog)
                 .wrapping_div(2)
                 .wrapping_add(
-                    (::core::mem::size_of::<u64>() as core::ffi::c_ulong)
-                        .wrapping_div(::core::mem::size_of::<u32>() as core::ffi::c_ulong)
+                    (size_of::<u64>() as core::ffi::c_ulong)
+                        .wrapping_div(size_of::<u32>() as core::ffi::c_ulong)
                         as core::ffi::c_ulonglong,
                 ),
         )
@@ -659,7 +659,7 @@ unsafe fn FSE_compress_usingCTable_generic(
         FSE_initCState2(&mut CState1, ct, *ip as u32);
     }
     srcSize = srcSize.wrapping_sub(2);
-    if (::core::mem::size_of::<BitContainerType>() as core::ffi::c_ulong).wrapping_mul(8)
+    if (size_of::<BitContainerType>() as core::ffi::c_ulong).wrapping_mul(8)
         > (FSE_MAX_TABLELOG * 4 + 7) as core::ffi::c_ulong
         && srcSize & 2 != 0
     {
@@ -676,7 +676,7 @@ unsafe fn FSE_compress_usingCTable_generic(
     while ip > istart {
         ip = ip.sub(1);
         FSE_encodeSymbol(&mut bitC, &mut CState2, *ip as core::ffi::c_uint);
-        if (::core::mem::size_of::<BitContainerType>() as core::ffi::c_ulong).wrapping_mul(8)
+        if (size_of::<BitContainerType>() as core::ffi::c_ulong).wrapping_mul(8)
             < (FSE_MAX_TABLELOG * 2 + 7) as core::ffi::c_ulong
         {
             if fast != 0 {
@@ -687,7 +687,7 @@ unsafe fn FSE_compress_usingCTable_generic(
         }
         ip = ip.sub(1);
         FSE_encodeSymbol(&mut bitC, &mut CState1, *ip as core::ffi::c_uint);
-        if (::core::mem::size_of::<BitContainerType>() as core::ffi::c_ulong).wrapping_mul(8)
+        if (size_of::<BitContainerType>() as core::ffi::c_ulong).wrapping_mul(8)
             > (FSE_MAX_TABLELOG * 4 + 7) as core::ffi::c_ulong
         {
             ip = ip.sub(1);
@@ -716,7 +716,7 @@ pub(crate) unsafe fn FSE_compress_usingCTable(
         >= srcSize
             .wrapping_add(srcSize >> 7)
             .wrapping_add(4)
-            .wrapping_add(::core::mem::size_of::<size_t>())) as core::ffi::c_int
+            .wrapping_add(size_of::<size_t>())) as core::ffi::c_int
         as core::ffi::c_uint;
     if fast != 0 {
         FSE_compress_usingCTable_generic(dst, dstSize, src, srcSize, ct, 1)

--- a/lib/compress/hist.rs
+++ b/lib/compress/hist.rs
@@ -9,7 +9,7 @@ use crate::lib::common::error_private::{ERR_isError, Error};
 use crate::lib::common::mem::MEM_read32;
 pub const HIST_WKSP_SIZE_U32: core::ffi::c_int = 1024;
 pub const HIST_WKSP_SIZE: size_t =
-    (HIST_WKSP_SIZE_U32 as size_t).wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>());
+    (HIST_WKSP_SIZE_U32 as size_t).wrapping_mul(size_of::<core::ffi::c_uint>());
 pub const HIST_FAST_THRESHOLD: core::ffi::c_int = 1500;
 pub unsafe fn HIST_isError(code: size_t) -> core::ffi::c_uint {
     ERR_isError(code) as _
@@ -42,7 +42,7 @@ pub unsafe fn HIST_count_simple(
         count as *mut u8,
         0,
         (maxSymbolValue.wrapping_add(1) as core::ffi::c_ulong)
-            .wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>() as core::ffi::c_ulong)
+            .wrapping_mul(size_of::<core::ffi::c_uint>() as core::ffi::c_ulong)
             as libc::size_t,
     );
     if srcSize == 0 {
@@ -80,7 +80,7 @@ unsafe fn HIST_count_parallel_wksp(
     let mut ip = source as *const u8;
     let iend = ip.add(sourceSize);
     let countSize = ((*maxSymbolValuePtr).wrapping_add(1) as core::ffi::c_ulong)
-        .wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>() as core::ffi::c_ulong);
+        .wrapping_mul(size_of::<core::ffi::c_uint>() as core::ffi::c_ulong);
     let mut max = 0;
     let Counting1 = workSpace;
     let Counting2 = Counting1.add(256);
@@ -95,7 +95,7 @@ unsafe fn HIST_count_parallel_wksp(
         workSpace as *mut u8,
         0,
         ((4 * 256) as core::ffi::c_ulong)
-            .wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>() as core::ffi::c_ulong)
+            .wrapping_mul(size_of::<core::ffi::c_uint>() as core::ffi::c_ulong)
             as libc::size_t,
     );
     let mut cached = MEM_read32(ip as *const core::ffi::c_void);
@@ -251,7 +251,7 @@ pub unsafe fn HIST_countFast(
         source,
         sourceSize,
         tmpCounters.as_mut_ptr() as *mut core::ffi::c_void,
-        ::core::mem::size_of::<[core::ffi::c_uint; 1024]>(),
+        size_of::<[core::ffi::c_uint; 1024]>(),
     )
 }
 pub unsafe fn HIST_count(
@@ -267,6 +267,6 @@ pub unsafe fn HIST_count(
         src,
         srcSize,
         tmpCounters.as_mut_ptr() as *mut core::ffi::c_void,
-        ::core::mem::size_of::<[core::ffi::c_uint; 1024]>(),
+        size_of::<[core::ffi::c_uint; 1024]>(),
     )
 }

--- a/lib/compress/huf_compress.rs
+++ b/lib/compress/huf_compress.rs
@@ -1756,7 +1756,7 @@ pub unsafe fn HUF_optimalTableLog(
         return FSE_optimalTableLog_internal(maxTableLog, srcSize, maxSymbolValue, 1);
     }
     let dst = (workSpace as *mut u8).offset(size_of::<HUF_WriteCTableWksp>() as c_ulong as isize);
-    let dstSize = wkspSize - (size_of::<HUF_WriteCTableWksp>());
+    let dstSize = wkspSize - size_of::<HUF_WriteCTableWksp>();
     let mut hSize: size_t = 0;
     let mut newSize: size_t = 0;
     let symbolCardinality = HUF_cardinality(count, maxSymbolValue);

--- a/lib/compress/huf_compress.rs
+++ b/lib/compress/huf_compress.rs
@@ -210,7 +210,7 @@ unsafe fn HUF_setValue(elt: *mut HUF_CElt, value: size_t) {
     let nbBits = HUF_getNbBits(*elt);
     if nbBits > 0 {
         debug_assert!((value >> nbBits) == 0);
-        *elt |= value << (core::mem::size_of::<HUF_CElt>() * 8 - nbBits);
+        *elt |= value << (HUF_CElt::BITS as usize - nbBits);
     }
 }
 
@@ -235,7 +235,7 @@ unsafe fn HUF_writeCTableHeader(ctable: *mut HUF_CElt, tableLog: u32, maxSymbolV
         unused: [0; _],
     };
     const {
-        assert!(core::mem::size_of::<HUF_CElt>() == core::mem::size_of::<HUF_CTableHeader>());
+        assert!(size_of::<HUF_CElt>() == size_of::<HUF_CTableHeader>());
     }
     ptr::write_bytes(
         &mut header as *mut HUF_CTableHeader as *mut u8,
@@ -277,7 +277,7 @@ pub unsafe fn HUF_writeCTable_wksp(
         as *mut HUF_WriteCTableWksp;
 
     const {
-        assert!(HUF_CTABLE_WORKSPACE_SIZE >= core::mem::size_of::<HUF_WriteCTableWksp>());
+        assert!(HUF_CTABLE_WORKSPACE_SIZE >= size_of::<HUF_WriteCTableWksp>());
     }
 
     debug_assert!(HUF_readCTableHeader(CTable).maxSymbolValue as c_uint == maxSymbolValue);
@@ -1254,7 +1254,7 @@ unsafe fn HUF_flushBits(bitC: *mut HUF_CStream_t, kFast: c_int) {
     /* Mask bitPos to account for the bytes we consumed. */
     *((*bitC).bitPos).as_mut_ptr() &= 7;
     debug_assert!(nbBits > 0);
-    debug_assert!(nbBits <= core::mem::size_of::<size_t>() * 8);
+    debug_assert!(nbBits <= size_t::BITS as usize);
     debug_assert!((*bitC).ptr <= (*bitC).endPtr);
     MEM_writeLEST((*bitC).ptr as *mut c_void, bitContainer);
     (*bitC).ptr = ((*bitC).ptr).add(nbBytes);

--- a/lib/compress/zstd_compress.rs
+++ b/lib/compress/zstd_compress.rs
@@ -798,11 +798,7 @@ unsafe fn ZSTD_checkDictValidity(
 }
 #[inline]
 unsafe fn ZSTD_window_init(window: *mut ZSTD_window_t) {
-    ptr::write_bytes(
-        window as *mut u8,
-        0,
-        ::core::mem::size_of::<ZSTD_window_t>(),
-    );
+    ptr::write_bytes(window as *mut u8, 0, size_of::<ZSTD_window_t>());
     (*window).base = b" \0" as *const u8 as *const core::ffi::c_char as *const u8;
     (*window).dictBase = b" \0" as *const u8 as *const core::ffi::c_char as *const u8;
     (*window).dictLimit = ZSTD_WINDOW_START_INDEX as u32;
@@ -1145,7 +1141,7 @@ unsafe fn ZSTD_cwksp_reserve_table(ws: *mut ZSTD_cwksp, bytes: size_t) -> *mut c
 }
 #[inline]
 unsafe fn ZSTD_cwksp_reserve_object(ws: *mut ZSTD_cwksp, bytes: size_t) -> *mut core::ffi::c_void {
-    let roundedBytes = ZSTD_cwksp_align(bytes, ::core::mem::size_of::<*mut core::ffi::c_void>());
+    let roundedBytes = ZSTD_cwksp_align(bytes, size_of::<*mut core::ffi::c_void>());
     let alloc = (*ws).objectEnd;
     let end = (alloc as *mut u8).add(roundedBytes) as *mut core::ffi::c_void;
     ZSTD_cwksp_assert_internal_consistency(ws);
@@ -1243,13 +1239,13 @@ unsafe fn ZSTD_cwksp_free(ws: *mut ZSTD_cwksp, customMem: ZSTD_customMem) {
     let size = (*ws)
         .workspaceEnd
         .byte_offset_from_unsigned((*ws).workspace);
-    ptr::write_bytes(ws as *mut u8, 0, ::core::mem::size_of::<ZSTD_cwksp>());
+    ptr::write_bytes(ws as *mut u8, 0, size_of::<ZSTD_cwksp>());
     ZSTD_customFree(ptr, size, customMem);
 }
 #[inline]
 unsafe fn ZSTD_cwksp_move(dst: *mut ZSTD_cwksp, src: *mut ZSTD_cwksp) {
     *dst = *src;
-    ptr::write_bytes(src as *mut u8, 0, ::core::mem::size_of::<ZSTD_cwksp>());
+    ptr::write_bytes(src as *mut u8, 0, size_of::<ZSTD_cwksp>());
 }
 #[inline]
 unsafe fn ZSTD_cwksp_reserve_failed(ws: *const ZSTD_cwksp) -> core::ffi::c_int {
@@ -1564,7 +1560,7 @@ pub const INT_MAX: core::ffi::c_int = __INT_MAX__;
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_compressBound))]
 pub extern "C" fn ZSTD_compressBound(srcSize: size_t) -> size_t {
     let r = if srcSize as core::ffi::c_ulonglong
-        >= (if ::core::mem::size_of::<size_t>() == 8 {
+        >= (if size_of::<size_t>() == 8 {
             0xff00ff00ff00ff00 as core::ffi::c_ulonglong
         } else {
             0xff00ff00 as core::ffi::c_uint as core::ffi::c_ulonglong
@@ -1589,14 +1585,14 @@ pub unsafe extern "C" fn ZSTD_createCCtx() -> *mut ZSTD_CCtx {
     ZSTD_createCCtx_advanced(ZSTD_customMem::default())
 }
 unsafe fn ZSTD_initCCtx(cctx: *mut ZSTD_CCtx, memManager: ZSTD_customMem) {
-    ptr::write_bytes(cctx as *mut u8, 0, ::core::mem::size_of::<ZSTD_CCtx>());
+    ptr::write_bytes(cctx as *mut u8, 0, size_of::<ZSTD_CCtx>());
     (*cctx).customMem = memManager;
     (*cctx).bmi2 = ZSTD_cpuSupportsBmi2() as _;
     let _err = ZSTD_CCtx_reset(cctx, ZSTD_ResetDirective::ZSTD_reset_parameters);
 }
 #[cfg_attr(feature = "export-symbols", export_name = crate::prefix!(ZSTD_createCCtx_advanced))]
 pub unsafe extern "C" fn ZSTD_createCCtx_advanced(customMem: ZSTD_customMem) -> *mut ZSTD_CCtx {
-    let cctx = ZSTD_customMalloc(::core::mem::size_of::<ZSTD_CCtx>(), customMem) as *mut ZSTD_CCtx;
+    let cctx = ZSTD_customMalloc(size_of::<ZSTD_CCtx>(), customMem) as *mut ZSTD_CCtx;
     if cctx.is_null() {
         return core::ptr::null_mut();
     }
@@ -1622,59 +1618,56 @@ pub unsafe extern "C" fn ZSTD_initStaticCCtx(
         isStatic: ZSTD_cwksp_dynamic_alloc,
     };
     let mut cctx = core::ptr::null_mut::<ZSTD_CCtx>();
-    if workspaceSize <= ::core::mem::size_of::<ZSTD_CCtx>() {
+    if workspaceSize <= size_of::<ZSTD_CCtx>() {
         return core::ptr::null_mut();
     }
     if workspace as size_t & 7 != 0 {
         return core::ptr::null_mut();
     }
     ZSTD_cwksp_init(&mut ws, workspace, workspaceSize, ZSTD_cwksp_static_alloc);
-    cctx =
-        ZSTD_cwksp_reserve_object(&mut ws, ::core::mem::size_of::<ZSTD_CCtx>()) as *mut ZSTD_CCtx;
+    cctx = ZSTD_cwksp_reserve_object(&mut ws, size_of::<ZSTD_CCtx>()) as *mut ZSTD_CCtx;
     if cctx.is_null() {
         return core::ptr::null_mut();
     }
-    ptr::write_bytes(cctx as *mut u8, 0, ::core::mem::size_of::<ZSTD_CCtx>());
+    ptr::write_bytes(cctx as *mut u8, 0, size_of::<ZSTD_CCtx>());
     ZSTD_cwksp_move(&mut (*cctx).workspace, &mut ws);
     (*cctx).staticSize = workspaceSize;
     if ZSTD_cwksp_check_available(
         &mut (*cctx).workspace,
         (if ((((8) << 10) + 512) as size_t).wrapping_add(
-            (::core::mem::size_of::<core::ffi::c_uint>())
+            (size_of::<core::ffi::c_uint>())
                 .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
         ) > 8208
         {
             ((((8) << 10) + 512) as size_t).wrapping_add(
-                (::core::mem::size_of::<core::ffi::c_uint>())
+                (size_of::<core::ffi::c_uint>())
                     .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
             )
         } else {
             8208
         })
-        .wrapping_add(
-            (2 as size_t).wrapping_mul(::core::mem::size_of::<ZSTD_compressedBlockState_t>()),
-        ),
+        .wrapping_add((2 as size_t).wrapping_mul(size_of::<ZSTD_compressedBlockState_t>())),
     ) == 0
     {
         return core::ptr::null_mut();
     }
     (*cctx).blockState.prevCBlock = ZSTD_cwksp_reserve_object(
         &mut (*cctx).workspace,
-        ::core::mem::size_of::<ZSTD_compressedBlockState_t>(),
+        size_of::<ZSTD_compressedBlockState_t>(),
     ) as *mut ZSTD_compressedBlockState_t;
     (*cctx).blockState.nextCBlock = ZSTD_cwksp_reserve_object(
         &mut (*cctx).workspace,
-        ::core::mem::size_of::<ZSTD_compressedBlockState_t>(),
+        size_of::<ZSTD_compressedBlockState_t>(),
     ) as *mut ZSTD_compressedBlockState_t;
     (*cctx).tmpWorkspace = ZSTD_cwksp_reserve_object(
         &mut (*cctx).workspace,
         if ((((8) << 10) + 512) as size_t).wrapping_add(
-            (::core::mem::size_of::<core::ffi::c_uint>())
+            (size_of::<core::ffi::c_uint>())
                 .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
         ) > 8208
         {
             ((((8) << 10) + 512) as size_t).wrapping_add(
-                (::core::mem::size_of::<core::ffi::c_uint>())
+                (size_of::<core::ffi::c_uint>())
                     .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
             )
         } else {
@@ -1682,12 +1675,12 @@ pub unsafe extern "C" fn ZSTD_initStaticCCtx(
         },
     );
     (*cctx).tmpWkspSize = if ((((8) << 10) + 512) as size_t).wrapping_add(
-        (::core::mem::size_of::<core::ffi::c_uint>())
+        (size_of::<core::ffi::c_uint>())
             .wrapping_mul(((if 35 > 52 as core::ffi::c_int { 35 } else { 52 }) + 2) as size_t),
     ) > 8208 as size_t
     {
         ((((8) << 10) + 512) as size_t).wrapping_add(
-            (::core::mem::size_of::<core::ffi::c_uint>())
+            (size_of::<core::ffi::c_uint>())
                 .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
         )
     } else {
@@ -1706,12 +1699,12 @@ unsafe fn ZSTD_clearAllDicts(cctx: *mut ZSTD_CCtx) {
     ptr::write_bytes(
         &mut (*cctx).localDict as *mut ZSTD_localDict as *mut u8,
         0,
-        ::core::mem::size_of::<ZSTD_localDict>(),
+        size_of::<ZSTD_localDict>(),
     );
     ptr::write_bytes(
         &mut (*cctx).prefixDict as *mut ZSTD_prefixDict as *mut u8,
         0,
-        ::core::mem::size_of::<ZSTD_prefixDict>(),
+        size_of::<ZSTD_prefixDict>(),
     );
     (*cctx).cdict = core::ptr::null();
 }
@@ -1744,7 +1737,7 @@ pub unsafe extern "C" fn ZSTD_freeCCtx(cctx: *mut ZSTD_CCtx) -> size_t {
     if cctxInWorkspace == 0 {
         ZSTD_customFree(
             cctx as *mut core::ffi::c_void,
-            ::core::mem::size_of::<ZSTD_CCtx>(),
+            size_of::<ZSTD_CCtx>(),
             (*cctx).customMem,
         );
     }
@@ -1761,7 +1754,7 @@ pub unsafe extern "C" fn ZSTD_sizeof_CCtx(cctx: *const ZSTD_CCtx) -> size_t {
     (if (*cctx).workspace.workspace == cctx as *mut core::ffi::c_void {
         0
     } else {
-        ::core::mem::size_of::<ZSTD_CCtx>()
+        size_of::<ZSTD_CCtx>()
     })
     .wrapping_add(ZSTD_cwksp_sizeof(&(*cctx).workspace))
     .wrapping_add(ZSTD_sizeof_localDict((*cctx).localDict))
@@ -1947,8 +1940,8 @@ unsafe fn ZSTD_makeCCtxParamsFromCParams(cParams: ZSTD_compressionParameters) ->
     cctxParams
 }
 unsafe fn ZSTD_createCCtxParams_advanced(customMem: ZSTD_customMem) -> *mut ZSTD_CCtx_params {
-    let params = ZSTD_customCalloc(::core::mem::size_of::<ZSTD_CCtx_params>(), customMem)
-        as *mut ZSTD_CCtx_params;
+    let params =
+        ZSTD_customCalloc(size_of::<ZSTD_CCtx_params>(), customMem) as *mut ZSTD_CCtx_params;
     if params.is_null() {
         return core::ptr::null_mut();
     }
@@ -1967,7 +1960,7 @@ pub unsafe extern "C" fn ZSTD_freeCCtxParams(params: *mut ZSTD_CCtx_params) -> s
     }
     ZSTD_customFree(
         params as *mut core::ffi::c_void,
-        ::core::mem::size_of::<ZSTD_CCtx_params>(),
+        size_of::<ZSTD_CCtx_params>(),
         (*params).customMem,
     );
     0
@@ -1984,11 +1977,7 @@ pub unsafe extern "C" fn ZSTD_CCtxParams_init(
     if cctxParams.is_null() {
         return Error::GENERIC.to_error_code();
     }
-    ptr::write_bytes(
-        cctxParams as *mut u8,
-        0,
-        ::core::mem::size_of::<ZSTD_CCtx_params>(),
-    );
+    ptr::write_bytes(cctxParams as *mut u8, 0, size_of::<ZSTD_CCtx_params>());
     (*cctxParams).compressionLevel = compressionLevel;
     (*cctxParams).fParams.contentSizeFlag = 1;
     0
@@ -1999,11 +1988,7 @@ unsafe fn ZSTD_CCtxParams_init_internal(
     params: *const ZSTD_parameters,
     compressionLevel: core::ffi::c_int,
 ) {
-    ptr::write_bytes(
-        cctxParams as *mut u8,
-        0,
-        ::core::mem::size_of::<ZSTD_CCtx_params>(),
-    );
+    ptr::write_bytes(cctxParams as *mut u8, 0, size_of::<ZSTD_CCtx_params>());
     (*cctxParams).cParams = (*params).cParams;
     (*cctxParams).fParams = (*params).fParams;
     (*cctxParams).compressionLevel = compressionLevel;
@@ -2061,7 +2046,7 @@ pub unsafe extern "C" fn ZSTD_cParam_getBounds(param: ZSTD_cParameter) -> ZSTD_b
         }
         101 => {
             bounds.lowerBound = ZSTD_WINDOWLOG_MIN;
-            bounds.upperBound = if ::core::mem::size_of::<size_t>() == 4 {
+            bounds.upperBound = if size_of::<size_t>() == 4 {
                 ZSTD_WINDOWLOG_MAX_32
             } else {
                 ZSTD_WINDOWLOG_MAX_64
@@ -2070,13 +2055,13 @@ pub unsafe extern "C" fn ZSTD_cParam_getBounds(param: ZSTD_cParameter) -> ZSTD_b
         }
         102 => {
             bounds.lowerBound = ZSTD_HASHLOG_MIN;
-            bounds.upperBound = if (if ::core::mem::size_of::<size_t>() == 4 {
+            bounds.upperBound = if (if size_of::<size_t>() == 4 {
                 ZSTD_WINDOWLOG_MAX_32
             } else {
                 ZSTD_WINDOWLOG_MAX_64
             }) < 30
             {
-                if ::core::mem::size_of::<size_t>() == 4 {
+                if size_of::<size_t>() == 4 {
                     ZSTD_WINDOWLOG_MAX_32
                 } else {
                     ZSTD_WINDOWLOG_MAX_64
@@ -2088,7 +2073,7 @@ pub unsafe extern "C" fn ZSTD_cParam_getBounds(param: ZSTD_cParameter) -> ZSTD_b
         }
         103 => {
             bounds.lowerBound = ZSTD_CHAINLOG_MIN;
-            bounds.upperBound = if ::core::mem::size_of::<size_t>() == 4 {
+            bounds.upperBound = if size_of::<size_t>() == 4 {
                 ZSTD_CHAINLOG_MAX_32
             } else {
                 ZSTD_CHAINLOG_MAX_64
@@ -2097,7 +2082,7 @@ pub unsafe extern "C" fn ZSTD_cParam_getBounds(param: ZSTD_cParameter) -> ZSTD_b
         }
         104 => {
             bounds.lowerBound = ZSTD_SEARCHLOG_MIN;
-            bounds.upperBound = (if ::core::mem::size_of::<size_t>() == 4 {
+            bounds.upperBound = (if size_of::<size_t>() == 4 {
                 ZSTD_WINDOWLOG_MAX_32
             } else {
                 ZSTD_WINDOWLOG_MAX_64
@@ -2136,7 +2121,7 @@ pub unsafe extern "C" fn ZSTD_cParam_getBounds(param: ZSTD_cParameter) -> ZSTD_b
         }
         400 => {
             bounds.lowerBound = 0;
-            bounds.upperBound = if ::core::mem::size_of::<*mut core::ffi::c_void>() == 4 {
+            bounds.upperBound = if size_of::<*mut core::ffi::c_void>() == 4 {
                 64
             } else {
                 256
@@ -2169,13 +2154,13 @@ pub unsafe extern "C" fn ZSTD_cParam_getBounds(param: ZSTD_cParameter) -> ZSTD_b
         }
         161 => {
             bounds.lowerBound = ZSTD_LDM_HASHLOG_MIN;
-            bounds.upperBound = if (if ::core::mem::size_of::<size_t>() == 4 {
+            bounds.upperBound = if (if size_of::<size_t>() == 4 {
                 ZSTD_WINDOWLOG_MAX_32
             } else {
                 ZSTD_WINDOWLOG_MAX_64
             }) < 30
             {
-                if ::core::mem::size_of::<size_t>() == 4 {
+                if size_of::<size_t>() == 4 {
                     ZSTD_WINDOWLOG_MAX_32
                 } else {
                     ZSTD_WINDOWLOG_MAX_64
@@ -2197,7 +2182,7 @@ pub unsafe extern "C" fn ZSTD_cParam_getBounds(param: ZSTD_cParameter) -> ZSTD_b
         }
         164 => {
             bounds.lowerBound = ZSTD_LDM_HASHRATELOG_MIN;
-            bounds.upperBound = (if ::core::mem::size_of::<size_t>() == 4 {
+            bounds.upperBound = (if size_of::<size_t>() == 4 {
                 ZSTD_WINDOWLOG_MAX_32
             } else {
                 ZSTD_WINDOWLOG_MAX_64
@@ -3257,7 +3242,7 @@ unsafe fn ZSTD_dictAndWindowLog(windowLog: u32, srcSize: u64, dictSize: u64) -> 
     if windowSize >= dictSize.wrapping_add(srcSize) {
         windowLog
     } else if dictAndWindowSize >= maxWindowSize {
-        (if ::core::mem::size_of::<size_t>() == 4 {
+        (if size_of::<size_t>() == 4 {
             ZSTD_WINDOWLOG_MAX_32
         } else {
             ZSTD_WINDOWLOG_MAX_64
@@ -3275,7 +3260,7 @@ unsafe fn ZSTD_adjustCParams_internal(
 ) -> ZSTD_compressionParameters {
     let minSrcSize = 513;
     let maxWindowResize = ((1)
-        << ((if ::core::mem::size_of::<size_t>() == 4 {
+        << ((if size_of::<size_t>() == 4 {
             ZSTD_WINDOWLOG_MAX_32
         } else {
             ZSTD_WINDOWLOG_MAX_64
@@ -3466,27 +3451,26 @@ unsafe fn ZSTD_sizeof_matchState(
         0 as size_t
     };
     let tableSpace = chainSize
-        .wrapping_mul(::core::mem::size_of::<u32>())
-        .wrapping_add(hSize.wrapping_mul(::core::mem::size_of::<u32>()))
-        .wrapping_add(h3Size.wrapping_mul(::core::mem::size_of::<u32>()));
-    let optPotentialSpace = (ZSTD_cwksp_aligned64_alloc_size(
-        ((MaxML + 1) as size_t).wrapping_mul(::core::mem::size_of::<u32>()),
-    ))
-    .wrapping_add(ZSTD_cwksp_aligned64_alloc_size(
-        ((MaxLL + 1) as size_t).wrapping_mul(::core::mem::size_of::<u32>()),
-    ))
-    .wrapping_add(ZSTD_cwksp_aligned64_alloc_size(
-        ((MaxOff + 1) as size_t).wrapping_mul(::core::mem::size_of::<u32>()),
-    ))
-    .wrapping_add(ZSTD_cwksp_aligned64_alloc_size(
-        (((1) << Litbits) as size_t).wrapping_mul(::core::mem::size_of::<u32>()),
-    ))
-    .wrapping_add(ZSTD_cwksp_aligned64_alloc_size(
-        (ZSTD_OPT_SIZE as size_t).wrapping_mul(::core::mem::size_of::<ZSTD_match_t>()),
-    ))
-    .wrapping_add(ZSTD_cwksp_aligned64_alloc_size(
-        (ZSTD_OPT_SIZE as size_t).wrapping_mul(::core::mem::size_of::<ZSTD_optimal_t>()),
-    ));
+        .wrapping_mul(size_of::<u32>())
+        .wrapping_add(hSize.wrapping_mul(size_of::<u32>()))
+        .wrapping_add(h3Size.wrapping_mul(size_of::<u32>()));
+    let optPotentialSpace =
+        (ZSTD_cwksp_aligned64_alloc_size(((MaxML + 1) as size_t).wrapping_mul(size_of::<u32>())))
+            .wrapping_add(ZSTD_cwksp_aligned64_alloc_size(
+                ((MaxLL + 1) as size_t).wrapping_mul(size_of::<u32>()),
+            ))
+            .wrapping_add(ZSTD_cwksp_aligned64_alloc_size(
+                ((MaxOff + 1) as size_t).wrapping_mul(size_of::<u32>()),
+            ))
+            .wrapping_add(ZSTD_cwksp_aligned64_alloc_size(
+                (((1) << Litbits) as size_t).wrapping_mul(size_of::<u32>()),
+            ))
+            .wrapping_add(ZSTD_cwksp_aligned64_alloc_size(
+                (ZSTD_OPT_SIZE as size_t).wrapping_mul(size_of::<ZSTD_match_t>()),
+            ))
+            .wrapping_add(ZSTD_cwksp_aligned64_alloc_size(
+                (ZSTD_OPT_SIZE as size_t).wrapping_mul(size_of::<ZSTD_optimal_t>()),
+            ));
     let lazyAdditionalSpace =
         if ZSTD_rowMatchFinderUsed((*cParams).strategy, useRowMatchFinder) != 0 {
             ZSTD_cwksp_aligned64_alloc_size(hSize)
@@ -3550,47 +3534,42 @@ unsafe fn ZSTD_estimateCCtxSize_usingCCtxParams_internal(
     let maxNbSeq = ZSTD_maxNbSeq(blockSize, (*cParams).minMatch, useSequenceProducer);
     let tokenSpace = (ZSTD_cwksp_alloc_size(WILDCOPY_OVERLENGTH.wrapping_add(blockSize)))
         .wrapping_add(ZSTD_cwksp_aligned64_alloc_size(
-            maxNbSeq.wrapping_mul(::core::mem::size_of::<SeqDef>()),
+            maxNbSeq.wrapping_mul(size_of::<SeqDef>()),
         ))
-        .wrapping_add(
-            3 * ZSTD_cwksp_alloc_size(maxNbSeq.wrapping_mul(::core::mem::size_of::<u8>())),
-        );
+        .wrapping_add(3 * ZSTD_cwksp_alloc_size(maxNbSeq.wrapping_mul(size_of::<u8>())));
     let tmpWorkSpace = ZSTD_cwksp_alloc_size(
         if ((((8) << 10) + 512) as size_t).wrapping_add(
-            (::core::mem::size_of::<core::ffi::c_uint>())
+            (size_of::<core::ffi::c_uint>())
                 .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
         ) > 8208
         {
             ((((8) << 10) + 512) as size_t).wrapping_add(
-                (::core::mem::size_of::<core::ffi::c_uint>())
+                (size_of::<core::ffi::c_uint>())
                     .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
             )
         } else {
             8208
         },
     );
-    let blockStateSpace =
-        2 * ZSTD_cwksp_alloc_size(::core::mem::size_of::<ZSTD_compressedBlockState_t>());
+    let blockStateSpace = 2 * ZSTD_cwksp_alloc_size(size_of::<ZSTD_compressedBlockState_t>());
     let matchStateSize = ZSTD_sizeof_matchState(cParams, useRowMatchFinder, 0, 1);
     let ldmSpace = ZSTD_ldm_getTableSize(*ldmParams);
     let maxNbLdmSeq = ZSTD_ldm_getMaxNbSeq(*ldmParams, blockSize);
     let ldmSeqSpace = if (*ldmParams).enableLdm == ZSTD_ParamSwitch_e::ZSTD_ps_enable {
-        ZSTD_cwksp_aligned64_alloc_size(maxNbLdmSeq.wrapping_mul(::core::mem::size_of::<rawSeq>()))
+        ZSTD_cwksp_aligned64_alloc_size(maxNbLdmSeq.wrapping_mul(size_of::<rawSeq>()))
     } else {
         0
     };
     let bufferSpace =
         (ZSTD_cwksp_alloc_size(buffInSize)).wrapping_add(ZSTD_cwksp_alloc_size(buffOutSize));
     let cctxSpace = if isStatic != 0 {
-        ZSTD_cwksp_alloc_size(::core::mem::size_of::<ZSTD_CCtx>())
+        ZSTD_cwksp_alloc_size(size_of::<ZSTD_CCtx>())
     } else {
         0
     };
     let maxNbExternalSeq = ZSTD_sequenceBound(blockSize);
     let externalSeqSpace = if useSequenceProducer != 0 {
-        ZSTD_cwksp_aligned64_alloc_size(
-            maxNbExternalSeq.wrapping_mul(::core::mem::size_of::<ZSTD_Sequence>()),
-        )
+        ZSTD_cwksp_aligned64_alloc_size(maxNbExternalSeq.wrapping_mul(size_of::<ZSTD_Sequence>()))
     } else {
         0
     };
@@ -3911,13 +3890,10 @@ unsafe fn ZSTD_reset_matchState(
     ms.lazySkipping = 0;
     ZSTD_invalidateMatchState(ms);
     ZSTD_cwksp_clear_tables(ws);
-    ms.hashTable =
-        ZSTD_cwksp_reserve_table(ws, hSize.wrapping_mul(::core::mem::size_of::<u32>())) as *mut u32;
+    ms.hashTable = ZSTD_cwksp_reserve_table(ws, hSize.wrapping_mul(size_of::<u32>())) as *mut u32;
     ms.chainTable =
-        ZSTD_cwksp_reserve_table(ws, chainSize.wrapping_mul(::core::mem::size_of::<u32>()))
-            as *mut u32;
-    ms.hashTable3 = ZSTD_cwksp_reserve_table(ws, h3Size.wrapping_mul(::core::mem::size_of::<u32>()))
-        as *mut u32;
+        ZSTD_cwksp_reserve_table(ws, chainSize.wrapping_mul(size_of::<u32>())) as *mut u32;
+    ms.hashTable3 = ZSTD_cwksp_reserve_table(ws, h3Size.wrapping_mul(size_of::<u32>())) as *mut u32;
     if ZSTD_cwksp_reserve_failed(ws) != 0 {
         return Error::memory_allocation.to_error_code();
     }
@@ -3956,27 +3932,27 @@ unsafe fn ZSTD_reset_matchState(
     {
         ms.opt.litFreq = ZSTD_cwksp_reserve_aligned64(
             ws,
-            (((1) << Litbits) as size_t).wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>()),
+            (((1) << Litbits) as size_t).wrapping_mul(size_of::<core::ffi::c_uint>()),
         ) as *mut core::ffi::c_uint;
         ms.opt.litLengthFreq = ZSTD_cwksp_reserve_aligned64(
             ws,
-            ((MaxLL + 1) as size_t).wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>()),
+            ((MaxLL + 1) as size_t).wrapping_mul(size_of::<core::ffi::c_uint>()),
         ) as *mut core::ffi::c_uint;
         ms.opt.matchLengthFreq = ZSTD_cwksp_reserve_aligned64(
             ws,
-            ((MaxML + 1) as size_t).wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>()),
+            ((MaxML + 1) as size_t).wrapping_mul(size_of::<core::ffi::c_uint>()),
         ) as *mut core::ffi::c_uint;
         ms.opt.offCodeFreq = ZSTD_cwksp_reserve_aligned64(
             ws,
-            ((MaxOff + 1) as size_t).wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>()),
+            ((MaxOff + 1) as size_t).wrapping_mul(size_of::<core::ffi::c_uint>()),
         ) as *mut core::ffi::c_uint;
         ms.opt.matchTable = ZSTD_cwksp_reserve_aligned64(
             ws,
-            (ZSTD_OPT_SIZE as size_t).wrapping_mul(::core::mem::size_of::<ZSTD_match_t>()),
+            (ZSTD_OPT_SIZE as size_t).wrapping_mul(size_of::<ZSTD_match_t>()),
         ) as *mut ZSTD_match_t;
         ms.opt.priceTable = ZSTD_cwksp_reserve_aligned64(
             ws,
-            (ZSTD_OPT_SIZE as size_t).wrapping_mul(::core::mem::size_of::<ZSTD_optimal_t>()),
+            (ZSTD_OPT_SIZE as size_t).wrapping_mul(size_of::<ZSTD_optimal_t>()),
         ) as *mut ZSTD_optimal_t;
     }
     ms.cParams = *cParams;
@@ -4103,13 +4079,13 @@ unsafe fn ZSTD_resetCCtx_internal(
             return err_code_0;
         }
         (*zc).blockState.prevCBlock =
-            ZSTD_cwksp_reserve_object(ws, ::core::mem::size_of::<ZSTD_compressedBlockState_t>())
+            ZSTD_cwksp_reserve_object(ws, size_of::<ZSTD_compressedBlockState_t>())
                 as *mut ZSTD_compressedBlockState_t;
         if ((*zc).blockState.prevCBlock).is_null() {
             return Error::memory_allocation.to_error_code();
         }
         (*zc).blockState.nextCBlock =
-            ZSTD_cwksp_reserve_object(ws, ::core::mem::size_of::<ZSTD_compressedBlockState_t>())
+            ZSTD_cwksp_reserve_object(ws, size_of::<ZSTD_compressedBlockState_t>())
                 as *mut ZSTD_compressedBlockState_t;
         if ((*zc).blockState.nextCBlock).is_null() {
             return Error::memory_allocation.to_error_code();
@@ -4117,12 +4093,12 @@ unsafe fn ZSTD_resetCCtx_internal(
         (*zc).tmpWorkspace = ZSTD_cwksp_reserve_object(
             ws,
             if ((((8) << 10) + 512) as size_t).wrapping_add(
-                (::core::mem::size_of::<core::ffi::c_uint>())
+                (size_of::<core::ffi::c_uint>())
                     .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
             ) > 8208
             {
                 ((((8) << 10) + 512) as size_t).wrapping_add(
-                    (::core::mem::size_of::<core::ffi::c_uint>())
+                    (size_of::<core::ffi::c_uint>())
                         .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
                 )
             } else {
@@ -4133,12 +4109,12 @@ unsafe fn ZSTD_resetCCtx_internal(
             return Error::memory_allocation.to_error_code();
         }
         (*zc).tmpWkspSize = if ((((8) << 10) + 512) as size_t).wrapping_add(
-            (::core::mem::size_of::<core::ffi::c_uint>())
+            (size_of::<core::ffi::c_uint>())
                 .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
         ) > 8208
         {
             ((((8) << 10) + 512) as size_t).wrapping_add(
-                (::core::mem::size_of::<core::ffi::c_uint>())
+                (size_of::<core::ffi::c_uint>())
                     .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
             )
         } else {
@@ -4174,23 +4150,20 @@ unsafe fn ZSTD_resetCCtx_internal(
         return err_code_1;
     }
     (*zc).seqStore.sequencesStart =
-        ZSTD_cwksp_reserve_aligned64(ws, maxNbSeq.wrapping_mul(::core::mem::size_of::<SeqDef>()))
-            as *mut SeqDef;
+        ZSTD_cwksp_reserve_aligned64(ws, maxNbSeq.wrapping_mul(size_of::<SeqDef>())) as *mut SeqDef;
     if (*params).ldmParams.enableLdm == ZSTD_ParamSwitch_e::ZSTD_ps_enable {
         let ldmHSize = (1 as size_t) << (*params).ldmParams.hashLog;
-        (*zc).ldmState.hashTable = ZSTD_cwksp_reserve_aligned64(
-            ws,
-            ldmHSize.wrapping_mul(::core::mem::size_of::<ldmEntry_t>()),
-        ) as *mut ldmEntry_t;
+        (*zc).ldmState.hashTable =
+            ZSTD_cwksp_reserve_aligned64(ws, ldmHSize.wrapping_mul(size_of::<ldmEntry_t>()))
+                as *mut ldmEntry_t;
         ptr::write_bytes(
             (*zc).ldmState.hashTable as *mut u8,
             0,
-            ldmHSize.wrapping_mul(::core::mem::size_of::<ldmEntry_t>()),
+            ldmHSize.wrapping_mul(size_of::<ldmEntry_t>()),
         );
-        (*zc).ldmSequences = ZSTD_cwksp_reserve_aligned64(
-            ws,
-            maxNbLdmSeq.wrapping_mul(::core::mem::size_of::<rawSeq>()),
-        ) as *mut rawSeq;
+        (*zc).ldmSequences =
+            ZSTD_cwksp_reserve_aligned64(ws, maxNbLdmSeq.wrapping_mul(size_of::<rawSeq>()))
+                as *mut rawSeq;
         (*zc).maxNbLdmSequences = maxNbLdmSeq;
         ZSTD_window_init(&mut (*zc).ldmState.window);
         (*zc).ldmState.loadedDictEnd = 0;
@@ -4200,7 +4173,7 @@ unsafe fn ZSTD_resetCCtx_internal(
         (*zc).extSeqBufCapacity = maxNbExternalSeq;
         (*zc).extSeqBuf = ZSTD_cwksp_reserve_aligned64(
             ws,
-            maxNbExternalSeq.wrapping_mul(::core::mem::size_of::<ZSTD_Sequence>()),
+            maxNbExternalSeq.wrapping_mul(size_of::<ZSTD_Sequence>()),
         ) as *mut ZSTD_Sequence;
     }
     (*zc).seqStore.litStart =
@@ -4219,12 +4192,9 @@ unsafe fn ZSTD_resetCCtx_internal(
     }
     ZSTD_referenceExternalSequences(zc, core::ptr::null_mut(), 0);
     (*zc).seqStore.maxNbSeq = maxNbSeq;
-    (*zc).seqStore.llCode =
-        ZSTD_cwksp_reserve_buffer(ws, maxNbSeq.wrapping_mul(::core::mem::size_of::<u8>()));
-    (*zc).seqStore.mlCode =
-        ZSTD_cwksp_reserve_buffer(ws, maxNbSeq.wrapping_mul(::core::mem::size_of::<u8>()));
-    (*zc).seqStore.ofCode =
-        ZSTD_cwksp_reserve_buffer(ws, maxNbSeq.wrapping_mul(::core::mem::size_of::<u8>()));
+    (*zc).seqStore.llCode = ZSTD_cwksp_reserve_buffer(ws, maxNbSeq.wrapping_mul(size_of::<u8>()));
+    (*zc).seqStore.mlCode = ZSTD_cwksp_reserve_buffer(ws, maxNbSeq.wrapping_mul(size_of::<u8>()));
+    (*zc).seqStore.ofCode = ZSTD_cwksp_reserve_buffer(ws, maxNbSeq.wrapping_mul(size_of::<u8>()));
     (*zc).initialized = 1;
     0
 }
@@ -4310,7 +4280,7 @@ unsafe fn ZSTD_resetCCtx_byAttachingCDict(
     libc::memcpy(
         (*cctx).blockState.prevCBlock as *mut core::ffi::c_void,
         &(*cdict).cBlockState as *const ZSTD_compressedBlockState_t as *const core::ffi::c_void,
-        ::core::mem::size_of::<ZSTD_compressedBlockState_t>(),
+        size_of::<ZSTD_compressedBlockState_t>(),
     );
     0
 }
@@ -4333,7 +4303,7 @@ unsafe fn ZSTD_copyCDictTableIntoCCtx(
         libc::memcpy(
             dst as *mut core::ffi::c_void,
             src as *const core::ffi::c_void,
-            tableSize.wrapping_mul(::core::mem::size_of::<u32>()),
+            tableSize.wrapping_mul(size_of::<u32>()),
         );
     }
 }
@@ -4399,7 +4369,7 @@ unsafe fn ZSTD_resetCCtx_byCopyingCDict(
     ptr::write_bytes(
         (*cctx).blockState.matchState.hashTable3 as *mut u8,
         0,
-        h3Size.wrapping_mul(::core::mem::size_of::<u32>()),
+        h3Size.wrapping_mul(size_of::<u32>()),
     );
     ZSTD_cwksp_mark_tables_clean(&mut (*cctx).workspace);
     let srcMatchState: *const ZSTD_MatchState_t = &(*cdict).matchState;
@@ -4412,7 +4382,7 @@ unsafe fn ZSTD_resetCCtx_byCopyingCDict(
     libc::memcpy(
         (*cctx).blockState.prevCBlock as *mut core::ffi::c_void,
         &(*cdict).cBlockState as *const ZSTD_compressedBlockState_t as *const core::ffi::c_void,
-        ::core::mem::size_of::<ZSTD_compressedBlockState_t>(),
+        size_of::<ZSTD_compressedBlockState_t>(),
     );
     0
 }
@@ -4443,7 +4413,7 @@ unsafe fn ZSTD_copyCCtx_internal(
     libc::memcpy(
         &mut (*dstCCtx).customMem as *mut ZSTD_customMem as *mut core::ffi::c_void,
         &(*srcCCtx).customMem as *const ZSTD_customMem as *const core::ffi::c_void,
-        ::core::mem::size_of::<ZSTD_customMem>(),
+        size_of::<ZSTD_customMem>(),
     );
     let mut params = (*dstCCtx).requestedParams;
     params.cParams = (*srcCCtx).appliedParams.cParams;
@@ -4481,17 +4451,17 @@ unsafe fn ZSTD_copyCCtx_internal(
     libc::memcpy(
         (*dstCCtx).blockState.matchState.hashTable as *mut core::ffi::c_void,
         (*srcCCtx).blockState.matchState.hashTable as *const core::ffi::c_void,
-        hSize.wrapping_mul(::core::mem::size_of::<u32>()) as libc::size_t,
+        hSize.wrapping_mul(size_of::<u32>()) as libc::size_t,
     );
     libc::memcpy(
         (*dstCCtx).blockState.matchState.chainTable as *mut core::ffi::c_void,
         (*srcCCtx).blockState.matchState.chainTable as *const core::ffi::c_void,
-        chainSize.wrapping_mul(::core::mem::size_of::<u32>()) as libc::size_t,
+        chainSize.wrapping_mul(size_of::<u32>()) as libc::size_t,
     );
     libc::memcpy(
         (*dstCCtx).blockState.matchState.hashTable3 as *mut core::ffi::c_void,
         (*srcCCtx).blockState.matchState.hashTable3 as *const core::ffi::c_void,
-        h3Size.wrapping_mul(::core::mem::size_of::<u32>()) as libc::size_t,
+        h3Size.wrapping_mul(size_of::<u32>()) as libc::size_t,
     );
     ZSTD_cwksp_mark_tables_clean(&mut (*dstCCtx).workspace);
     let srcMatchState: *const ZSTD_MatchState_t = &(*srcCCtx).blockState.matchState;
@@ -4504,7 +4474,7 @@ unsafe fn ZSTD_copyCCtx_internal(
     libc::memcpy(
         (*dstCCtx).blockState.prevCBlock as *mut core::ffi::c_void,
         (*srcCCtx).blockState.prevCBlock as *const core::ffi::c_void,
-        ::core::mem::size_of::<ZSTD_compressedBlockState_t>() as libc::size_t,
+        size_of::<ZSTD_compressedBlockState_t>() as libc::size_t,
     );
     0
 }
@@ -4705,7 +4675,7 @@ unsafe fn ZSTD_buildSequencesStatistics(
         LL_defaultNormLog,
         MaxLL,
         ((*prevEntropy).litlengthCTable).as_ptr(),
-        ::core::mem::size_of::<[FSE_CTable; 329]>(),
+        size_of::<[FSE_CTable; 329]>(),
         entropyWorkspace,
         entropyWkspSize,
     );
@@ -4759,7 +4729,7 @@ unsafe fn ZSTD_buildSequencesStatistics(
         OF_defaultNormLog,
         DefaultMaxOff,
         ((*prevEntropy).offcodeCTable).as_ptr(),
-        ::core::mem::size_of::<[FSE_CTable; 193]>(),
+        size_of::<[FSE_CTable; 193]>(),
         entropyWorkspace,
         entropyWkspSize,
     );
@@ -4808,7 +4778,7 @@ unsafe fn ZSTD_buildSequencesStatistics(
         ML_defaultNormLog,
         MaxML,
         ((*prevEntropy).matchlengthCTable).as_ptr(),
-        ::core::mem::size_of::<[FSE_CTable; 363]>(),
+        size_of::<[FSE_CTable; 363]>(),
         entropyWorkspace,
         entropyWkspSize,
     );
@@ -4857,7 +4827,7 @@ unsafe fn ZSTD_entropyCompressSeqStore_internal(
         count.offset(((if 35 > 52 { 35 } else { 52 }) + 1) as isize) as *mut core::ffi::c_void;
     entropyWkspSize = (entropyWkspSize as size_t).wrapping_sub(
         ((if 35 > 52 { 35 as size_t } else { 52 }) + 1)
-            .wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>()),
+            .wrapping_mul(size_of::<core::ffi::c_uint>()),
     );
     let numSequences =
         ((*seqStorePtr).sequences).offset_from((*seqStorePtr).sequencesStart) as size_t;
@@ -4906,7 +4876,7 @@ unsafe fn ZSTD_entropyCompressSeqStore_internal(
         libc::memcpy(
             &mut (*nextEntropy).fse as *mut ZSTD_fseCTables_t as *mut core::ffi::c_void,
             &(*prevEntropy).fse as *const ZSTD_fseCTables_t as *const core::ffi::c_void,
-            ::core::mem::size_of::<ZSTD_fseCTables_t>(),
+            size_of::<ZSTD_fseCTables_t>(),
         );
         return op.offset_from_unsigned(ostart);
     }
@@ -5212,7 +5182,7 @@ unsafe fn ZSTD_postProcessSequenceProducerResult(
         ptr::write_bytes(
             &mut *outSeqs as *mut ZSTD_Sequence as *mut u8,
             0,
-            ::core::mem::size_of::<ZSTD_Sequence>(),
+            size_of::<ZSTD_Sequence>(),
         );
         return 1;
     }
@@ -5226,7 +5196,7 @@ unsafe fn ZSTD_postProcessSequenceProducerResult(
     ptr::write_bytes(
         &mut *outSeqs.add(nbExternalSeqs) as *mut ZSTD_Sequence as *mut u8,
         0,
-        ::core::mem::size_of::<ZSTD_Sequence>(),
+        size_of::<ZSTD_Sequence>(),
     );
     nbExternalSeqs.wrapping_add(1)
 }
@@ -5467,7 +5437,7 @@ unsafe fn ZSTD_copyBlockSequences(
     libc::memcpy(
         &mut repcodes as *mut Repcodes_t as *mut core::ffi::c_void,
         prevRepcodes as *const core::ffi::c_void,
-        ::core::mem::size_of::<Repcodes_t>(),
+        size_of::<Repcodes_t>(),
     );
     i = 0;
     while i < nbInSequences {
@@ -5601,7 +5571,7 @@ unsafe fn ZSTD_isRLE(src: *const u8, length: size_t) -> core::ffi::c_int {
     let value = *ip;
     let valueST = (value as u64 as core::ffi::c_ulonglong)
         .wrapping_mul(0x101010101010101 as core::ffi::c_ulonglong) as size_t;
-    let unrollSize = ::core::mem::size_of::<size_t>().wrapping_mul(4);
+    let unrollSize = size_of::<size_t>().wrapping_mul(4);
     let unrollMask = unrollSize.wrapping_sub(1);
     let prefixLength = length & unrollMask;
     let mut i: size_t = 0;
@@ -5621,7 +5591,7 @@ unsafe fn ZSTD_isRLE(src: *const u8, length: size_t) -> core::ffi::c_int {
             if MEM_readST(ip.add(i).add(u) as *const core::ffi::c_void) != valueST {
                 return 0;
             }
-            u = (u as size_t).wrapping_add(::core::mem::size_of::<size_t>());
+            u = (u as size_t).wrapping_add(size_of::<size_t>());
         }
         i = i.wrapping_add(unrollSize);
     }
@@ -5667,8 +5637,8 @@ unsafe fn ZSTD_buildBlockEntropyStats_literals(
     let wkspEnd = wkspStart.add(wkspSize);
     let countWkspStart = wkspStart;
     let countWksp = workspace as *mut core::ffi::c_uint;
-    let countWkspSize = ((HUF_SYMBOLVALUE_MAX + 1) as size_t)
-        .wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>());
+    let countWkspSize =
+        ((HUF_SYMBOLVALUE_MAX + 1) as size_t).wrapping_mul(size_of::<core::ffi::c_uint>());
     let nodeWksp = countWkspStart.add(countWkspSize);
     let nodeWkspSize = wkspEnd.offset_from_unsigned(nodeWksp);
     let mut maxSymbolValue = HUF_SYMBOLVALUE_MAX;
@@ -5677,7 +5647,7 @@ unsafe fn ZSTD_buildBlockEntropyStats_literals(
     libc::memcpy(
         nextHuf as *mut core::ffi::c_void,
         prevHuf as *const core::ffi::c_void,
-        ::core::mem::size_of::<ZSTD_hufCTables_t>(),
+        size_of::<ZSTD_hufCTables_t>(),
     );
     if literalsCompressionIsDisabled != 0 {
         (*hufMetadata).hType = set_basic;
@@ -5722,7 +5692,7 @@ unsafe fn ZSTD_buildBlockEntropyStats_literals(
     ptr::write_bytes(
         ((*nextHuf).CTable).as_mut_ptr() as *mut u8,
         0,
-        ::core::mem::size_of::<[HUF_CElt; 257]>(),
+        size_of::<[HUF_CElt; 257]>(),
     );
     huffLog = HUF_optimalTableLog(
         huffLog,
@@ -5751,7 +5721,7 @@ unsafe fn ZSTD_buildBlockEntropyStats_literals(
         HUF_estimateCompressedSize(((*nextHuf).CTable).as_mut_ptr(), countWksp, maxSymbolValue);
     let hSize = HUF_writeCTable_wksp(
         ((*hufMetadata).hufDesBuffer).as_mut_ptr() as *mut core::ffi::c_void,
-        ::core::mem::size_of::<[u8; 128]>(),
+        size_of::<[u8; 128]>(),
         ((*nextHuf).CTable).as_mut_ptr(),
         maxSymbolValue,
         huffLog,
@@ -5767,7 +5737,7 @@ unsafe fn ZSTD_buildBlockEntropyStats_literals(
             libc::memcpy(
                 nextHuf as *mut core::ffi::c_void,
                 prevHuf as *const core::ffi::c_void,
-                ::core::mem::size_of::<ZSTD_hufCTables_t>(),
+                size_of::<ZSTD_hufCTables_t>(),
             );
             (*hufMetadata).hType = set_repeat;
             return 0;
@@ -5777,7 +5747,7 @@ unsafe fn ZSTD_buildBlockEntropyStats_literals(
         libc::memcpy(
             nextHuf as *mut core::ffi::c_void,
             prevHuf as *const core::ffi::c_void,
-            ::core::mem::size_of::<ZSTD_hufCTables_t>(),
+            size_of::<ZSTD_hufCTables_t>(),
         );
         (*hufMetadata).hType = set_basic;
         return 0;
@@ -5817,13 +5787,13 @@ unsafe fn ZSTD_buildBlockEntropyStats_sequences(
     let strategy = (*cctxParams).cParams.strategy;
     let nbSeq = ((*seqStorePtr).sequences).offset_from((*seqStorePtr).sequencesStart) as size_t;
     let ostart = ((*fseMetadata).fseTablesBuffer).as_mut_ptr();
-    let oend = ostart.add(::core::mem::size_of::<[u8; 133]>());
+    let oend = ostart.add(size_of::<[u8; 133]>());
     let op = ostart;
     let countWorkspace = workspace as *mut core::ffi::c_uint;
     let entropyWorkspace = countWorkspace.offset(((if 35 > 52 { 35 } else { 52 }) + 1) as isize);
     let entropyWorkspaceSize = wkspSize.wrapping_sub(
         ((if 35 > 52 { 35 as size_t } else { 52 }) + 1)
-            .wrapping_mul(::core::mem::size_of::<core::ffi::c_uint>()),
+            .wrapping_mul(size_of::<core::ffi::c_uint>()),
     );
     let mut stats = ZSTD_symbolEncodingTypeStats_t {
         LLtype: 0,
@@ -6444,17 +6414,17 @@ unsafe fn ZSTD_compressBlock_splitBlock_internal(
     libc::memcpy(
         (dRep.rep).as_mut_ptr() as *mut core::ffi::c_void,
         ((*(*zc).blockState.prevCBlock).rep).as_mut_ptr() as *const core::ffi::c_void,
-        ::core::mem::size_of::<Repcodes_t>(),
+        size_of::<Repcodes_t>(),
     );
     libc::memcpy(
         (cRep.rep).as_mut_ptr() as *mut core::ffi::c_void,
         ((*(*zc).blockState.prevCBlock).rep).as_mut_ptr() as *const core::ffi::c_void,
-        ::core::mem::size_of::<Repcodes_t>(),
+        size_of::<Repcodes_t>(),
     );
     ptr::write_bytes(
         nextSeqStore as *mut SeqStore_t as *mut u8,
         0,
-        ::core::mem::size_of::<SeqStore_t>(),
+        size_of::<SeqStore_t>(),
     );
     if numSplits == 0 {
         let cSizeSingleBlock = ZSTD_compressSeqStore_singleBlock(
@@ -6521,7 +6491,7 @@ unsafe fn ZSTD_compressBlock_splitBlock_internal(
     libc::memcpy(
         ((*(*zc).blockState.prevCBlock).rep).as_mut_ptr() as *mut core::ffi::c_void,
         (dRep.rep).as_mut_ptr() as *const core::ffi::c_void,
-        ::core::mem::size_of::<Repcodes_t>(),
+        size_of::<Repcodes_t>(),
     );
     cSize
 }
@@ -8507,7 +8477,7 @@ pub unsafe extern "C" fn ZSTD_estimateCDictSize_advanced(
     cParams: ZSTD_compressionParameters,
     dictLoadMethod: ZSTD_dictLoadMethod_e,
 ) -> size_t {
-    (ZSTD_cwksp_alloc_size(::core::mem::size_of::<ZSTD_CDict>()))
+    (ZSTD_cwksp_alloc_size(size_of::<ZSTD_CDict>()))
         .wrapping_add(ZSTD_cwksp_alloc_size(HUF_WORKSPACE_SIZE))
         .wrapping_add(ZSTD_sizeof_matchState(
             &cParams,
@@ -8523,7 +8493,7 @@ pub unsafe extern "C" fn ZSTD_estimateCDictSize_advanced(
             } else {
                 ZSTD_cwksp_alloc_size(ZSTD_cwksp_align(
                     dictSize,
-                    ::core::mem::size_of::<*mut core::ffi::c_void>(),
+                    size_of::<*mut core::ffi::c_void>(),
                 ))
             },
         )
@@ -8549,7 +8519,7 @@ pub unsafe extern "C" fn ZSTD_sizeof_CDict(cdict: *const ZSTD_CDict) -> size_t {
     (if (*cdict).workspace.workspace == cdict as *mut core::ffi::c_void {
         0
     } else {
-        ::core::mem::size_of::<ZSTD_CDict>()
+        size_of::<ZSTD_CDict>()
     })
     .wrapping_add(ZSTD_cwksp_sizeof(&(*cdict).workspace))
 }
@@ -8572,7 +8542,7 @@ unsafe fn ZSTD_initCDict_internal(
     } else {
         let internalBuffer = ZSTD_cwksp_reserve_object(
             &mut (*cdict).workspace,
-            ZSTD_cwksp_align(dictSize, ::core::mem::size_of::<*mut core::ffi::c_void>()),
+            ZSTD_cwksp_align(dictSize, size_of::<*mut core::ffi::c_void>()),
         );
         if internalBuffer.is_null() {
             return Error::memory_allocation.to_error_code();
@@ -8627,7 +8597,7 @@ unsafe fn ZSTD_createCDict_advanced_internal(
     enableDedicatedDictSearch: core::ffi::c_int,
     customMem: ZSTD_customMem,
 ) -> *mut ZSTD_CDict {
-    let workspaceSize = (ZSTD_cwksp_alloc_size(::core::mem::size_of::<ZSTD_CDict>()))
+    let workspaceSize = (ZSTD_cwksp_alloc_size(size_of::<ZSTD_CDict>()))
         .wrapping_add(ZSTD_cwksp_alloc_size(HUF_WORKSPACE_SIZE))
         .wrapping_add(ZSTD_sizeof_matchState(
             &cParams,
@@ -8640,7 +8610,7 @@ unsafe fn ZSTD_createCDict_advanced_internal(
         } else {
             ZSTD_cwksp_alloc_size(ZSTD_cwksp_align(
                 dictSize,
-                ::core::mem::size_of::<*mut core::ffi::c_void>(),
+                size_of::<*mut core::ffi::c_void>(),
             ))
         });
     let workspace = ZSTD_customMalloc(workspaceSize, customMem);
@@ -8661,8 +8631,7 @@ unsafe fn ZSTD_createCDict_advanced_internal(
         return core::ptr::null_mut();
     }
     ZSTD_cwksp_init(&mut ws, workspace, workspaceSize, ZSTD_cwksp_dynamic_alloc);
-    let cdict =
-        ZSTD_cwksp_reserve_object(&mut ws, ::core::mem::size_of::<ZSTD_CDict>()) as *mut ZSTD_CDict;
+    let cdict = ZSTD_cwksp_reserve_object(&mut ws, size_of::<ZSTD_CDict>()) as *mut ZSTD_CDict;
     ZSTD_cwksp_move(&mut (*cdict).workspace, &mut ws);
     (*cdict).customMem = customMem;
     (*cdict).compressionLevel = ZSTD_NO_CLEVEL;
@@ -8732,7 +8701,7 @@ pub unsafe extern "C" fn ZSTD_createCDict_advanced(
     ptr::write_bytes(
         &mut cctxParams as *mut ZSTD_CCtx_params as *mut u8,
         0,
-        ::core::mem::size_of::<ZSTD_CCtx_params>(),
+        size_of::<ZSTD_CCtx_params>(),
     );
     ZSTD_CCtxParams_init(&mut cctxParams, 0);
     cctxParams.cParams = cParams;
@@ -8900,13 +8869,13 @@ pub unsafe extern "C" fn ZSTD_initStaticCDict(
     let useRowMatchFinder =
         ZSTD_resolveRowMatchFinderMode(ZSTD_ParamSwitch_e::ZSTD_ps_auto, &cParams);
     let matchStateSize = ZSTD_sizeof_matchState(&cParams, useRowMatchFinder, 1, 0);
-    let neededSize = (ZSTD_cwksp_alloc_size(::core::mem::size_of::<ZSTD_CDict>()))
+    let neededSize = (ZSTD_cwksp_alloc_size(size_of::<ZSTD_CDict>()))
         .wrapping_add(if dictLoadMethod == ZSTD_dlm_byRef {
             0
         } else {
             ZSTD_cwksp_alloc_size(ZSTD_cwksp_align(
                 dictSize,
-                ::core::mem::size_of::<*mut core::ffi::c_void>(),
+                size_of::<*mut core::ffi::c_void>(),
             ))
         })
         .wrapping_add(ZSTD_cwksp_alloc_size(HUF_WORKSPACE_SIZE))
@@ -8980,8 +8949,7 @@ pub unsafe extern "C" fn ZSTD_initStaticCDict(
         isStatic: ZSTD_cwksp_dynamic_alloc,
     };
     ZSTD_cwksp_init(&mut ws, workspace, workspaceSize, ZSTD_cwksp_static_alloc);
-    cdict =
-        ZSTD_cwksp_reserve_object(&mut ws, ::core::mem::size_of::<ZSTD_CDict>()) as *mut ZSTD_CDict;
+    cdict = ZSTD_cwksp_reserve_object(&mut ws, size_of::<ZSTD_CDict>()) as *mut ZSTD_CDict;
     if cdict.is_null() {
         return core::ptr::null();
     }
@@ -9834,7 +9802,7 @@ unsafe fn ZSTD_CCtx_init_compressStream2(
     ptr::write_bytes(
         &mut (*cctx).prefixDict as *mut ZSTD_prefixDict as *mut u8,
         0,
-        ::core::mem::size_of::<ZSTD_prefixDict>(),
+        size_of::<ZSTD_prefixDict>(),
     );
     if !((*cctx).cdict).is_null() && ((*cctx).localDict.cdict).is_null() {
         params.compressionLevel = (*(*cctx).cdict).compressionLevel;
@@ -10196,7 +10164,7 @@ unsafe fn ZSTD_transferSequences_wBlockDelim(
     libc::memcpy(
         (updatedRepcodes.rep).as_mut_ptr() as *mut core::ffi::c_void,
         ((*(*cctx).blockState.prevCBlock).rep).as_mut_ptr() as *const core::ffi::c_void,
-        ::core::mem::size_of::<Repcodes_t>(),
+        size_of::<Repcodes_t>(),
     );
     while (idx as size_t) < inSeqsSize
         && ((*inSeqs.offset(idx as isize)).matchLength != 0
@@ -10270,7 +10238,7 @@ unsafe fn ZSTD_transferSequences_wBlockDelim(
     libc::memcpy(
         ((*(*cctx).blockState.nextCBlock).rep).as_mut_ptr() as *mut core::ffi::c_void,
         (updatedRepcodes.rep).as_mut_ptr() as *const core::ffi::c_void,
-        ::core::mem::size_of::<Repcodes_t>(),
+        size_of::<Repcodes_t>(),
     );
     if (*inSeqs.offset(idx as isize)).litLength != 0 {
         ZSTD_storeLastLiterals(
@@ -10321,7 +10289,7 @@ unsafe fn ZSTD_transferSequences_noDelim(
     libc::memcpy(
         (updatedRepcodes.rep).as_mut_ptr() as *mut core::ffi::c_void,
         ((*(*cctx).blockState.prevCBlock).rep).as_mut_ptr() as *const core::ffi::c_void,
-        ::core::mem::size_of::<Repcodes_t>(),
+        size_of::<Repcodes_t>(),
     );
     while endPosInSequence != 0 && (idx as size_t) < inSeqsSize && finalMatchSplit == 0 {
         let currSeq = *inSeqs.offset(idx as isize);
@@ -10420,7 +10388,7 @@ unsafe fn ZSTD_transferSequences_noDelim(
     libc::memcpy(
         ((*(*cctx).blockState.nextCBlock).rep).as_mut_ptr() as *mut core::ffi::c_void,
         (updatedRepcodes.rep).as_mut_ptr() as *const core::ffi::c_void,
-        ::core::mem::size_of::<Repcodes_t>(),
+        size_of::<Repcodes_t>(),
     );
     iend = iend.offset(-(bytesAdjustment as isize));
     if ip != iend {
@@ -10781,7 +10749,7 @@ pub unsafe fn ZSTD_convertBlockSequences(
     libc::memcpy(
         (updatedRepcodes.rep).as_mut_ptr() as *mut core::ffi::c_void,
         ((*(*cctx).blockState.prevCBlock).rep).as_mut_ptr() as *const core::ffi::c_void,
-        ::core::mem::size_of::<Repcodes_t>(),
+        size_of::<Repcodes_t>(),
     );
     if repcodeResolution == 0 {
         let longl = convertSequences_noRepcodes(
@@ -10842,7 +10810,7 @@ pub unsafe fn ZSTD_convertBlockSequences(
     libc::memcpy(
         ((*(*cctx).blockState.nextCBlock).rep).as_mut_ptr() as *mut core::ffi::c_void,
         (updatedRepcodes.rep).as_mut_ptr() as *const core::ffi::c_void,
-        ::core::mem::size_of::<Repcodes_t>(),
+        size_of::<Repcodes_t>(),
     );
     0
 }
@@ -12372,7 +12340,7 @@ unsafe fn ZSTD_getParams_internal(
     ptr::write_bytes(
         &mut params as *mut ZSTD_parameters as *mut u8,
         0,
-        ::core::mem::size_of::<ZSTD_parameters>(),
+        size_of::<ZSTD_parameters>(),
     );
     params.cParams = cParams;
     params.fParams.contentSizeFlag = 1;

--- a/lib/compress/zstd_compress.rs
+++ b/lib/compress/zstd_compress.rs
@@ -1635,12 +1635,12 @@ pub unsafe extern "C" fn ZSTD_initStaticCCtx(
     if ZSTD_cwksp_check_available(
         &mut (*cctx).workspace,
         (if ((((8) << 10) + 512) as size_t).wrapping_add(
-            (size_of::<core::ffi::c_uint>())
+            size_of::<core::ffi::c_uint>()
                 .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
         ) > 8208
         {
             ((((8) << 10) + 512) as size_t).wrapping_add(
-                (size_of::<core::ffi::c_uint>())
+                size_of::<core::ffi::c_uint>()
                     .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
             )
         } else {
@@ -1662,12 +1662,12 @@ pub unsafe extern "C" fn ZSTD_initStaticCCtx(
     (*cctx).tmpWorkspace = ZSTD_cwksp_reserve_object(
         &mut (*cctx).workspace,
         if ((((8) << 10) + 512) as size_t).wrapping_add(
-            (size_of::<core::ffi::c_uint>())
+            size_of::<core::ffi::c_uint>()
                 .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
         ) > 8208
         {
             ((((8) << 10) + 512) as size_t).wrapping_add(
-                (size_of::<core::ffi::c_uint>())
+                size_of::<core::ffi::c_uint>()
                     .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
             )
         } else {
@@ -1675,12 +1675,12 @@ pub unsafe extern "C" fn ZSTD_initStaticCCtx(
         },
     );
     (*cctx).tmpWkspSize = if ((((8) << 10) + 512) as size_t).wrapping_add(
-        (size_of::<core::ffi::c_uint>())
+        size_of::<core::ffi::c_uint>()
             .wrapping_mul(((if 35 > 52 as core::ffi::c_int { 35 } else { 52 }) + 2) as size_t),
     ) > 8208 as size_t
     {
         ((((8) << 10) + 512) as size_t).wrapping_add(
-            (size_of::<core::ffi::c_uint>())
+            size_of::<core::ffi::c_uint>()
                 .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
         )
     } else {
@@ -3539,12 +3539,12 @@ unsafe fn ZSTD_estimateCCtxSize_usingCCtxParams_internal(
         .wrapping_add(3 * ZSTD_cwksp_alloc_size(maxNbSeq.wrapping_mul(size_of::<u8>())));
     let tmpWorkSpace = ZSTD_cwksp_alloc_size(
         if ((((8) << 10) + 512) as size_t).wrapping_add(
-            (size_of::<core::ffi::c_uint>())
+            size_of::<core::ffi::c_uint>()
                 .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
         ) > 8208
         {
             ((((8) << 10) + 512) as size_t).wrapping_add(
-                (size_of::<core::ffi::c_uint>())
+                size_of::<core::ffi::c_uint>()
                     .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
             )
         } else {
@@ -4093,12 +4093,12 @@ unsafe fn ZSTD_resetCCtx_internal(
         (*zc).tmpWorkspace = ZSTD_cwksp_reserve_object(
             ws,
             if ((((8) << 10) + 512) as size_t).wrapping_add(
-                (size_of::<core::ffi::c_uint>())
+                size_of::<core::ffi::c_uint>()
                     .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
             ) > 8208
             {
                 ((((8) << 10) + 512) as size_t).wrapping_add(
-                    (size_of::<core::ffi::c_uint>())
+                    size_of::<core::ffi::c_uint>()
                         .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
                 )
             } else {
@@ -4109,12 +4109,12 @@ unsafe fn ZSTD_resetCCtx_internal(
             return Error::memory_allocation.to_error_code();
         }
         (*zc).tmpWkspSize = if ((((8) << 10) + 512) as size_t).wrapping_add(
-            (size_of::<core::ffi::c_uint>())
+            size_of::<core::ffi::c_uint>()
                 .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
         ) > 8208
         {
             ((((8) << 10) + 512) as size_t).wrapping_add(
-                (size_of::<core::ffi::c_uint>())
+                size_of::<core::ffi::c_uint>()
                     .wrapping_mul(((if 35 > 52 { 35 } else { 52 }) + 2) as size_t),
             )
         } else {

--- a/lib/compress/zstd_compress_internal.rs
+++ b/lib/compress/zstd_compress_internal.rs
@@ -161,22 +161,21 @@ pub(crate) unsafe fn ZSTD_count(
     pInLimit: *const u8,
 ) -> usize {
     let pStart = pIn;
-    let pInLoopLimit =
-        pInLimit.offset(-((::core::mem::size_of::<usize>()).wrapping_sub(1) as isize));
+    let pInLoopLimit = pInLimit.offset(-((size_of::<usize>()).wrapping_sub(1) as isize));
     if pIn < pInLoopLimit {
         let diff = MEM_readST(pMatch as *const core::ffi::c_void)
             ^ MEM_readST(pIn as *const core::ffi::c_void);
         if diff != 0 {
             return ZSTD_NbCommonBytes(diff) as usize;
         }
-        pIn = pIn.add(::core::mem::size_of::<usize>());
-        pMatch = pMatch.add(::core::mem::size_of::<usize>());
+        pIn = pIn.add(size_of::<usize>());
+        pMatch = pMatch.add(size_of::<usize>());
         while pIn < pInLoopLimit {
             let diff_0 = MEM_readST(pMatch as *const core::ffi::c_void)
                 ^ MEM_readST(pIn as *const core::ffi::c_void);
             if diff_0 == 0 {
-                pIn = pIn.add(::core::mem::size_of::<usize>());
-                pMatch = pMatch.add(::core::mem::size_of::<usize>());
+                pIn = pIn.add(size_of::<usize>());
+                pMatch = pMatch.add(size_of::<usize>());
             } else {
                 pIn = pIn.offset(ZSTD_NbCommonBytes(diff_0) as isize);
                 return pIn.offset_from_unsigned(pStart);

--- a/lib/compress/zstd_compress_internal.rs
+++ b/lib/compress/zstd_compress_internal.rs
@@ -161,7 +161,7 @@ pub(crate) unsafe fn ZSTD_count(
     pInLimit: *const u8,
 ) -> usize {
     let pStart = pIn;
-    let pInLoopLimit = pInLimit.offset(-((size_of::<usize>()).wrapping_sub(1) as isize));
+    let pInLoopLimit = pInLimit.offset(-(size_of::<usize>().wrapping_sub(1) as isize));
     if pIn < pInLoopLimit {
         let diff = MEM_readST(pMatch as *const core::ffi::c_void)
             ^ MEM_readST(pIn as *const core::ffi::c_void);

--- a/lib/compress/zstd_compress_literals.rs
+++ b/lib/compress/zstd_compress_literals.rs
@@ -171,7 +171,7 @@ pub unsafe fn ZSTD_compressLiterals(
     libc::memcpy(
         nextHuf as *mut core::ffi::c_void,
         prevHuf as *const core::ffi::c_void,
-        ::core::mem::size_of::<ZSTD_hufCTables_t>() as core::ffi::c_ulong as libc::size_t,
+        size_of::<ZSTD_hufCTables_t>() as core::ffi::c_ulong as libc::size_t,
     );
     if disableLiteralCompression != 0 {
         return ZSTD_noCompressLiterals(dst, dstCapacity, src, srcSize);
@@ -266,7 +266,7 @@ pub unsafe fn ZSTD_compressLiterals(
         libc::memcpy(
             nextHuf as *mut core::ffi::c_void,
             prevHuf as *const core::ffi::c_void,
-            ::core::mem::size_of::<ZSTD_hufCTables_t>() as core::ffi::c_ulong as libc::size_t,
+            size_of::<ZSTD_hufCTables_t>() as core::ffi::c_ulong as libc::size_t,
         );
         return ZSTD_noCompressLiterals(dst, dstCapacity, src, srcSize);
     }
@@ -274,7 +274,7 @@ pub unsafe fn ZSTD_compressLiterals(
         libc::memcpy(
             nextHuf as *mut core::ffi::c_void,
             prevHuf as *const core::ffi::c_void,
-            ::core::mem::size_of::<ZSTD_hufCTables_t>() as core::ffi::c_ulong as libc::size_t,
+            size_of::<ZSTD_hufCTables_t>() as core::ffi::c_ulong as libc::size_t,
         );
         return ZSTD_compressRleLiteralsBlock(dst, dstCapacity, src, srcSize);
     }

--- a/lib/compress/zstd_compress_sequences.rs
+++ b/lib/compress/zstd_compress_sequences.rs
@@ -78,7 +78,7 @@ unsafe fn ZSTD_NCountCost(
     }
     FSE_writeNCount(
         wksp.as_mut_ptr() as *mut core::ffi::c_void,
-        ::core::mem::size_of::<[u8; 512]>(),
+        size_of::<[u8; 512]>(),
         norm.as_mut_ptr(),
         max,
         tableLog,
@@ -328,7 +328,7 @@ pub unsafe fn ZSTD_buildCTable(
                 max,
                 tableLog,
                 ((*wksp).wksp).as_mut_ptr() as *mut core::ffi::c_void,
-                ::core::mem::size_of::<[u32; 285]>(),
+                size_of::<[u32; 285]>(),
             );
             if ERR_isError(err_code_3) {
                 return err_code_3;

--- a/lib/compress/zstd_compress_superblock.rs
+++ b/lib/compress/zstd_compress_superblock.rs
@@ -1080,7 +1080,7 @@ unsafe fn ZSTD_compressSubBlock_multi(
         libc::memcpy(
             &mut (*nextCBlock).entropy.huf as *mut ZSTD_hufCTables_t as *mut core::ffi::c_void,
             &(*prevCBlock).entropy.huf as *const ZSTD_hufCTables_t as *const core::ffi::c_void,
-            ::core::mem::size_of::<ZSTD_hufCTables_t>() as core::ffi::c_ulong as libc::size_t,
+            size_of::<ZSTD_hufCTables_t>() as core::ffi::c_ulong as libc::size_t,
         );
     }
     if writeSeqEntropy != 0 && ZSTD_needSequenceEntropyTables(&(*entropyMetadata).fseMetadata) != 0
@@ -1107,7 +1107,7 @@ unsafe fn ZSTD_compressSubBlock_multi(
             libc::memcpy(
                 &mut rep as *mut Repcodes_t as *mut core::ffi::c_void,
                 ((*prevCBlock).rep).as_ptr() as *const core::ffi::c_void,
-                ::core::mem::size_of::<Repcodes_t>() as core::ffi::c_ulong as libc::size_t,
+                size_of::<Repcodes_t>() as core::ffi::c_ulong as libc::size_t,
             );
             seq = sstart;
             while seq < sp {
@@ -1122,7 +1122,7 @@ unsafe fn ZSTD_compressSubBlock_multi(
             libc::memcpy(
                 ((*nextCBlock).rep).as_mut_ptr() as *mut core::ffi::c_void,
                 &mut rep as *mut Repcodes_t as *const core::ffi::c_void,
-                ::core::mem::size_of::<Repcodes_t>() as core::ffi::c_ulong as libc::size_t,
+                size_of::<Repcodes_t>() as core::ffi::c_ulong as libc::size_t,
             );
         }
     }

--- a/lib/compress/zstd_double_fast.rs
+++ b/lib/compress/zstd_double_fast.rs
@@ -521,9 +521,9 @@ unsafe fn ZSTD_compressBlock_doubleFast_dictMatchState_generic(
         + dictEnd.offset_from(dictStart) as core::ffi::c_long) as u32;
     if ms.prefetchCDictTables != 0 {
         let hashTableBytes =
-            ((1 as size_t) << (*dictCParams).hashLog).wrapping_mul(::core::mem::size_of::<u32>());
+            ((1 as size_t) << (*dictCParams).hashLog).wrapping_mul(size_of::<u32>());
         let chainTableBytes =
-            ((1 as size_t) << (*dictCParams).chainLog).wrapping_mul(::core::mem::size_of::<u32>());
+            ((1 as size_t) << (*dictCParams).chainLog).wrapping_mul(size_of::<u32>());
         let _ptr = dictHashLong as *const core::ffi::c_char;
         let _size = hashTableBytes;
         let mut _pos: size_t = 0;

--- a/lib/compress/zstd_fast.rs
+++ b/lib/compress/zstd_fast.rs
@@ -585,7 +585,7 @@ unsafe fn ZSTD_compressBlock_fast_dictMatchState_generic(
 
     if ms.prefetchCDictTables != 0 {
         let hashTableBytes = ((1 as core::ffi::c_int as size_t) << (*dictCParams).hashLog)
-            .wrapping_mul(::core::mem::size_of::<u32>());
+            .wrapping_mul(size_of::<u32>());
         let _ptr = dictHashTable as *const core::ffi::c_char;
         let _size = hashTableBytes;
         let mut _pos: size_t = 0;

--- a/lib/compress/zstd_ldm.rs
+++ b/lib/compress/zstd_ldm.rs
@@ -670,13 +670,13 @@ pub unsafe fn ZSTD_ldm_adjustParameters(
     if (*params).hashLog == 0 {
         (*params).hashLog = if 6
             > (if ((*params).windowLog).wrapping_sub((*params).hashRateLog)
-                < (if (if ::core::mem::size_of::<size_t>() as core::ffi::c_ulong == 4 {
+                < (if (if size_of::<size_t>() as core::ffi::c_ulong == 4 {
                     30
                 } else {
                     31
                 }) < 30
                 {
-                    if ::core::mem::size_of::<size_t>() as core::ffi::c_ulong == 4 {
+                    if size_of::<size_t>() as core::ffi::c_ulong == 4 {
                         30
                     } else {
                         31
@@ -687,13 +687,13 @@ pub unsafe fn ZSTD_ldm_adjustParameters(
             {
                 ((*params).windowLog).wrapping_sub((*params).hashRateLog)
             } else {
-                (if (if ::core::mem::size_of::<size_t>() as core::ffi::c_ulong == 4 {
+                (if (if size_of::<size_t>() as core::ffi::c_ulong == 4 {
                     30
                 } else {
                     31
                 }) < 30
                 {
-                    if ::core::mem::size_of::<size_t>() as core::ffi::c_ulong == 4 {
+                    if size_of::<size_t>() as core::ffi::c_ulong == 4 {
                         30
                     } else {
                         31
@@ -704,13 +704,13 @@ pub unsafe fn ZSTD_ldm_adjustParameters(
             }) {
             6
         } else if ((*params).windowLog).wrapping_sub((*params).hashRateLog)
-            < (if (if ::core::mem::size_of::<size_t>() as core::ffi::c_ulong == 4 {
+            < (if (if size_of::<size_t>() as core::ffi::c_ulong == 4 {
                 30
             } else {
                 31
             }) < 30
             {
-                if ::core::mem::size_of::<size_t>() as core::ffi::c_ulong == 4 {
+                if size_of::<size_t>() as core::ffi::c_ulong == 4 {
                     30
                 } else {
                     31
@@ -721,13 +721,13 @@ pub unsafe fn ZSTD_ldm_adjustParameters(
         {
             ((*params).windowLog).wrapping_sub((*params).hashRateLog)
         } else {
-            (if (if ::core::mem::size_of::<size_t>() as core::ffi::c_ulong == 4 {
+            (if (if size_of::<size_t>() as core::ffi::c_ulong == 4 {
                 30
             } else {
                 31
             }) < 30
             {
-                if ::core::mem::size_of::<size_t>() as core::ffi::c_ulong == 4 {
+                if size_of::<size_t>() as core::ffi::c_ulong == 4 {
                     30
                 } else {
                     31
@@ -774,7 +774,7 @@ pub unsafe fn ZSTD_ldm_getTableSize(params: ldmParams_t) -> size_t {
     }) as size_t;
     let ldmBucketSize = (1) << (params.hashLog as size_t).wrapping_sub(ldmBucketSizeLog);
     let totalSize = (ZSTD_cwksp_alloc_size(ldmBucketSize)).wrapping_add(ZSTD_cwksp_alloc_size(
-        ldmHSize.wrapping_mul(::core::mem::size_of::<ldmEntry_t>()),
+        ldmHSize.wrapping_mul(size_of::<ldmEntry_t>()),
     ));
     if params.enableLdm == ZSTD_ParamSwitch_e::ZSTD_ps_enable {
         totalSize

--- a/lib/compress/zstd_opt.rs
+++ b/lib/compress/zstd_opt.rs
@@ -119,7 +119,7 @@ unsafe fn ZSTD_newRep(rep: *const u32, offBase: u32, ll0: u32) -> Repcodes_t {
     libc::memcpy(
         &mut newReps as *mut Repcodes_t as *mut core::ffi::c_void,
         rep as *const core::ffi::c_void,
-        ::core::mem::size_of::<Repcodes_t>() as core::ffi::c_ulong as libc::size_t,
+        size_of::<Repcodes_t>() as core::ffi::c_ulong as libc::size_t,
     );
     ZSTD_updateRep((newReps.rep).as_mut_ptr(), offBase, ll0);
     newReps
@@ -359,8 +359,7 @@ unsafe fn ZSTD_rescaleFreqs(
             libc::memcpy(
                 (*optPtr).litLengthFreq as *mut core::ffi::c_void,
                 baseLLfreqs.as_ptr() as *const core::ffi::c_void,
-                ::core::mem::size_of::<[core::ffi::c_uint; 36]>() as core::ffi::c_ulong
-                    as libc::size_t,
+                size_of::<[core::ffi::c_uint; 36]>() as core::ffi::c_ulong as libc::size_t,
             );
             (*optPtr).litLengthSum = sum_u32(baseLLfreqs.as_ptr(), (MaxLL + 1) as size_t);
             let mut ml_0: core::ffi::c_uint = 0;
@@ -377,8 +376,7 @@ unsafe fn ZSTD_rescaleFreqs(
             libc::memcpy(
                 (*optPtr).offCodeFreq as *mut core::ffi::c_void,
                 baseOFCfreqs.as_ptr() as *const core::ffi::c_void,
-                ::core::mem::size_of::<[core::ffi::c_uint; 32]>() as core::ffi::c_ulong
-                    as libc::size_t,
+                size_of::<[core::ffi::c_uint; 32]>() as core::ffi::c_ulong as libc::size_t,
             );
             (*optPtr).offCodeSum = sum_u32(baseOFCfreqs.as_ptr(), (MaxOff + 1) as size_t);
         }
@@ -1765,7 +1763,7 @@ unsafe fn ZSTD_compressBlock_opt_generic(
     ptr::write_bytes(
         &mut lastStretch as *mut ZSTD_optimal_t as *mut u8,
         0,
-        ::core::mem::size_of::<ZSTD_optimal_t>(),
+        size_of::<ZSTD_optimal_t>(),
     );
     optLdm.seqStore = if !(ms.ldmSeqStore).is_null() {
         *ms.ldmSeqStore
@@ -1814,7 +1812,7 @@ unsafe fn ZSTD_compressBlock_opt_generic(
             libc::memcpy(
                 &mut (*opt).rep as *mut [u32; 3] as *mut core::ffi::c_void,
                 rep as *const core::ffi::c_void,
-                ::core::mem::size_of::<[u32; 3]>() as core::ffi::c_ulong as libc::size_t,
+                size_of::<[u32; 3]>() as core::ffi::c_ulong as libc::size_t,
             );
             let maxML = (*matches.offset(nbMatches.wrapping_sub(1) as isize)).len;
             let maxOffBase = (*matches.offset(nbMatches.wrapping_sub(1) as isize)).off;
@@ -1931,8 +1929,7 @@ unsafe fn ZSTD_compressBlock_opt_generic(
                                     ((*opt.offset(cur.wrapping_add(1) as isize)).rep).as_mut_ptr()
                                         as *mut core::ffi::c_void,
                                     &newReps as *const Repcodes_t as *const core::ffi::c_void,
-                                    ::core::mem::size_of::<Repcodes_t>() as core::ffi::c_ulong
-                                        as libc::size_t,
+                                    size_of::<Repcodes_t>() as core::ffi::c_ulong as libc::size_t,
                                 );
                                 (*opt.offset(cur.wrapping_add(1) as isize)).litlen = 1;
                                 (*opt.offset(cur.wrapping_add(1) as isize)).price = with1literal;
@@ -1953,8 +1950,7 @@ unsafe fn ZSTD_compressBlock_opt_generic(
                             ((*opt.offset(cur as isize)).rep).as_mut_ptr()
                                 as *mut core::ffi::c_void,
                             &newReps_0 as *const Repcodes_t as *const core::ffi::c_void,
-                            ::core::mem::size_of::<Repcodes_t>() as core::ffi::c_ulong
-                                as libc::size_t,
+                            size_of::<Repcodes_t>() as core::ffi::c_ulong as libc::size_t,
                         );
                     }
                     if inr <= ilimit {
@@ -2077,13 +2073,13 @@ unsafe fn ZSTD_compressBlock_opt_generic(
                     libc::memcpy(
                         rep as *mut core::ffi::c_void,
                         &reps as *const Repcodes_t as *const core::ffi::c_void,
-                        ::core::mem::size_of::<Repcodes_t>() as core::ffi::c_ulong as libc::size_t,
+                        size_of::<Repcodes_t>() as core::ffi::c_ulong as libc::size_t,
                     );
                 } else {
                     libc::memcpy(
                         rep as *mut core::ffi::c_void,
                         (lastStretch.rep).as_mut_ptr() as *const core::ffi::c_void,
-                        ::core::mem::size_of::<Repcodes_t>() as core::ffi::c_ulong as libc::size_t,
+                        size_of::<Repcodes_t>() as core::ffi::c_ulong as libc::size_t,
                     );
                     cur = cur.wrapping_sub(lastStretch.litlen);
                 }
@@ -2179,7 +2175,7 @@ unsafe fn ZSTD_initStats_ultra(
     libc::memcpy(
         tmpRep.as_mut_ptr() as *mut core::ffi::c_void,
         rep as *const core::ffi::c_void,
-        ::core::mem::size_of::<[u32; 3]>() as core::ffi::c_ulong as libc::size_t,
+        size_of::<[u32; 3]>() as core::ffi::c_ulong as libc::size_t,
     );
     ZSTD_compressBlock_opt2(ms, seqStore, tmpRep.as_mut_ptr(), src, srcSize, ZSTD_noDict);
     ZSTD_resetSeqStore(seqStore);

--- a/lib/compress/zstdmt_compress.rs
+++ b/lib/compress/zstdmt_compress.rs
@@ -222,11 +222,7 @@ unsafe fn ZSTD_window_clear(window: *mut ZSTD_window_t) {
 }
 #[inline]
 unsafe fn ZSTD_window_init(window: *mut ZSTD_window_t) {
-    ptr::write_bytes(
-        window as *mut u8,
-        0,
-        ::core::mem::size_of::<ZSTD_window_t>(),
-    );
+    ptr::write_bytes(window as *mut u8, 0, size_of::<ZSTD_window_t>());
     (*window).base = b" \0" as *const u8 as *const core::ffi::c_char as *const u8;
     (*window).dictBase = b" \0" as *const u8 as *const core::ffi::c_char as *const u8;
     (*window).dictLimit = ZSTD_WINDOW_START_INDEX as u32;
@@ -311,8 +307,7 @@ unsafe fn ZSTDMT_createBufferPool(
     maxNbBuffers: core::ffi::c_uint,
     cMem: ZSTD_customMem,
 ) -> *mut ZSTDMT_bufferPool {
-    let bufPool = ZSTD_customCalloc(::core::mem::size_of::<ZSTDMT_bufferPool>(), cMem)
-        as *mut ZSTDMT_bufferPool;
+    let bufPool = ZSTD_customCalloc(size_of::<ZSTDMT_bufferPool>(), cMem) as *mut ZSTDMT_bufferPool;
     if bufPool.is_null() {
         return core::ptr::null_mut();
     }
@@ -321,7 +316,7 @@ unsafe fn ZSTDMT_createBufferPool(
         Mutex::new(()),
     );
     (*bufPool).buffers = ZSTD_customCalloc(
-        (maxNbBuffers as usize).wrapping_mul(::core::mem::size_of::<Buffer>()),
+        (maxNbBuffers as usize).wrapping_mul(size_of::<Buffer>()),
         cMem,
     ) as *mut Buffer;
     if ((*bufPool).buffers).is_null() {
@@ -335,9 +330,8 @@ unsafe fn ZSTDMT_createBufferPool(
     bufPool
 }
 unsafe fn ZSTDMT_sizeof_bufferPool(bufPool: *mut ZSTDMT_bufferPool) -> size_t {
-    let poolSize = ::core::mem::size_of::<ZSTDMT_bufferPool>();
-    let arraySize =
-        ((*bufPool).totalBuffers as size_t).wrapping_mul(::core::mem::size_of::<Buffer>());
+    let poolSize = size_of::<ZSTDMT_bufferPool>();
+    let arraySize = ((*bufPool).totalBuffers as size_t).wrapping_mul(size_of::<Buffer>());
     let mut u: core::ffi::c_uint = 0;
     let mut totalBufferSize = 0 as size_t;
     let _guard = (*bufPool).poolMutex.lock().unwrap();
@@ -423,7 +417,7 @@ unsafe fn ZSTDMT_sizeof_seqPool(seqPool: *mut ZSTDMT_seqPool) -> size_t {
 unsafe fn bufferToSeq(buffer: Buffer) -> RawSeqStore_t {
     let mut seq = kNullRawSeqStore;
     seq.seq = buffer.start as *mut rawSeq;
-    seq.capacity = (buffer.capacity).wrapping_div(::core::mem::size_of::<rawSeq>());
+    seq.capacity = (buffer.capacity).wrapping_div(size_of::<rawSeq>());
     seq
 }
 unsafe fn seqToBuffer(seq: RawSeqStore_t) -> Buffer {
@@ -432,7 +426,7 @@ unsafe fn seqToBuffer(seq: RawSeqStore_t) -> Buffer {
         capacity: 0,
     };
     buffer.start = seq.seq as *mut core::ffi::c_void;
-    buffer.capacity = (seq.capacity).wrapping_mul(::core::mem::size_of::<rawSeq>());
+    buffer.capacity = (seq.capacity).wrapping_mul(size_of::<rawSeq>());
     buffer
 }
 unsafe fn ZSTDMT_getSeq(seqPool: *mut ZSTDMT_seqPool) -> RawSeqStore_t {
@@ -445,10 +439,7 @@ unsafe fn ZSTDMT_releaseSeq(seqPool: *mut ZSTDMT_seqPool, seq: RawSeqStore_t) {
     ZSTDMT_releaseBuffer(seqPool, seqToBuffer(seq));
 }
 unsafe fn ZSTDMT_setNbSeq(seqPool: *mut ZSTDMT_seqPool, nbSeq: size_t) {
-    ZSTDMT_setBufferSize(
-        seqPool,
-        nbSeq.wrapping_mul(::core::mem::size_of::<rawSeq>()),
-    );
+    ZSTDMT_setBufferSize(seqPool, nbSeq.wrapping_mul(size_of::<rawSeq>()));
 }
 unsafe fn ZSTDMT_createSeqPool(
     nbWorkers: core::ffi::c_uint,
@@ -481,7 +472,7 @@ unsafe fn ZSTDMT_freeCCtxPool(pool: *mut ZSTDMT_CCtxPool) {
         }
         ZSTD_customFree(
             (*pool).cctxs as *mut core::ffi::c_void,
-            ((*pool).totalCCtx as usize).wrapping_mul(::core::mem::size_of::<*mut ZSTD_CCtx>()),
+            ((*pool).totalCCtx as usize).wrapping_mul(size_of::<*mut ZSTD_CCtx>()),
             (*pool).cMem,
         );
     }
@@ -495,8 +486,7 @@ unsafe fn ZSTDMT_createCCtxPool(
     nbWorkers: core::ffi::c_int,
     cMem: ZSTD_customMem,
 ) -> *mut ZSTDMT_CCtxPool {
-    let cctxPool =
-        ZSTD_customCalloc(::core::mem::size_of::<ZSTDMT_CCtxPool>(), cMem) as *mut ZSTDMT_CCtxPool;
+    let cctxPool = ZSTD_customCalloc(size_of::<ZSTDMT_CCtxPool>(), cMem) as *mut ZSTDMT_CCtxPool;
     if cctxPool.is_null() {
         return core::ptr::null_mut();
     }
@@ -506,7 +496,7 @@ unsafe fn ZSTDMT_createCCtxPool(
     );
     (*cctxPool).totalCCtx = nbWorkers;
     (*cctxPool).cctxs = ZSTD_customCalloc(
-        (nbWorkers as usize).wrapping_mul(::core::mem::size_of::<*mut ZSTD_CCtx>()),
+        (nbWorkers as usize).wrapping_mul(size_of::<*mut ZSTD_CCtx>()),
         cMem,
     ) as *mut *mut ZSTD_CCtx;
     if ((*cctxPool).cctxs).is_null() {
@@ -540,9 +530,8 @@ unsafe fn ZSTDMT_expandCCtxPool(
 unsafe fn ZSTDMT_sizeof_CCtxPool(cctxPool: *mut ZSTDMT_CCtxPool) -> size_t {
     let _guard = (*cctxPool).poolMutex.lock().unwrap();
     let nbWorkers = (*cctxPool).totalCCtx as core::ffi::c_uint;
-    let poolSize = ::core::mem::size_of::<ZSTDMT_CCtxPool>();
-    let arraySize =
-        ((*cctxPool).totalCCtx as usize).wrapping_mul(::core::mem::size_of::<*mut ZSTD_CCtx>());
+    let poolSize = size_of::<ZSTDMT_CCtxPool>();
+    let arraySize = ((*cctxPool).totalCCtx as usize).wrapping_mul(size_of::<*mut ZSTD_CCtx>());
     let mut totalCCtxSize = 0 as size_t;
     let mut u: core::ffi::c_uint = 0;
     u = 0;
@@ -591,7 +580,7 @@ unsafe fn ZSTDMT_serialState_reset(
         ptr::write_bytes(
             &mut params.ldmParams as *mut ldmParams_t as *mut u8,
             0,
-            ::core::mem::size_of::<ldmParams_t>(),
+            size_of::<ldmParams_t>(),
         );
     }
     (*serialState).nextJobID = 0;
@@ -601,8 +590,7 @@ unsafe fn ZSTDMT_serialState_reset(
     if params.ldmParams.enableLdm == ZSTD_ParamSwitch_e::ZSTD_ps_enable {
         let cMem = params.customMem;
         let hashLog = params.ldmParams.hashLog;
-        let hashSize =
-            ((1 as size_t) << hashLog).wrapping_mul(::core::mem::size_of::<ldmEntry_t>());
+        let hashSize = ((1 as size_t) << hashLog).wrapping_mul(size_of::<ldmEntry_t>());
         let bucketLog = (params.ldmParams.hashLog).wrapping_sub(params.ldmParams.bucketSizeLog);
         let prevBucketLog = ((*serialState).params.ldmParams.hashLog)
             .wrapping_sub((*serialState).params.ldmParams.bucketSizeLog);
@@ -661,11 +649,7 @@ unsafe fn ZSTDMT_serialState_reset(
     0
 }
 unsafe fn ZSTDMT_serialState_init(serialState: *mut SerialState) -> core::ffi::c_int {
-    ptr::write_bytes(
-        serialState as *mut u8,
-        0,
-        ::core::mem::size_of::<SerialState>(),
-    );
+    ptr::write_bytes(serialState as *mut u8, 0, size_of::<SerialState>());
     core::ptr::write(
         core::ptr::addr_of_mut!((*serialState).mutex),
         Mutex::new(()),
@@ -688,7 +672,7 @@ unsafe fn ZSTDMT_serialState_free(serialState: *mut SerialState) {
     core::ptr::drop_in_place(core::ptr::addr_of_mut!((*serialState).ldmWindowMutex));
     core::ptr::drop_in_place(core::ptr::addr_of_mut!((*serialState).ldmWindowCond));
     let hashLog = (*serialState).params.ldmParams.hashLog;
-    let hashSize = ((1 as size_t) << hashLog).wrapping_mul(::core::mem::size_of::<ldmEntry_t>());
+    let hashSize = ((1 as size_t) << hashLog).wrapping_mul(size_of::<ldmEntry_t>());
     let bucketLog = ((*serialState).params.ldmParams.hashLog)
         .wrapping_sub((*serialState).params.ldmParams.bucketSizeLog);
     let numBuckets = 1usize << bucketLog;
@@ -1089,7 +1073,7 @@ unsafe fn ZSTDMT_freeJobsTable(
     }
     ZSTD_customFree(
         jobTable as *mut core::ffi::c_void,
-        (nbJobs as usize).wrapping_mul(::core::mem::size_of::<ZSTDMT_jobDescription>()),
+        (nbJobs as usize).wrapping_mul(size_of::<ZSTDMT_jobDescription>()),
         cMem,
     );
 }
@@ -1101,7 +1085,7 @@ unsafe fn ZSTDMT_createJobsTable(
     let nbJobs = ((1) << nbJobsLog2) as u32;
     let mut jobNb: u32 = 0;
     let jobTable = ZSTD_customCalloc(
-        (nbJobs as usize).wrapping_mul(::core::mem::size_of::<ZSTDMT_jobDescription>()),
+        (nbJobs as usize).wrapping_mul(size_of::<ZSTDMT_jobDescription>()),
         cMem,
     ) as *mut ZSTDMT_jobDescription;
     if jobTable.is_null() {
@@ -1161,7 +1145,7 @@ unsafe fn ZSTDMT_createCCtx_advanced_internal(
         return core::ptr::null_mut();
     }
     nbWorkers = if nbWorkers
-        < (if ::core::mem::size_of::<*mut core::ffi::c_void>() as core::ffi::c_ulong == 4 {
+        < (if size_of::<*mut core::ffi::c_void>() as core::ffi::c_ulong == 4 {
             64
         } else {
             256
@@ -1169,13 +1153,13 @@ unsafe fn ZSTDMT_createCCtx_advanced_internal(
     {
         nbWorkers
     } else {
-        (if ::core::mem::size_of::<*mut core::ffi::c_void>() as core::ffi::c_ulong == 4 {
+        (if size_of::<*mut core::ffi::c_void>() as core::ffi::c_ulong == 4 {
             64
         } else {
             256
         }) as core::ffi::c_uint
     };
-    let mtctx = ZSTD_customCalloc(::core::mem::size_of::<ZSTDMT_CCtx>(), cMem) as *mut ZSTDMT_CCtx;
+    let mtctx = ZSTD_customCalloc(size_of::<ZSTDMT_CCtx>(), cMem) as *mut ZSTDMT_CCtx;
     if mtctx.is_null() {
         return core::ptr::null_mut();
     }
@@ -1238,7 +1222,7 @@ unsafe fn ZSTDMT_releaseAllJobResources(mtctx: *mut ZSTDMT_CCtx) {
         ptr::write_bytes(
             &mut *((*mtctx).jobs).offset(jobID as isize) as *mut ZSTDMT_jobDescription as *mut u8,
             0,
-            ::core::mem::size_of::<ZSTDMT_jobDescription>(),
+            size_of::<ZSTDMT_jobDescription>(),
         );
         core::ptr::write(
             core::ptr::addr_of_mut!((*((*mtctx).jobs).offset(jobID as isize)).job_mutex),
@@ -1299,7 +1283,7 @@ pub unsafe fn ZSTDMT_freeCCtx(mtctx: *mut ZSTDMT_CCtx) -> size_t {
     }
     ZSTD_customFree(
         mtctx as *mut core::ffi::c_void,
-        ::core::mem::size_of::<ZSTDMT_CCtx>(),
+        size_of::<ZSTDMT_CCtx>(),
         (*mtctx).cMem,
     );
     0
@@ -1308,12 +1292,12 @@ pub unsafe fn ZSTDMT_sizeof_CCtx(mtctx: *mut ZSTDMT_CCtx) -> size_t {
     if mtctx.is_null() {
         return 0;
     }
-    (::core::mem::size_of::<ZSTDMT_CCtx>())
+    (size_of::<ZSTDMT_CCtx>())
         .wrapping_add(POOL_sizeof((*mtctx).factory))
         .wrapping_add(ZSTDMT_sizeof_bufferPool((*mtctx).bufPool))
         .wrapping_add(
             (((*mtctx).jobIDMask).wrapping_add(1) as size_t)
-                .wrapping_mul(::core::mem::size_of::<ZSTDMT_jobDescription>()),
+                .wrapping_mul(size_of::<ZSTDMT_jobDescription>()),
         )
         .wrapping_add(ZSTDMT_sizeof_CCtxPool((*mtctx).cctxPool))
         .wrapping_add(ZSTDMT_sizeof_seqPool((*mtctx).seqPool))

--- a/lib/compress/zstdmt_compress.rs
+++ b/lib/compress/zstdmt_compress.rs
@@ -1292,7 +1292,7 @@ pub unsafe fn ZSTDMT_sizeof_CCtx(mtctx: *mut ZSTDMT_CCtx) -> size_t {
     if mtctx.is_null() {
         return 0;
     }
-    (size_of::<ZSTDMT_CCtx>())
+    size_of::<ZSTDMT_CCtx>()
         .wrapping_add(POOL_sizeof((*mtctx).factory))
         .wrapping_add(ZSTDMT_sizeof_bufferPool((*mtctx).bufPool))
         .wrapping_add(

--- a/lib/decompress/huf_decompress.rs
+++ b/lib/decompress/huf_decompress.rs
@@ -278,7 +278,7 @@ unsafe fn init_remaining_dstream<'a>(
     let bitContainer = MEM_readLEST(args.ip[stream] as *const core::ffi::c_void) as usize;
     let bitsConsumed = args.bits[stream].trailing_zeros();
     let start = args.ilowest as *const core::ffi::c_char;
-    let limitPtr = start.add(::core::mem::size_of::<size_t>());
+    let limitPtr = start.add(size_of::<size_t>());
     let ptr = args.ip[stream] as *const core::ffi::c_char;
 
     Ok(BIT_DStream_t {

--- a/lib/decompress/zstd_ddict.rs
+++ b/lib/decompress/zstd_ddict.rs
@@ -351,7 +351,7 @@ pub unsafe extern "C" fn ZSTD_sizeof_DDict(ddict: *const ZSTD_DDict) -> size_t {
     if ddict.is_null() {
         return 0;
     }
-    (size_of::<ZSTD_DDict>()).wrapping_add(if !((*ddict).dictBuffer).is_null() {
+    size_of::<ZSTD_DDict>().wrapping_add(if !((*ddict).dictBuffer).is_null() {
         (*ddict).dictSize
     } else {
         0

--- a/lib/decompress/zstd_ddict.rs
+++ b/lib/decompress/zstd_ddict.rs
@@ -351,7 +351,7 @@ pub unsafe extern "C" fn ZSTD_sizeof_DDict(ddict: *const ZSTD_DDict) -> size_t {
     if ddict.is_null() {
         return 0;
     }
-    (::core::mem::size_of::<ZSTD_DDict>()).wrapping_add(if !((*ddict).dictBuffer).is_null() {
+    (size_of::<ZSTD_DDict>()).wrapping_add(if !((*ddict).dictBuffer).is_null() {
         (*ddict).dictSize
     } else {
         0

--- a/lib/decompress/zstd_decompress.rs
+++ b/lib/decompress/zstd_decompress.rs
@@ -521,7 +521,7 @@ unsafe fn ZSTD_DDictHashSet_expand(
 ) -> size_t {
     let newTableSize = hashSet.ddictPtrTableSize * DDICT_HASHSET_RESIZE_FACTOR as size_t;
     let newTable = ZSTD_customCalloc(
-        (::core::mem::size_of::<*mut ZSTD_DDict>()).wrapping_mul(newTableSize),
+        (size_of::<*mut ZSTD_DDict>()).wrapping_mul(newTableSize),
         customMem,
     ) as *mut *const ZSTD_DDict;
     let oldTable = hashSet.ddictPtrTable;
@@ -545,7 +545,7 @@ unsafe fn ZSTD_DDictHashSet_expand(
     }
     ZSTD_customFree(
         oldTable as *mut core::ffi::c_void,
-        oldTableSize.wrapping_mul(::core::mem::size_of::<*mut ZSTD_DDict>()),
+        oldTableSize.wrapping_mul(size_of::<*mut ZSTD_DDict>()),
         customMem,
     );
     0
@@ -589,20 +589,19 @@ unsafe fn ZSTD_DDictHashSet_getDDict(
 ///   values automatically set to `NULL` to begin with.
 /// - `NULL` if allocation failed
 unsafe fn ZSTD_createDDictHashSet(customMem: ZSTD_customMem) -> *mut ZSTD_DDictHashSet {
-    let ret = ZSTD_customMalloc(::core::mem::size_of::<ZSTD_DDictHashSet>(), customMem)
-        as *mut ZSTD_DDictHashSet;
+    let ret =
+        ZSTD_customMalloc(size_of::<ZSTD_DDictHashSet>(), customMem) as *mut ZSTD_DDictHashSet;
     if ret.is_null() {
         return core::ptr::null_mut();
     }
     (*ret).ddictPtrTable = ZSTD_customCalloc(
-        (DDICT_HASHSET_TABLE_BASE_SIZE as size_t)
-            .wrapping_mul(::core::mem::size_of::<*mut ZSTD_DDict>()),
+        (DDICT_HASHSET_TABLE_BASE_SIZE as size_t).wrapping_mul(size_of::<*mut ZSTD_DDict>()),
         customMem,
     ) as *mut *const ZSTD_DDict;
     if ((*ret).ddictPtrTable).is_null() {
         ZSTD_customFree(
             ret as *mut core::ffi::c_void,
-            ::core::mem::size_of::<ZSTD_DDictHashSet>(),
+            size_of::<ZSTD_DDictHashSet>(),
             customMem,
         );
         return core::ptr::null_mut();
@@ -621,14 +620,14 @@ unsafe fn ZSTD_freeDDictHashSet(hashSet: *mut ZSTD_DDictHashSet, customMem: ZSTD
             (*hashSet).ddictPtrTable as *mut core::ffi::c_void,
             (*hashSet)
                 .ddictPtrTableSize
-                .wrapping_mul(::core::mem::size_of::<*mut ZSTD_DDict>()),
+                .wrapping_mul(size_of::<*mut ZSTD_DDict>()),
             customMem,
         );
     }
     if !hashSet.is_null() {
         ZSTD_customFree(
             hashSet as *mut core::ffi::c_void,
-            ::core::mem::size_of::<ZSTD_DDictHashSet>(),
+            size_of::<ZSTD_DDictHashSet>(),
             customMem,
         );
     }
@@ -668,7 +667,7 @@ pub unsafe extern "C" fn ZSTD_sizeof_DCtx(dctx: *const ZSTD_DCtx) -> size_t {
     if dctx.is_null() {
         return 0;
     }
-    (::core::mem::size_of::<ZSTD_DCtx>())
+    (size_of::<ZSTD_DCtx>())
         .wrapping_add(ZSTD_sizeof_DDict((*dctx).ddictLocal))
         .wrapping_add((*dctx).inBuffSize)
         .wrapping_add((*dctx).outBuffSize)
@@ -757,7 +756,7 @@ pub unsafe extern "C" fn ZSTD_initStaticDCtx(
     }
 
     // check minimum workspace size
-    if workspaceSize < ::core::mem::size_of::<ZSTD_DCtx>() {
+    if workspaceSize < size_of::<ZSTD_DCtx>() {
         return core::ptr::null_mut();
     }
 
@@ -770,7 +769,7 @@ pub unsafe extern "C" fn ZSTD_initStaticDCtx(
 }
 
 unsafe fn ZSTD_createDCtx_internal(customMem: ZSTD_customMem) -> *mut ZSTD_DCtx {
-    let alloc = ZSTD_customMalloc(::core::mem::size_of::<ZSTD_DCtx>(), customMem);
+    let alloc = ZSTD_customMalloc(size_of::<ZSTD_DCtx>(), customMem);
     let Some(dctx) = alloc.cast::<MaybeUninit<ZSTD_DCtx>>().as_mut() else {
         return core::ptr::null_mut();
     };
@@ -831,11 +830,7 @@ pub unsafe extern "C" fn ZSTD_freeDCtx(dctx: *mut ZSTD_DCtx) -> size_t {
         ZSTD_freeDDictHashSet((*dctx).ddictSet, cMem);
         (*dctx).ddictSet = core::ptr::null_mut();
     }
-    ZSTD_customFree(
-        dctx as *mut core::ffi::c_void,
-        ::core::mem::size_of::<ZSTD_DCtx>(),
-        cMem,
-    );
+    ZSTD_customFree(dctx as *mut core::ffi::c_void, size_of::<ZSTD_DCtx>(), cMem);
     0
 }
 

--- a/lib/decompress/zstd_decompress.rs
+++ b/lib/decompress/zstd_decompress.rs
@@ -521,7 +521,7 @@ unsafe fn ZSTD_DDictHashSet_expand(
 ) -> size_t {
     let newTableSize = hashSet.ddictPtrTableSize * DDICT_HASHSET_RESIZE_FACTOR as size_t;
     let newTable = ZSTD_customCalloc(
-        (size_of::<*mut ZSTD_DDict>()).wrapping_mul(newTableSize),
+        size_of::<*mut ZSTD_DDict>().wrapping_mul(newTableSize),
         customMem,
     ) as *mut *const ZSTD_DDict;
     let oldTable = hashSet.ddictPtrTable;
@@ -667,7 +667,7 @@ pub unsafe extern "C" fn ZSTD_sizeof_DCtx(dctx: *const ZSTD_DCtx) -> size_t {
     if dctx.is_null() {
         return 0;
     }
-    (size_of::<ZSTD_DCtx>())
+    size_of::<ZSTD_DCtx>()
         .wrapping_add(ZSTD_sizeof_DDict((*dctx).ddictLocal))
         .wrapping_add((*dctx).inBuffSize)
         .wrapping_add((*dctx).outBuffSize)

--- a/lib/dictBuilder/cover.rs
+++ b/lib/dictBuilder/cover.rs
@@ -333,7 +333,7 @@ fn stableSort(ctx: &mut COVER_ctx_t) {
                 qsort_r(
                     ctx.suffix.as_mut_ptr() as *mut core::ffi::c_void,
                     ctx.suffix.len(),
-                    ::core::mem::size_of::<u32>(),
+                    size_of::<u32>(),
                     &raw mut *ctx as *mut core::ffi::c_void,
                     compare_fn,
                 );
@@ -344,7 +344,7 @@ fn stableSort(ctx: &mut COVER_ctx_t) {
                 qsort_s(
                     ctx.suffix.as_mut_ptr() as *mut core::ffi::c_void,
                     ctx.suffix.len(),
-                    ::core::mem::size_of::<u32>(),
+                    size_of::<u32>(),
                     compare_fn,
                     &raw mut *ctx as *mut core::ffi::c_void,
                 );
@@ -355,7 +355,7 @@ fn stableSort(ctx: &mut COVER_ctx_t) {
                 qsort_r(
                     ctx.suffix.as_mut_ptr() as *mut core::ffi::c_void,
                     ctx.suffix.len(),
-                    ::core::mem::size_of::<u32>(),
+                    size_of::<u32>(),
                     compare_fn,
                     &raw mut *ctx as *mut core::ffi::c_void,
                 );
@@ -561,13 +561,13 @@ fn COVER_ctx_init<'a>(
     };
     ctx.displayLevel = displayLevel;
     if totalSamplesSize
-        < (if d as size_t > ::core::mem::size_of::<u64>() {
+        < (if d as size_t > size_of::<u64>() {
             d as size_t
         } else {
-            ::core::mem::size_of::<u64>()
+            size_of::<u64>()
         })
         || totalSamplesSize
-            >= (if ::core::mem::size_of::<size_t>() == 8 {
+            >= (if size_of::<size_t>() == 8 {
                 -(1 as core::ffi::c_int) as core::ffi::c_uint
             } else {
                 (1 as core::ffi::c_int as core::ffi::c_uint).wrapping_mul((1) << 30)
@@ -577,7 +577,7 @@ fn COVER_ctx_init<'a>(
             eprintln!(
                 "Total samples size is too large ({} MB), maximum size is {} MB",
                 (totalSamplesSize >> 20) as core::ffi::c_uint,
-                (if ::core::mem::size_of::<size_t>() == 8 {
+                (if size_of::<size_t>() == 8 {
                     -(1 as core::ffi::c_int) as core::ffi::c_uint
                 } else {
                     (1 as core::ffi::c_uint).wrapping_mul((1) << 30)
@@ -623,10 +623,10 @@ fn COVER_ctx_init<'a>(
     ctx.nbTrainSamples = nbTrainSamples as size_t;
     ctx.nbTestSamples = nbTestSamples as size_t;
     ctx.suffixSize = trainingSamplesSize
-        .wrapping_sub(if d as size_t > ::core::mem::size_of::<u64>() {
+        .wrapping_sub(if d as size_t > size_of::<u64>() {
             d as size_t
         } else {
-            ::core::mem::size_of::<u64>()
+            size_of::<u64>()
         })
         .wrapping_add(1);
     ctx.suffix = (0..ctx.suffixSize as u32).collect();

--- a/lib/dictBuilder/fastcover.rs
+++ b/lib/dictBuilder/fastcover.rs
@@ -260,7 +260,7 @@ fn FASTCOVER_ctx_init<'a>(
     };
 
     ctx.displayLevel = displayLevel;
-    if totalSamplesSize < Ord::max(d as size_t, ::core::mem::size_of::<u64>())
+    if totalSamplesSize < Ord::max(d as size_t, size_of::<u64>())
         || totalSamplesSize >= FASTCOVER_MAX_SAMPLES_SIZE
     {
         if displayLevel >= 1 {
@@ -307,8 +307,7 @@ fn FASTCOVER_ctx_init<'a>(
     ctx.nbSamples = nbSamples as size_t;
     ctx.nbTrainSamples = nbTrainSamples as size_t;
     ctx.nbTestSamples = nbTestSamples as size_t;
-    ctx.nbDmers =
-        trainingSamplesSize.wrapping_sub(Ord::max(d as size_t, ::core::mem::size_of::<u64>())) + 1;
+    ctx.nbDmers = trainingSamplesSize.wrapping_sub(Ord::max(d as size_t, size_of::<u64>())) + 1;
     ctx.d = d;
     ctx.f = f;
     ctx.accelParams = accelParams;

--- a/lib/dictBuilder/zdict.rs
+++ b/lib/dictBuilder/zdict.rs
@@ -874,7 +874,7 @@ unsafe fn analyze_entropy_internal(
         255,
         huffLog,
         wksp.as_mut_ptr() as *mut core::ffi::c_void,
-        ::core::mem::size_of::<[u32; HUF_CTABLE_WORKSPACE_SIZE_U32]>(),
+        size_of::<[u32; HUF_CTABLE_WORKSPACE_SIZE_U32]>(),
     );
     if let Some(err) = Error::from_error_code(maxNbBits) {
         if notificationLevel >= 1 {
@@ -894,7 +894,7 @@ unsafe fn analyze_entropy_internal(
             255,
             huffLog,
             wksp.as_mut_ptr() as *mut core::ffi::c_void,
-            ::core::mem::size_of::<[u32; HUF_CTABLE_WORKSPACE_SIZE_U32]>(),
+            size_of::<[u32; HUF_CTABLE_WORKSPACE_SIZE_U32]>(),
         );
     }
     let huffLog = maxNbBits as u32;
@@ -963,7 +963,7 @@ unsafe fn analyze_entropy_internal(
         255,
         huffLog,
         wksp.as_mut_ptr() as *mut core::ffi::c_void,
-        ::core::mem::size_of::<[u32; HUF_CTABLE_WORKSPACE_SIZE_U32]>(),
+        size_of::<[u32; HUF_CTABLE_WORKSPACE_SIZE_U32]>(),
     );
     if let Some(err) = Error::from_error_code(hhSize) {
         if notificationLevel >= 1 {

--- a/lib/legacy/zstd_v05.rs
+++ b/lib/legacy/zstd_v05.rs
@@ -644,9 +644,7 @@ fn FSEv05_decompress_usingDTable_generic<const N: usize>(
         } else {
             FSEv05_decodeSymbol(&mut state1, &mut bitD) as core::ffi::c_int
         }) as u8;
-        if (FSEv05_MAX_TABLELOG * 2 + 7) as size_t
-            > (::core::mem::size_of::<size_t>()).wrapping_mul(8)
-        {
+        if (FSEv05_MAX_TABLELOG * 2 + 7) as size_t > (size_of::<size_t>()).wrapping_mul(8) {
             bitD.reload();
         }
         op[1] = (if fast != 0 {
@@ -654,8 +652,7 @@ fn FSEv05_decompress_usingDTable_generic<const N: usize>(
         } else {
             FSEv05_decodeSymbol(&mut state2, &mut bitD) as core::ffi::c_int
         }) as u8;
-        if (FSEv05_MAX_TABLELOG * 4 + 7) as size_t
-            > (::core::mem::size_of::<size_t>()).wrapping_mul(8)
+        if (FSEv05_MAX_TABLELOG * 4 + 7) as size_t > (size_of::<size_t>()).wrapping_mul(8)
             && bitD.reload() > StreamStatus::Unfinished
         {
             op = &mut op[2..];
@@ -666,9 +663,7 @@ fn FSEv05_decompress_usingDTable_generic<const N: usize>(
         } else {
             FSEv05_decodeSymbol(&mut state1, &mut bitD) as core::ffi::c_int
         }) as u8;
-        if (FSEv05_MAX_TABLELOG * 2 + 7) as size_t
-            > (::core::mem::size_of::<size_t>()).wrapping_mul(8)
-        {
+        if (FSEv05_MAX_TABLELOG * 2 + 7) as size_t > (size_of::<size_t>()).wrapping_mul(8) {
             bitD.reload();
         }
         op[3] = (if fast != 0 {
@@ -1892,7 +1887,7 @@ unsafe fn ZSTDv05_decompressBegin(dctx: *mut ZSTDv05_DCtx) {
     (*dctx).flagStaticTables = 0;
 }
 pub(crate) unsafe fn ZSTDv05_createDCtx() -> *mut ZSTDv05_DCtx {
-    let dctx = malloc(::core::mem::size_of::<ZSTDv05_DCtx>()) as *mut ZSTDv05_DCtx;
+    let dctx = malloc(size_of::<ZSTDv05_DCtx>()) as *mut ZSTDv05_DCtx;
     if dctx.is_null() {
         return core::ptr::null_mut();
     }
@@ -1932,7 +1927,7 @@ pub(crate) fn ZSTDv05_getFrameParams(
         ptr::write_bytes(
             params as *mut ZSTDv05_parameters as *mut u8,
             0,
-            ::core::mem::size_of::<ZSTDv05_parameters>(),
+            size_of::<ZSTDv05_parameters>(),
         );
     }
     params.windowLog = ((src[4] & 15) + ZSTDv05_WINDOWLOG_ABSOLUTEMIN) as u32;
@@ -2667,7 +2662,7 @@ unsafe fn ZSTDv05_decompress_continueDCtx(
     ptr::write_bytes(
         &mut blockProperties as *mut blockProperties_t as *mut u8,
         0,
-        ::core::mem::size_of::<blockProperties_t>(),
+        size_of::<blockProperties_t>(),
     );
     let mut frameHeaderSize: size_t = 0;
     if src.len() < ZSTDv05_frameHeaderSize_min.wrapping_add(ZSTDv05_blockHeaderSize) {
@@ -2982,11 +2977,11 @@ unsafe fn ZBUFFv05_limitCopy(
 }
 const ZSTDv05_frameHeaderSize_max_0: core::ffi::c_int = 5;
 pub(crate) unsafe fn ZBUFFv05_createDCtx() -> *mut ZBUFFv05_DCtx {
-    let zbc = malloc(::core::mem::size_of::<ZBUFFv05_DCtx>()) as *mut ZBUFFv05_DCtx;
+    let zbc = malloc(size_of::<ZBUFFv05_DCtx>()) as *mut ZBUFFv05_DCtx;
     if zbc.is_null() {
         return core::ptr::null_mut();
     }
-    ptr::write_bytes(zbc as *mut u8, 0, ::core::mem::size_of::<ZBUFFv05_DCtx>());
+    ptr::write_bytes(zbc as *mut u8, 0, size_of::<ZBUFFv05_DCtx>());
     (*zbc).zc = ZSTDv05_createDCtx();
     (*zbc).stage = ZBUFFv05ds_init;
     zbc

--- a/lib/legacy/zstd_v05.rs
+++ b/lib/legacy/zstd_v05.rs
@@ -644,7 +644,7 @@ fn FSEv05_decompress_usingDTable_generic<const N: usize>(
         } else {
             FSEv05_decodeSymbol(&mut state1, &mut bitD) as core::ffi::c_int
         }) as u8;
-        if (FSEv05_MAX_TABLELOG * 2 + 7) as size_t > (size_of::<size_t>()).wrapping_mul(8) {
+        if (FSEv05_MAX_TABLELOG * 2 + 7) as size_t > size_of::<size_t>().wrapping_mul(8) {
             bitD.reload();
         }
         op[1] = (if fast != 0 {
@@ -652,7 +652,7 @@ fn FSEv05_decompress_usingDTable_generic<const N: usize>(
         } else {
             FSEv05_decodeSymbol(&mut state2, &mut bitD) as core::ffi::c_int
         }) as u8;
-        if (FSEv05_MAX_TABLELOG * 4 + 7) as size_t > (size_of::<size_t>()).wrapping_mul(8)
+        if (FSEv05_MAX_TABLELOG * 4 + 7) as size_t > size_of::<size_t>().wrapping_mul(8)
             && bitD.reload() > StreamStatus::Unfinished
         {
             op = &mut op[2..];
@@ -663,7 +663,7 @@ fn FSEv05_decompress_usingDTable_generic<const N: usize>(
         } else {
             FSEv05_decodeSymbol(&mut state1, &mut bitD) as core::ffi::c_int
         }) as u8;
-        if (FSEv05_MAX_TABLELOG * 2 + 7) as size_t > (size_of::<size_t>()).wrapping_mul(8) {
+        if (FSEv05_MAX_TABLELOG * 2 + 7) as size_t > size_of::<size_t>().wrapping_mul(8) {
             bitD.reload();
         }
         op[3] = (if fast != 0 {

--- a/lib/legacy/zstd_v06.rs
+++ b/lib/legacy/zstd_v06.rs
@@ -236,22 +236,18 @@ unsafe fn BITv06_initDStream(
     srcSize: size_t,
 ) -> size_t {
     if srcSize < 1 {
-        ptr::write_bytes(
-            bitD as *mut u8,
-            0,
-            ::core::mem::size_of::<BITv06_DStream_t>(),
-        );
+        ptr::write_bytes(bitD as *mut u8, 0, size_of::<BITv06_DStream_t>());
         return Error::srcSize_wrong.to_error_code();
     }
 
     let bitD = &mut *bitD;
 
-    if srcSize >= ::core::mem::size_of::<size_t>() {
+    if srcSize >= size_of::<size_t>() {
         // normal case
         bitD.start = srcBuffer as *const core::ffi::c_char;
         bitD.ptr = (srcBuffer as *const core::ffi::c_char)
             .add(srcSize)
-            .sub(::core::mem::size_of::<size_t>());
+            .sub(size_of::<size_t>());
         bitD.bitContainer = MEM_readLEST(bitD.ptr as *const core::ffi::c_void);
         let lastByte = *(srcBuffer as *const u8).add(srcSize.wrapping_sub(1));
         if lastByte == 0 {
@@ -264,18 +260,18 @@ unsafe fn BITv06_initDStream(
         bitD.bitContainer = *(bitD.start as *const u8) as size_t;
 
         if srcSize == 7 {
-            bitD.bitContainer += (*(bitD.start as *const u8).add(6) as size_t)
-                << (::core::mem::size_of::<size_t>() * 8 - 16);
+            bitD.bitContainer +=
+                (*(bitD.start as *const u8).add(6) as size_t) << (size_t::BITS as usize - 16);
         }
 
         if srcSize >= 6 {
-            bitD.bitContainer += (*(bitD.start as *const u8).add(5) as size_t)
-                << (::core::mem::size_of::<size_t>() * 8 - 24);
+            bitD.bitContainer +=
+                (*(bitD.start as *const u8).add(5) as size_t) << (size_t::BITS as usize - 24);
         }
 
         if srcSize >= 5 {
-            bitD.bitContainer += (*(bitD.start as *const u8).add(4) as size_t)
-                << (::core::mem::size_of::<size_t>() * 8 - 32);
+            bitD.bitContainer +=
+                (*(bitD.start as *const u8).add(4) as size_t) << (size_t::BITS as usize - 32);
         }
 
         if srcSize >= 4 {
@@ -296,25 +292,21 @@ unsafe fn BITv06_initDStream(
             return Error::GENERIC.to_error_code();
         }
         bitD.bitsConsumed = (8 as core::ffi::c_uint) - BITv06_highbit32(lastByte as u32);
-        bitD.bitsConsumed += (::core::mem::size_of::<size_t>() - srcSize) as u32 * 8;
+        bitD.bitsConsumed += (size_of::<size_t>() - srcSize) as u32 * 8;
     }
     srcSize
 }
 
 #[inline]
 unsafe fn BITv06_lookBits(bitD: *const BITv06_DStream_t, nbBits: u32) -> size_t {
-    let bitMask = (::core::mem::size_of::<size_t>())
-        .wrapping_mul(8)
-        .wrapping_sub(1) as u32;
+    let bitMask = (size_of::<size_t>()).wrapping_mul(8).wrapping_sub(1) as u32;
     (*bitD).bitContainer << ((*bitD).bitsConsumed & bitMask)
         >> 1
         >> (bitMask.wrapping_sub(nbBits) & bitMask)
 }
 #[inline]
 unsafe fn BITv06_lookBitsFast(bitD: *const BITv06_DStream_t, nbBits: u32) -> size_t {
-    let bitMask = (::core::mem::size_of::<size_t>())
-        .wrapping_mul(8)
-        .wrapping_sub(1) as u32;
+    let bitMask = (size_of::<size_t>()).wrapping_mul(8).wrapping_sub(1) as u32;
     (*bitD).bitContainer << ((*bitD).bitsConsumed & bitMask)
         >> (bitMask.wrapping_add(1).wrapping_sub(nbBits) & bitMask)
 }
@@ -336,17 +328,17 @@ unsafe fn BITv06_readBitsFast(bitD: *mut BITv06_DStream_t, nbBits: u32) -> size_
 }
 #[inline]
 unsafe fn BITv06_reloadDStream(bitD: *mut BITv06_DStream_t) -> BITv06_DStream_status {
-    if (*bitD).bitsConsumed as size_t > (::core::mem::size_of::<size_t>()).wrapping_mul(8) {
+    if (*bitD).bitsConsumed as size_t > (size_of::<size_t>()).wrapping_mul(8) {
         return BITv06_DStream_overflow;
     }
-    if (*bitD).ptr >= ((*bitD).start).add(::core::mem::size_of::<size_t>()) {
+    if (*bitD).ptr >= ((*bitD).start).add(size_of::<size_t>()) {
         (*bitD).ptr = ((*bitD).ptr).offset(-(((*bitD).bitsConsumed >> 3) as isize));
         (*bitD).bitsConsumed &= 7;
         (*bitD).bitContainer = MEM_readLEST((*bitD).ptr as *const core::ffi::c_void);
         return BITv06_DStream_unfinished;
     }
     if (*bitD).ptr == (*bitD).start {
-        if ((*bitD).bitsConsumed as size_t) < (::core::mem::size_of::<size_t>()).wrapping_mul(8) {
+        if ((*bitD).bitsConsumed as size_t) < (size_of::<size_t>()).wrapping_mul(8) {
             return BITv06_DStream_endOfBuffer;
         }
         return BITv06_DStream_completed;
@@ -365,7 +357,7 @@ unsafe fn BITv06_reloadDStream(bitD: *mut BITv06_DStream_t) -> BITv06_DStream_st
 #[inline]
 unsafe fn BITv06_endOfDStream(DStream: *const BITv06_DStream_t) -> core::ffi::c_uint {
     ((*DStream).ptr == (*DStream).start
-        && (*DStream).bitsConsumed as size_t == (::core::mem::size_of::<size_t>()).wrapping_mul(8))
+        && (*DStream).bitsConsumed as size_t == (size_of::<size_t>()).wrapping_mul(8))
         as core::ffi::c_int as core::ffi::c_uint
 }
 #[inline]
@@ -588,7 +580,7 @@ unsafe fn FSEv06_buildDTable(
     memcpy(
         dt as *mut core::ffi::c_void,
         &mut DTableH as *mut FSEv06_DTableHeader as *const core::ffi::c_void,
-        ::core::mem::size_of::<FSEv06_DTableHeader>(),
+        size_of::<FSEv06_DTableHeader>(),
     );
     let tableMask = tableSize.wrapping_sub(1);
     let step = (tableSize >> 1)
@@ -685,9 +677,7 @@ unsafe fn FSEv06_decompress_usingDTable_generic(
         } else {
             FSEv06_decodeSymbol(&mut state1, &mut bitD) as core::ffi::c_int
         }) as u8;
-        if (FSEv06_MAX_TABLELOG * 2 + 7) as size_t
-            > (::core::mem::size_of::<size_t>()).wrapping_mul(8)
-        {
+        if (FSEv06_MAX_TABLELOG * 2 + 7) as size_t > (size_of::<size_t>()).wrapping_mul(8) {
             BITv06_reloadDStream(&mut bitD);
         }
         *op.add(1) = (if fast != 0 {
@@ -695,8 +685,7 @@ unsafe fn FSEv06_decompress_usingDTable_generic(
         } else {
             FSEv06_decodeSymbol(&mut state2, &mut bitD) as core::ffi::c_int
         }) as u8;
-        if (FSEv06_MAX_TABLELOG * 4 + 7) as size_t
-            > (::core::mem::size_of::<size_t>()).wrapping_mul(8)
+        if (FSEv06_MAX_TABLELOG * 4 + 7) as size_t > (size_of::<size_t>()).wrapping_mul(8)
             && BITv06_reloadDStream(&mut bitD) as core::ffi::c_uint
                 > BITv06_DStream_unfinished as core::ffi::c_int as core::ffi::c_uint
         {
@@ -708,9 +697,7 @@ unsafe fn FSEv06_decompress_usingDTable_generic(
         } else {
             FSEv06_decodeSymbol(&mut state1, &mut bitD) as core::ffi::c_int
         }) as u8;
-        if (FSEv06_MAX_TABLELOG * 2 + 7) as size_t
-            > (::core::mem::size_of::<size_t>()).wrapping_mul(8)
-        {
+        if (FSEv06_MAX_TABLELOG * 2 + 7) as size_t > (size_of::<size_t>()).wrapping_mul(8) {
             BITv06_reloadDStream(&mut bitD);
         }
         *op.add(3) = (if fast != 0 {
@@ -1332,7 +1319,7 @@ unsafe fn HUFv06_fillDTableX4Level2(
     memcpy(
         rankVal.as_mut_ptr() as *mut core::ffi::c_void,
         rankValOrigin as *const core::ffi::c_void,
-        ::core::mem::size_of::<[u32; 17]>(),
+        size_of::<[u32; 17]>(),
     );
     if minWeight > 1 {
         let mut i: u32 = 0;
@@ -1395,7 +1382,7 @@ unsafe fn HUFv06_fillDTableX4(
     memcpy(
         rankVal.as_mut_ptr() as *mut core::ffi::c_void,
         rankValOrigin as *const core::ffi::c_void,
-        ::core::mem::size_of::<[u32; 17]>(),
+        size_of::<[u32; 17]>(),
     );
     s = 0;
     while s < sortedListSize {
@@ -1574,13 +1561,10 @@ unsafe fn HUFv06_decodeLastSymbolX4(
     memcpy(op, dt.add(val) as *const core::ffi::c_void, 1);
     if (*dt.add(val)).length as core::ffi::c_int == 1 {
         BITv06_skipBits(DStream, (*dt.add(val)).nbBits as u32);
-    } else if ((*DStream).bitsConsumed as size_t)
-        < (::core::mem::size_of::<size_t>()).wrapping_mul(8)
-    {
+    } else if ((*DStream).bitsConsumed as size_t) < (size_of::<size_t>()).wrapping_mul(8) {
         BITv06_skipBits(DStream, (*dt.add(val)).nbBits as u32);
-        if (*DStream).bitsConsumed as size_t > (::core::mem::size_of::<size_t>()).wrapping_mul(8) {
-            (*DStream).bitsConsumed =
-                (::core::mem::size_of::<size_t>()).wrapping_mul(8) as core::ffi::c_uint;
+        if (*DStream).bitsConsumed as size_t > (size_of::<size_t>()).wrapping_mul(8) {
+            (*DStream).bitsConsumed = (size_of::<size_t>()).wrapping_mul(8) as core::ffi::c_uint;
         }
     }
     1
@@ -2321,7 +2305,7 @@ unsafe fn ZSTDv06_decompressBegin(dctx: *mut ZSTDv06_DCtx) -> size_t {
     0
 }
 pub(crate) unsafe fn ZSTDv06_createDCtx() -> *mut ZSTDv06_DCtx {
-    let dctx = malloc(::core::mem::size_of::<ZSTDv06_DCtx>()) as *mut ZSTDv06_DCtx;
+    let dctx = malloc(size_of::<ZSTDv06_DCtx>()) as *mut ZSTDv06_DCtx;
     if dctx.is_null() {
         return core::ptr::null_mut();
     }
@@ -2365,11 +2349,7 @@ pub(crate) unsafe fn ZSTDv06_getFrameParams(
         return fhsize;
     }
 
-    ptr::write_bytes(
-        fparamsPtr as *mut u8,
-        0,
-        ::core::mem::size_of::<ZSTDv06_frameParams>(),
-    );
+    ptr::write_bytes(fparamsPtr as *mut u8, 0, size_of::<ZSTDv06_frameParams>());
 
     let frameDesc = *ip.add(4);
     (*fparamsPtr).windowLog =
@@ -3168,7 +3148,7 @@ unsafe fn ZSTDv06_decompressSequences(
         ptr::write_bytes(
             &mut sequence as *mut seq_t as *mut u8,
             0,
-            ::core::mem::size_of::<seq_t>(),
+            size_of::<seq_t>(),
         );
         sequence.offset = REPCODE_STARTVALUE as size_t;
         let mut i: u32 = 0;
@@ -3691,11 +3671,11 @@ unsafe fn ZSTDv06_decompressBegin_usingDict(
     0
 }
 pub(crate) unsafe fn ZBUFFv06_createDCtx() -> *mut ZBUFFv06_DCtx {
-    let zbd = malloc(::core::mem::size_of::<ZBUFFv06_DCtx>()) as *mut ZBUFFv06_DCtx;
+    let zbd = malloc(size_of::<ZBUFFv06_DCtx>()) as *mut ZBUFFv06_DCtx;
     if zbd.is_null() {
         return core::ptr::null_mut();
     }
-    ptr::write_bytes(zbd as *mut u8, 0, ::core::mem::size_of::<ZBUFFv06_DCtx>());
+    ptr::write_bytes(zbd as *mut u8, 0, size_of::<ZBUFFv06_DCtx>());
     (*zbd).zd = ZSTDv06_createDCtx();
     if ((*zbd).zd).is_null() {
         ZBUFFv06_freeDCtx(zbd);

--- a/lib/legacy/zstd_v06.rs
+++ b/lib/legacy/zstd_v06.rs
@@ -299,14 +299,14 @@ unsafe fn BITv06_initDStream(
 
 #[inline]
 unsafe fn BITv06_lookBits(bitD: *const BITv06_DStream_t, nbBits: u32) -> size_t {
-    let bitMask = (size_of::<size_t>()).wrapping_mul(8).wrapping_sub(1) as u32;
+    let bitMask = size_of::<size_t>().wrapping_mul(8).wrapping_sub(1) as u32;
     (*bitD).bitContainer << ((*bitD).bitsConsumed & bitMask)
         >> 1
         >> (bitMask.wrapping_sub(nbBits) & bitMask)
 }
 #[inline]
 unsafe fn BITv06_lookBitsFast(bitD: *const BITv06_DStream_t, nbBits: u32) -> size_t {
-    let bitMask = (size_of::<size_t>()).wrapping_mul(8).wrapping_sub(1) as u32;
+    let bitMask = size_of::<size_t>().wrapping_mul(8).wrapping_sub(1) as u32;
     (*bitD).bitContainer << ((*bitD).bitsConsumed & bitMask)
         >> (bitMask.wrapping_add(1).wrapping_sub(nbBits) & bitMask)
 }
@@ -328,7 +328,7 @@ unsafe fn BITv06_readBitsFast(bitD: *mut BITv06_DStream_t, nbBits: u32) -> size_
 }
 #[inline]
 unsafe fn BITv06_reloadDStream(bitD: *mut BITv06_DStream_t) -> BITv06_DStream_status {
-    if (*bitD).bitsConsumed as size_t > (size_of::<size_t>()).wrapping_mul(8) {
+    if (*bitD).bitsConsumed as size_t > size_of::<size_t>().wrapping_mul(8) {
         return BITv06_DStream_overflow;
     }
     if (*bitD).ptr >= ((*bitD).start).add(size_of::<size_t>()) {
@@ -338,7 +338,7 @@ unsafe fn BITv06_reloadDStream(bitD: *mut BITv06_DStream_t) -> BITv06_DStream_st
         return BITv06_DStream_unfinished;
     }
     if (*bitD).ptr == (*bitD).start {
-        if ((*bitD).bitsConsumed as size_t) < (size_of::<size_t>()).wrapping_mul(8) {
+        if ((*bitD).bitsConsumed as size_t) < size_of::<size_t>().wrapping_mul(8) {
             return BITv06_DStream_endOfBuffer;
         }
         return BITv06_DStream_completed;
@@ -357,7 +357,7 @@ unsafe fn BITv06_reloadDStream(bitD: *mut BITv06_DStream_t) -> BITv06_DStream_st
 #[inline]
 unsafe fn BITv06_endOfDStream(DStream: *const BITv06_DStream_t) -> core::ffi::c_uint {
     ((*DStream).ptr == (*DStream).start
-        && (*DStream).bitsConsumed as size_t == (size_of::<size_t>()).wrapping_mul(8))
+        && (*DStream).bitsConsumed as size_t == size_of::<size_t>().wrapping_mul(8))
         as core::ffi::c_int as core::ffi::c_uint
 }
 #[inline]
@@ -677,7 +677,7 @@ unsafe fn FSEv06_decompress_usingDTable_generic(
         } else {
             FSEv06_decodeSymbol(&mut state1, &mut bitD) as core::ffi::c_int
         }) as u8;
-        if (FSEv06_MAX_TABLELOG * 2 + 7) as size_t > (size_of::<size_t>()).wrapping_mul(8) {
+        if (FSEv06_MAX_TABLELOG * 2 + 7) as size_t > size_of::<size_t>().wrapping_mul(8) {
             BITv06_reloadDStream(&mut bitD);
         }
         *op.add(1) = (if fast != 0 {
@@ -685,7 +685,7 @@ unsafe fn FSEv06_decompress_usingDTable_generic(
         } else {
             FSEv06_decodeSymbol(&mut state2, &mut bitD) as core::ffi::c_int
         }) as u8;
-        if (FSEv06_MAX_TABLELOG * 4 + 7) as size_t > (size_of::<size_t>()).wrapping_mul(8)
+        if (FSEv06_MAX_TABLELOG * 4 + 7) as size_t > size_of::<size_t>().wrapping_mul(8)
             && BITv06_reloadDStream(&mut bitD) as core::ffi::c_uint
                 > BITv06_DStream_unfinished as core::ffi::c_int as core::ffi::c_uint
         {
@@ -697,7 +697,7 @@ unsafe fn FSEv06_decompress_usingDTable_generic(
         } else {
             FSEv06_decodeSymbol(&mut state1, &mut bitD) as core::ffi::c_int
         }) as u8;
-        if (FSEv06_MAX_TABLELOG * 2 + 7) as size_t > (size_of::<size_t>()).wrapping_mul(8) {
+        if (FSEv06_MAX_TABLELOG * 2 + 7) as size_t > size_of::<size_t>().wrapping_mul(8) {
             BITv06_reloadDStream(&mut bitD);
         }
         *op.add(3) = (if fast != 0 {
@@ -1561,10 +1561,10 @@ unsafe fn HUFv06_decodeLastSymbolX4(
     memcpy(op, dt.add(val) as *const core::ffi::c_void, 1);
     if (*dt.add(val)).length as core::ffi::c_int == 1 {
         BITv06_skipBits(DStream, (*dt.add(val)).nbBits as u32);
-    } else if ((*DStream).bitsConsumed as size_t) < (size_of::<size_t>()).wrapping_mul(8) {
+    } else if ((*DStream).bitsConsumed as size_t) < size_of::<size_t>().wrapping_mul(8) {
         BITv06_skipBits(DStream, (*dt.add(val)).nbBits as u32);
-        if (*DStream).bitsConsumed as size_t > (size_of::<size_t>()).wrapping_mul(8) {
-            (*DStream).bitsConsumed = (size_of::<size_t>()).wrapping_mul(8) as core::ffi::c_uint;
+        if (*DStream).bitsConsumed as size_t > size_of::<size_t>().wrapping_mul(8) {
+            (*DStream).bitsConsumed = size_of::<size_t>().wrapping_mul(8) as core::ffi::c_uint;
         }
     }
     1

--- a/lib/legacy/zstd_v07.rs
+++ b/lib/legacy/zstd_v07.rs
@@ -223,16 +223,12 @@ impl<'a> BITv07_DStream_t<'a> {
             return Err(Error::srcSize_wrong);
         }
 
-        if src.len() >= ::core::mem::size_of::<usize>() {
+        if src.len() >= size_of::<usize>() {
             // normal case
             let mut bitD = BITv07_DStream_t {
                 bitContainer: 0,
                 bitsConsumed: 0,
-                ptr: unsafe {
-                    src.as_ptr()
-                        .add(src.len())
-                        .sub(::core::mem::size_of::<usize>())
-                },
+                ptr: unsafe { src.as_ptr().add(src.len()).sub(size_of::<usize>()) },
                 start: src.as_ptr(),
                 _marker: PhantomData,
             };
@@ -294,7 +290,7 @@ impl<'a> BITv07_DStream_t<'a> {
                 // endMark not present
                 return Err(Error::GENERIC);
             }
-            bitD.bitsConsumed += (::core::mem::size_of::<usize>() - src.len()) as u32 * 8;
+            bitD.bitsConsumed += (size_of::<usize>() - src.len()) as u32 * 8;
 
             Ok(bitD)
         }

--- a/programs/benchfn.rs
+++ b/programs/benchfn.rs
@@ -91,7 +91,7 @@ unsafe fn BMK_runOutcome_error(errorResult: size_t) -> BMK_runOutcome_t {
     ptr::write_bytes(
         &mut b as *mut BMK_runOutcome_t as *mut u8,
         0,
-        ::core::mem::size_of::<BMK_runOutcome_t>(),
+        size_of::<BMK_runOutcome_t>(),
     );
     b.error_tag_never_ever_use_directly = 1;
     b.error_result_never_ever_use_directly = errorResult;
@@ -165,7 +165,7 @@ pub unsafe fn BMK_createTimedFnState(
     total_ms: core::ffi::c_uint,
     run_ms: core::ffi::c_uint,
 ) -> *mut BMK_timedFnState_t {
-    let r = malloc(::core::mem::size_of::<BMK_timedFnState_t>()) as *mut BMK_timedFnState_t;
+    let r = malloc(size_of::<BMK_timedFnState_t>()) as *mut BMK_timedFnState_t;
     if r.is_null() {
         return core::ptr::null_mut();
     }
@@ -186,7 +186,7 @@ pub unsafe fn BMK_initStatic_timedFnState(
     if buffer.is_null() {
         return core::ptr::null_mut();
     }
-    if size < ::core::mem::size_of::<BMK_timedFnState_s>() {
+    if size < size_of::<BMK_timedFnState_s>() {
         return core::ptr::null_mut();
     }
     if !(buffer as size_t).is_multiple_of(tfs_alignment) {

--- a/programs/benchzstd.rs
+++ b/programs/benchzstd.rs
@@ -95,10 +95,10 @@ pub const MB_UNIT: core::ffi::c_int = 1000000;
 pub const TIMELOOP_NANOSEC: core::ffi::c_ulonglong =
     (1 as core::ffi::c_ulonglong).wrapping_mul(1000000000);
 pub const BMK_RUNTEST_DEFAULT_MS: core::ffi::c_int = 1000;
-static maxMemory: usize = if ::core::mem::size_of::<size_t>() == 4 {
+static maxMemory: usize = if size_of::<size_t>() == 4 {
     2 * (1 << 30) - 64 * (1 << 20)
 } else {
-    1usize << (::core::mem::size_of::<usize>() * 8 - 31)
+    1usize << (size_of::<usize>() * 8 - 31)
 };
 pub const DEBUG: core::ffi::c_int = 0;
 unsafe fn uintSize(mut value: core::ffi::c_uint) -> size_t {
@@ -747,7 +747,7 @@ unsafe fn BMK_benchOutcome_error() -> BMK_benchOutcome_t {
     ptr::write_bytes(
         &mut b as *mut BMK_benchOutcome_t as *mut u8,
         0,
-        ::core::mem::size_of::<BMK_benchOutcome_t>(),
+        size_of::<BMK_benchOutcome_t>(),
     );
     b.tag = 1;
     b
@@ -817,7 +817,7 @@ unsafe fn BMK_benchMemAdvancedNoAlloc(
     ptr::write_bytes(
         &mut benchResult as *mut BMK_benchResult_t as *mut u8,
         0,
-        ::core::mem::size_of::<BMK_benchResult_t>(),
+        size_of::<BMK_benchResult_t>(),
     );
     if strlen(displayName) > 17 {
         displayName = displayName.add((strlen(displayName)).wrapping_sub(17));
@@ -845,7 +845,7 @@ unsafe fn BMK_benchMemAdvancedNoAlloc(
                 ptr::write_bytes(
                     &mut r as *mut BMK_benchOutcome_t as *mut u8,
                     0,
-                    ::core::mem::size_of::<BMK_benchOutcome_t>(),
+                    size_of::<BMK_benchOutcome_t>(),
                 );
                 if displayLevel >= 1 {
                     fprintf(
@@ -883,7 +883,7 @@ unsafe fn BMK_benchMemAdvancedNoAlloc(
                 ptr::write_bytes(
                     &mut r_0 as *mut BMK_benchOutcome_t as *mut u8,
                     0,
-                    ::core::mem::size_of::<BMK_benchOutcome_t>(),
+                    size_of::<BMK_benchOutcome_t>(),
                 );
                 if displayLevel >= 1 {
                     fprintf(
@@ -928,7 +928,7 @@ unsafe fn BMK_benchMemAdvancedNoAlloc(
             ptr::write_bytes(
                 &mut r_1 as *mut BMK_benchOutcome_t as *mut u8,
                 0,
-                ::core::mem::size_of::<BMK_benchOutcome_t>(),
+                size_of::<BMK_benchOutcome_t>(),
             );
             if displayLevel >= 1 {
                 fprintf(
@@ -967,7 +967,7 @@ unsafe fn BMK_benchMemAdvancedNoAlloc(
             ptr::write_bytes(
                 &mut r_2 as *mut BMK_benchOutcome_t as *mut u8,
                 0,
-                ::core::mem::size_of::<BMK_benchOutcome_t>(),
+                size_of::<BMK_benchOutcome_t>(),
             );
             if displayLevel >= 1 {
                 fprintf(
@@ -1211,7 +1211,7 @@ unsafe fn BMK_benchMemAdvancedNoAlloc(
                 ptr::write_bytes(
                     &mut r_3 as *mut BMK_benchOutcome_t as *mut u8,
                     0,
-                    ::core::mem::size_of::<BMK_benchOutcome_t>(),
+                    size_of::<BMK_benchOutcome_t>(),
                 );
                 if displayLevel >= 1 {
                     fprintf(
@@ -1291,7 +1291,7 @@ unsafe fn BMK_benchMemAdvancedNoAlloc(
                 ptr::write_bytes(
                     &mut r_4 as *mut BMK_benchOutcome_t as *mut u8,
                     0,
-                    ::core::mem::size_of::<BMK_benchOutcome_t>(),
+                    size_of::<BMK_benchOutcome_t>(),
                 );
                 if displayLevel >= 1 {
                     fprintf(
@@ -1552,23 +1552,17 @@ pub unsafe fn BMK_benchMemAdvanced(
     .wrapping_add((srcSize == 0) as core::ffi::c_int as size_t);
     let nbChunksMax = ((srcSize.wrapping_add(chunkSize.wrapping_sub(1)) / chunkSize) as u32)
         .wrapping_add(nbFiles);
-    let srcPtrs = malloc(
-        (nbChunksMax as size_t).wrapping_mul(::core::mem::size_of::<*mut core::ffi::c_void>()),
-    ) as *mut *const core::ffi::c_void;
-    let srcSizes = malloc((nbChunksMax as size_t).wrapping_mul(::core::mem::size_of::<size_t>()))
-        as *mut size_t;
-    let cPtrs = malloc(
-        (nbChunksMax as size_t).wrapping_mul(::core::mem::size_of::<*mut core::ffi::c_void>()),
-    ) as *mut *mut core::ffi::c_void;
-    let cSizes = malloc((nbChunksMax as size_t).wrapping_mul(::core::mem::size_of::<size_t>()))
-        as *mut size_t;
-    let cCapacities = malloc((nbChunksMax as size_t).wrapping_mul(::core::mem::size_of::<size_t>()))
-        as *mut size_t;
-    let resPtrs = malloc(
-        (nbChunksMax as size_t).wrapping_mul(::core::mem::size_of::<*mut core::ffi::c_void>()),
-    ) as *mut *mut core::ffi::c_void;
-    let resSizes = malloc((nbChunksMax as size_t).wrapping_mul(::core::mem::size_of::<size_t>()))
-        as *mut size_t;
+    let srcPtrs = malloc((nbChunksMax as size_t).wrapping_mul(size_of::<*mut core::ffi::c_void>()))
+        as *mut *const core::ffi::c_void;
+    let srcSizes = malloc((nbChunksMax as size_t).wrapping_mul(size_of::<size_t>())) as *mut size_t;
+    let cPtrs = malloc((nbChunksMax as size_t).wrapping_mul(size_of::<*mut core::ffi::c_void>()))
+        as *mut *mut core::ffi::c_void;
+    let cSizes = malloc((nbChunksMax as size_t).wrapping_mul(size_of::<size_t>())) as *mut size_t;
+    let cCapacities =
+        malloc((nbChunksMax as size_t).wrapping_mul(size_of::<size_t>())) as *mut size_t;
+    let resPtrs = malloc((nbChunksMax as size_t).wrapping_mul(size_of::<*mut core::ffi::c_void>()))
+        as *mut *mut core::ffi::c_void;
+    let resSizes = malloc((nbChunksMax as size_t).wrapping_mul(size_of::<size_t>())) as *mut size_t;
     let timeStateCompress = BMK_createTimedFnState(
         ((*adv).nbSeconds).wrapping_mul(1000),
         BMK_RUNTEST_DEFAULT_MS as core::ffi::c_uint,
@@ -1668,7 +1662,7 @@ pub unsafe fn BMK_benchMemAdvanced(
         ptr::write_bytes(
             &mut r as *mut BMK_benchOutcome_t as *mut u8,
             0,
-            ::core::mem::size_of::<BMK_benchOutcome_t>(),
+            size_of::<BMK_benchOutcome_t>(),
         );
         if displayLevel >= 1 {
             fprintf(
@@ -1705,7 +1699,7 @@ pub unsafe fn BMK_benchMemAdvanced(
         ptr::write_bytes(
             &mut r_0 as *mut BMK_benchOutcome_t as *mut u8,
             0,
-            ::core::mem::size_of::<BMK_benchOutcome_t>(),
+            size_of::<BMK_benchOutcome_t>(),
         );
         if displayLevel >= 1 {
             fprintf(
@@ -1884,7 +1878,7 @@ pub unsafe fn BMK_syntheticTest(
         RDG_genBuffer(srcBuffer, benchedSize, compressibility, 0.0f64, 0);
         formatString_u(
             nameBuff.as_mut_ptr(),
-            ::core::mem::size_of::<[core::ffi::c_char; 20]>(),
+            size_of::<[core::ffi::c_char; 20]>(),
             b"Synthetic %u%%\0" as *const u8 as *const core::ffi::c_char,
             (compressibility * 100.0) as core::ffi::c_uint,
         );
@@ -2097,7 +2091,7 @@ pub unsafe fn BMK_benchFilesAdvanced(
         return 15;
     }
 
-    fileSizes = calloc(nbFiles as size_t, ::core::mem::size_of::<size_t>()) as *mut size_t;
+    fileSizes = calloc(nbFiles as size_t, size_of::<size_t>()) as *mut size_t;
     if fileSizes.is_null() {
         if displayLevel >= 1 {
             eprintln!("not enough memory for fileSizes");
@@ -2203,7 +2197,7 @@ pub unsafe fn BMK_benchFilesAdvanced(
         let mut mfName: [core::ffi::c_char; 20] = [0; 20];
         formatString_u(
             mfName.as_mut_ptr(),
-            ::core::mem::size_of::<[core::ffi::c_char; 20]>(),
+            size_of::<[core::ffi::c_char; 20]>(),
             c" %u files".as_ptr(),
             nbFiles,
         );

--- a/programs/datagen.rs
+++ b/programs/datagen.rs
@@ -154,11 +154,7 @@ pub unsafe fn RDG_genBuffer(
 ) {
     let mut seed32 = seed;
     let mut ldt: [u8; 8192] = [0; 8192];
-    ptr::write_bytes(
-        ldt.as_mut_ptr() as *mut u8,
-        b'0',
-        ::core::mem::size_of::<[u8; 8192]>(),
-    );
+    ptr::write_bytes(ldt.as_mut_ptr() as *mut u8, b'0', size_of::<[u8; 8192]>());
     if litProba <= 0.0f64 {
         litProba = matchProba / 4.5f64;
     }
@@ -187,11 +183,7 @@ pub unsafe fn RDG_genStdout(
     if litProba <= 0.0f64 {
         litProba = matchProba / 4.5f64;
     }
-    ptr::write_bytes(
-        ldt.as_mut_ptr() as *mut u8,
-        b'0',
-        ::core::mem::size_of::<[u8; 8192]>(),
-    );
+    ptr::write_bytes(ldt.as_mut_ptr() as *mut u8, b'0', size_of::<[u8; 8192]>());
     RDG_fillLiteralDistrib(
         ldt.as_mut_ptr(),
         (litProba * 256.0 + 0.001f64) as fixedPoint_24_8,

--- a/programs/dibio.rs
+++ b/programs/dibio.rs
@@ -30,10 +30,10 @@ pub const SAMPLESIZE_MAX: core::ffi::c_int = 128 * ((1) << 10);
 pub const MEMMULT: core::ffi::c_int = 11;
 pub const COVER_MEMMULT: core::ffi::c_int = 9;
 pub const FASTCOVER_MEMMULT: core::ffi::c_int = 1;
-static g_maxMemory: usize = if ::core::mem::size_of::<size_t>() == 4 {
+static g_maxMemory: usize = if size_of::<size_t>() == 4 {
     2usize * (1 << 30) - 64 * (1 << 20)
 } else {
-    (512usize * (1 << 20)) << ::core::mem::size_of::<size_t>()
+    (512usize * (1 << 20)) << size_of::<size_t>()
 };
 pub const NOISELENGTH: core::ffi::c_int = 32;
 static g_refreshRate: u64 = SEC_TO_MICRO as PTime / 6;
@@ -323,7 +323,7 @@ unsafe fn DiB_fileStats(
     ptr::write_bytes(
         &mut fs as *mut fileStats as *mut u8,
         0,
-        ::core::mem::size_of::<fileStats>(),
+        size_of::<fileStats>(),
     );
     n = 0;
     while n < nbFiles {
@@ -460,8 +460,7 @@ pub unsafe fn DiB_trainFromFiles(
         };
     }
     srcBuffer = malloc(loadedSize.wrapping_add(NOISELENGTH as size_t));
-    sampleSizes = malloc((fs.nbSamples as size_t).wrapping_mul(::core::mem::size_of::<size_t>()))
-        as *mut size_t;
+    sampleSizes = malloc((fs.nbSamples as size_t).wrapping_mul(size_of::<size_t>())) as *mut size_t;
     if fs.nbSamples != 0 && sampleSizes.is_null() || srcBuffer.is_null() || dictBuffer.is_null() {
         fprintf(
             stderr,

--- a/programs/fileio.rs
+++ b/programs/fileio.rs
@@ -390,7 +390,7 @@ unsafe fn FIO_shouldDisplayMultipleFileSummary(fCtx: *const FIO_ctx_t) -> core::
 pub const FIO_OVERLAP_LOG_NOTSET: core::ffi::c_int = 9999;
 pub const FIO_LDM_PARAM_NOTSET: core::ffi::c_int = 9999;
 pub unsafe fn FIO_createPreferences() -> *mut FIO_prefs_t {
-    let ret = malloc(::core::mem::size_of::<FIO_prefs_t>()) as *mut FIO_prefs_t;
+    let ret = malloc(size_of::<FIO_prefs_t>()) as *mut FIO_prefs_t;
     if ret.is_null() {
         if g_display_prefs.displayLevel >= 1 {
             fprintf(stderr, b"zstd: \0" as *const u8 as *const core::ffi::c_char);
@@ -452,7 +452,7 @@ pub unsafe fn FIO_createPreferences() -> *mut FIO_prefs_t {
     ret
 }
 pub unsafe fn FIO_createContext() -> *mut FIO_ctx_t {
-    let ret = malloc(::core::mem::size_of::<FIO_ctx_t>()) as *mut FIO_ctx_t;
+    let ret = malloc(size_of::<FIO_ctx_t>()) as *mut FIO_ctx_t;
     if ret.is_null() {
         if g_display_prefs.displayLevel >= 1 {
             fprintf(stderr, b"zstd: \0" as *const u8 as *const core::ffi::c_char);
@@ -1360,7 +1360,7 @@ pub unsafe fn FIO_checkFilenameCollisions(
     let mut filename = core::ptr::null::<core::ffi::c_char>();
     let mut u: core::ffi::c_uint = 0;
     filenameTableSorted =
-        malloc((::core::mem::size_of::<*mut core::ffi::c_char>()).wrapping_mul(nbFiles as size_t))
+        malloc((size_of::<*mut core::ffi::c_char>()).wrapping_mul(nbFiles as size_t))
             as *mut *const core::ffi::c_char;
     if filenameTableSorted.is_null() {
         if g_display_prefs.displayLevel >= 1 {
@@ -1387,7 +1387,7 @@ pub unsafe fn FIO_checkFilenameCollisions(
     qsort(
         filenameTableSorted as *mut core::ffi::c_void,
         nbFiles as size_t,
-        ::core::mem::size_of::<*mut core::ffi::c_char>(),
+        size_of::<*mut core::ffi::c_char>(),
         Some(
             UTIL_compareStr
                 as unsafe extern "C" fn(
@@ -1525,7 +1525,7 @@ unsafe fn FIO_adjustMemLimitForPatchFromMode(
         maxSrcFileSize
     };
     let maxWindowSize = (1 as core::ffi::c_uint)
-        << (if ::core::mem::size_of::<size_t>() == 4 {
+        << (if size_of::<size_t>() == 4 {
             ZSTD_WINDOWLOG_MAX_32
         } else {
             ZSTD_WINDOWLOG_MAX_64
@@ -1780,7 +1780,7 @@ unsafe fn FIO_adjustParamsForPatchFromMode(
     );
     FIO_adjustMemLimitForPatchFromMode(prefs, dictSize, maxSrcFileSize);
     if fileWindowLog
-        > (if ::core::mem::size_of::<size_t>() == 4 {
+        > (if size_of::<size_t>() == 4 {
             ZSTD_WINDOWLOG_MAX_32
         } else {
             ZSTD_WINDOWLOG_MAX_64
@@ -1794,34 +1794,18 @@ unsafe fn FIO_adjustParamsForPatchFromMode(
         );
     }
     (*comprParams).windowLog = if 10
-        > (if ((if ::core::mem::size_of::<size_t>() == 4 {
-            30
-        } else {
-            31
-        }) as core::ffi::c_uint)
+        > (if ((if size_of::<size_t>() == 4 { 30 } else { 31 }) as core::ffi::c_uint)
             < fileWindowLog
         {
-            (if ::core::mem::size_of::<size_t>() == 4 {
-                30
-            } else {
-                31
-            }) as core::ffi::c_uint
+            (if size_of::<size_t>() == 4 { 30 } else { 31 }) as core::ffi::c_uint
         } else {
             fileWindowLog
         }) {
         10
-    } else if ((if ::core::mem::size_of::<size_t>() == 4 {
-        30
-    } else {
-        31
-    }) as core::ffi::c_uint)
+    } else if ((if size_of::<size_t>() == 4 { 30 } else { 31 }) as core::ffi::c_uint)
         < fileWindowLog
     {
-        (if ::core::mem::size_of::<size_t>() == 4 {
-            30
-        } else {
-            31
-        }) as core::ffi::c_uint
+        (if size_of::<size_t>() == 4 { 30 } else { 31 }) as core::ffi::c_uint
     } else {
         fileWindowLog
     };
@@ -1855,11 +1839,7 @@ unsafe fn FIO_adjustParamsForPatchFromMode(
                 stderr,
                 b"- Set a larger chainLog (e.g. --zstd=chainLog=%u)\n\0" as *const u8
                     as *const core::ffi::c_char,
-                if ::core::mem::size_of::<size_t>() == 4 {
-                    29
-                } else {
-                    30
-                },
+                if size_of::<size_t>() == 4 { 29 } else { 30 },
             );
         }
         if g_display_prefs.displayLevel >= 4 {
@@ -1867,13 +1847,8 @@ unsafe fn FIO_adjustParamsForPatchFromMode(
                 stderr,
                 b"- Set a larger LDM hashLog (e.g. --zstd=ldmHashLog=%u)\n\0" as *const u8
                     as *const core::ffi::c_char,
-                if (if ::core::mem::size_of::<size_t>() == 4 {
-                    30
-                } else {
-                    31
-                }) < 30
-                {
-                    if ::core::mem::size_of::<size_t>() == 4 {
+                if (if size_of::<size_t>() == 4 { 30 } else { 31 }) < 30 {
+                    if size_of::<size_t>() == 4 {
                         30
                     } else {
                         31
@@ -1951,7 +1926,7 @@ unsafe fn FIO_createCResources(
     ptr::write_bytes(
         &mut ress as *mut cRess_t as *mut u8,
         0,
-        ::core::mem::size_of::<cRess_t>(),
+        size_of::<cRess_t>(),
     );
     if g_display_prefs.displayLevel >= 6 {
         fprintf(
@@ -3322,7 +3297,7 @@ unsafe fn FIO_compressGzFrame(
         8,
         0,
         ZLIB_VERSION.as_ptr(),
-        ::core::mem::size_of::<z_stream>() as core::ffi::c_int,
+        size_of::<z_stream>() as core::ffi::c_int,
     );
     if ret != Z_OK {
         if g_display_prefs.displayLevel >= 1 {
@@ -5479,12 +5454,12 @@ unsafe fn FIO_createDResources(
     ptr::write_bytes(
         &mut statbuf as *mut stat_t as *mut u8,
         0,
-        ::core::mem::size_of::<stat_t>(),
+        size_of::<stat_t>(),
     );
     ptr::write_bytes(
         &mut ress as *mut dRess_t as *mut u8,
         0,
-        ::core::mem::size_of::<dRess_t>(),
+        size_of::<dRess_t>(),
     );
     FIO_getDictFileStat(dictFileName, &mut statbuf);
     if (*prefs).patchFromMode != 0 {
@@ -5882,7 +5857,7 @@ unsafe fn FIO_zstdErrorHelp(
             );
         }
         if windowLog
-            <= (if ::core::mem::size_of::<size_t>() == 4 {
+            <= (if size_of::<size_t>() == 4 {
                 ZSTD_WINDOWLOG_MAX_32
             } else {
                 ZSTD_WINDOWLOG_MAX_64
@@ -5912,11 +5887,7 @@ unsafe fn FIO_zstdErrorHelp(
             b"%s : Window log larger than ZSTD_WINDOWLOG_MAX=%u; not supported \n\0" as *const u8
                 as *const core::ffi::c_char,
             srcFileName,
-            if ::core::mem::size_of::<size_t>() == 4 {
-                30
-            } else {
-                31
-            },
+            if size_of::<size_t>() == 4 { 30 } else { 31 },
         );
     }
 }
@@ -6077,7 +6048,7 @@ unsafe fn FIO_decompressGzFrame(
         &mut strm,
         15 + 16,
         ZLIB_VERSION.as_ptr(),
-        ::core::mem::size_of::<z_stream>() as core::ffi::c_int,
+        size_of::<z_stream>() as core::ffi::c_int,
     ) != Z_OK
     {
         return FIO_ERROR_FRAME_DECODING as core::ffi::c_ulonglong;
@@ -6867,7 +6838,7 @@ unsafe fn FIO_analyzeFrames(info: *mut fileInfo_t, srcFile: *mut FILE) -> InfoEr
         let numBytesRead = fread(
             headerBuffer.as_mut_ptr() as *mut core::ffi::c_void,
             1,
-            ::core::mem::size_of::<[u8; 18]>(),
+            size_of::<[u8; 18]>(),
             srcFile,
         );
         if numBytesRead
@@ -7340,7 +7311,7 @@ unsafe fn FIO_addFInfo(fi1: fileInfo_t, fi2: fileInfo_t) -> fileInfo_t {
     ptr::write_bytes(
         &mut total as *mut fileInfo_t as *mut u8,
         0,
-        ::core::mem::size_of::<fileInfo_t>(),
+        size_of::<fileInfo_t>(),
     );
     total.numActualFrames = fi1.numActualFrames + fi2.numActualFrames;
     total.numSkippableFrames = fi1.numSkippableFrames + fi2.numSkippableFrames;
@@ -7371,7 +7342,7 @@ unsafe fn FIO_listFile(
     ptr::write_bytes(
         &mut info as *mut fileInfo_t as *mut u8,
         0,
-        ::core::mem::size_of::<fileInfo_t>(),
+        size_of::<fileInfo_t>(),
     );
     let error = getFileInfo(&mut info, inFileName);
     match error as core::ffi::c_uint {
@@ -7489,7 +7460,7 @@ pub unsafe fn FIO_listMultipleFiles(
     ptr::write_bytes(
         &mut total as *mut fileInfo_t as *mut u8,
         0,
-        ::core::mem::size_of::<fileInfo_t>(),
+        size_of::<fileInfo_t>(),
     );
     total.usesCheck = 1;
     let mut u_0: core::ffi::c_uint = 0;

--- a/programs/fileio.rs
+++ b/programs/fileio.rs
@@ -1360,7 +1360,7 @@ pub unsafe fn FIO_checkFilenameCollisions(
     let mut filename = core::ptr::null::<core::ffi::c_char>();
     let mut u: core::ffi::c_uint = 0;
     filenameTableSorted =
-        malloc((size_of::<*mut core::ffi::c_char>()).wrapping_mul(nbFiles as size_t))
+        malloc(size_of::<*mut core::ffi::c_char>().wrapping_mul(nbFiles as size_t))
             as *mut *const core::ffi::c_char;
     if filenameTableSorted.is_null() {
         if g_display_prefs.displayLevel >= 1 {

--- a/programs/fileio_asyncio.rs
+++ b/programs/fileio_asyncio.rs
@@ -117,8 +117,8 @@ pub struct IOJob_t {
 }
 pub const SEEK_CUR: core::ffi::c_int = 1;
 pub const MAX_IO_JOBS: core::ffi::c_int = 10;
-static segmentSizeT: usize = 32usize * (1 << 10) / ::core::mem::size_of::<size_t>();
-static maskT: usize = ::core::mem::size_of::<size_t>() - 1;
+static segmentSizeT: usize = 32usize * (1 << 10) / size_of::<size_t>();
+static maskT: usize = size_of::<size_t>() - 1;
 unsafe fn AIO_fwriteSparse(
     file: *mut FILE,
     buffer: *const core::ffi::c_void,
@@ -127,7 +127,7 @@ unsafe fn AIO_fwriteSparse(
     mut storedSkips: core::ffi::c_uint,
 ) -> core::ffi::c_uint {
     let bufferT = buffer as *const size_t;
-    let mut bufferSizeT = bufferSize.wrapping_div(::core::mem::size_of::<size_t>());
+    let mut bufferSizeT = bufferSize.wrapping_div(size_of::<size_t>());
     let bufferTEnd = bufferT.add(bufferSizeT);
     let mut ptrT = bufferT;
     if (*prefs).testMode != 0 {
@@ -216,8 +216,8 @@ unsafe fn AIO_fwriteSparse(
         while nb0T < seg0SizeT && *ptrT.add(nb0T) == 0 {
             nb0T = nb0T.wrapping_add(1);
         }
-        storedSkips = storedSkips
-            .wrapping_add(nb0T.wrapping_mul(::core::mem::size_of::<size_t>()) as core::ffi::c_uint);
+        storedSkips =
+            storedSkips.wrapping_add(nb0T.wrapping_mul(size_of::<size_t>()) as core::ffi::c_uint);
         if nb0T != seg0SizeT {
             let nbNon0ST = seg0SizeT.wrapping_sub(nb0T);
             if fseek(file, storedSkips as core::ffi::c_long, SEEK_CUR) != 0 {
@@ -255,7 +255,7 @@ unsafe fn AIO_fwriteSparse(
             storedSkips = 0;
             if fwrite(
                 ptrT.add(nb0T) as *const core::ffi::c_void,
-                ::core::mem::size_of::<size_t>(),
+                size_of::<size_t>(),
                 nbNon0ST,
                 file,
             ) != nbNon0ST
@@ -294,7 +294,7 @@ unsafe fn AIO_fwriteSparse(
         let restStart = bufferTEnd as *const core::ffi::c_char;
         let mut restPtr = restStart;
         let restEnd = (buffer as *const core::ffi::c_char).add(bufferSize);
-        assert!(restEnd > restStart && restEnd < restStart.add(::core::mem::size_of::<size_t>()));
+        assert!(restEnd > restStart && restEnd < restStart.add(size_of::<size_t>()));
         while restPtr < restEnd && *restPtr as core::ffi::c_int == 0 {
             restPtr = restPtr.offset(1);
         }
@@ -453,7 +453,7 @@ pub unsafe fn AIO_supported() -> core::ffi::c_int {
     1
 }
 unsafe fn AIO_IOPool_createIoJob(ctx: *mut IOPoolCtx_t, bufferSize: size_t) -> *mut IOJob_t {
-    let job = malloc(::core::mem::size_of::<IOJob_t>()) as *mut IOJob_t;
+    let job = malloc(size_of::<IOJob_t>()) as *mut IOJob_t;
     let buffer = malloc(bufferSize);
     if job.is_null() || buffer.is_null() {
         if g_display_prefs.displayLevel >= 1 {
@@ -726,7 +726,7 @@ pub unsafe fn AIO_WritePool_create(
     prefs: *const FIO_prefs_t,
     bufferSize: size_t,
 ) -> *mut WritePoolCtx_t {
-    let ctx = malloc(::core::mem::size_of::<WritePoolCtx_t>()) as *mut WritePoolCtx_t;
+    let ctx = malloc(size_of::<WritePoolCtx_t>()) as *mut WritePoolCtx_t;
     if ctx.is_null() {
         if g_display_prefs.displayLevel >= 1 {
             fprintf(stderr, b"zstd: \0" as *const u8 as *const core::ffi::c_char);
@@ -951,7 +951,7 @@ pub unsafe fn AIO_ReadPool_create(
     prefs: *const FIO_prefs_t,
     bufferSize: size_t,
 ) -> *mut ReadPoolCtx_t {
-    let ctx = malloc(::core::mem::size_of::<ReadPoolCtx_t>()) as *mut ReadPoolCtx_t;
+    let ctx = malloc(size_of::<ReadPoolCtx_t>()) as *mut ReadPoolCtx_t;
     if ctx.is_null() {
         if g_display_prefs.displayLevel >= 1 {
             fprintf(stderr, b"zstd: \0" as *const u8 as *const core::ffi::c_char);

--- a/programs/util.rs
+++ b/programs/util.rs
@@ -1300,8 +1300,7 @@ unsafe fn UTIL_createLinePointers(
 ) -> *mut *const core::ffi::c_char {
     let mut lineIndex = 0;
     let mut pos = 0;
-    let bufferPtrs =
-        malloc(numLines.wrapping_mul(::core::mem::size_of::<*mut *const core::ffi::c_char>()));
+    let bufferPtrs = malloc(numLines.wrapping_mul(size_of::<*mut *const core::ffi::c_char>()));
     let linePointers = bufferPtrs as *mut *const core::ffi::c_char;
     if bufferPtrs.is_null() {
         return core::ptr::null_mut();
@@ -1396,7 +1395,7 @@ unsafe fn UTIL_assembleFileNamesTable2(
     tableCapacity: size_t,
     buf: *mut core::ffi::c_char,
 ) -> *mut FileNamesTable {
-    let table = malloc(::core::mem::size_of::<FileNamesTable>()) as *mut FileNamesTable;
+    let table = malloc(size_of::<FileNamesTable>()) as *mut FileNamesTable;
     if table.is_null() {
         if g_utilDisplayLevel >= 1 {
             fprintf(
@@ -1431,7 +1430,7 @@ pub unsafe fn UTIL_freeFileNamesTable(table: *mut FileNamesTable) {
     free(table as *mut core::ffi::c_void);
 }
 pub unsafe fn UTIL_allocateFileNamesTable(tableSize: size_t) -> *mut FileNamesTable {
-    let fnTable = malloc(tableSize.wrapping_mul(::core::mem::size_of::<*const core::ffi::c_char>()))
+    let fnTable = malloc(tableSize.wrapping_mul(size_of::<*const core::ffi::c_char>()))
         as *mut *const core::ffi::c_char;
     let mut fnt = core::ptr::null_mut::<FileNamesTable>();
     if fnTable.is_null() {
@@ -1494,10 +1493,7 @@ pub unsafe fn UTIL_mergeFileNamesTable(
         exit(1);
     }
     newTotalTableSize = (getTotalTableSize(table1)).wrapping_add(getTotalTableSize(table2));
-    buf = calloc(
-        newTotalTableSize,
-        ::core::mem::size_of::<core::ffi::c_char>(),
-    ) as *mut core::ffi::c_char;
+    buf = calloc(newTotalTableSize, size_of::<core::ffi::c_char>()) as *mut core::ffi::c_char;
     if buf.is_null() {
         if g_utilDisplayLevel >= 1 {
             fprintf(
@@ -1512,10 +1508,8 @@ pub unsafe fn UTIL_mergeFileNamesTable(
     }
     (*newTable).buf = buf;
     (*newTable).tableSize = ((*table1).tableSize).wrapping_add((*table2).tableSize);
-    (*newTable).fileNames = calloc(
-        (*newTable).tableSize,
-        ::core::mem::size_of::<*const core::ffi::c_char>(),
-    ) as *mut *const core::ffi::c_char;
+    (*newTable).fileNames = calloc((*newTable).tableSize, size_of::<*const core::ffi::c_char>())
+        as *mut *const core::ffi::c_char;
     if ((*newTable).fileNames).is_null() {
         if g_utilDisplayLevel >= 1 {
             fprintf(
@@ -1983,9 +1977,8 @@ unsafe fn makeUniqueMirroredDestDirs(
     if nbFile == 0 {
         return;
     }
-    uniqueDirNames =
-        malloc((nbFile as size_t).wrapping_mul(::core::mem::size_of::<*mut core::ffi::c_char>()))
-            as *mut *mut core::ffi::c_char;
+    uniqueDirNames = malloc((nbFile as size_t).wrapping_mul(size_of::<*mut core::ffi::c_char>()))
+        as *mut *mut core::ffi::c_char;
     if uniqueDirNames.is_null() {
         if g_utilDisplayLevel >= 1 {
             fprintf(
@@ -2001,7 +1994,7 @@ unsafe fn makeUniqueMirroredDestDirs(
     qsort(
         srcDirNames as *mut core::ffi::c_void,
         nbFile as size_t,
-        ::core::mem::size_of::<*mut core::ffi::c_char>(),
+        size_of::<*mut core::ffi::c_char>(),
         Some(
             compareDir
                 as unsafe extern "C" fn(
@@ -2047,9 +2040,8 @@ pub unsafe fn UTIL_mirrorSourceFilesDirectories(
 ) {
     let mut i = 0;
     let mut validFilenamesNr = 0 as core::ffi::c_uint;
-    let srcFileNames =
-        malloc((nbFile as size_t).wrapping_mul(::core::mem::size_of::<*mut core::ffi::c_char>()))
-            as *mut *mut core::ffi::c_char;
+    let srcFileNames = malloc((nbFile as size_t).wrapping_mul(size_of::<*mut core::ffi::c_char>()))
+        as *mut *mut core::ffi::c_char;
     if srcFileNames.is_null() {
         if g_utilDisplayLevel >= 1 {
             fprintf(
@@ -2152,9 +2144,8 @@ pub unsafe fn UTIL_createExpandedFNT(
     let mut ifnNb_0: size_t = 0;
     let mut pos_0: size_t = 0;
     let fntCapacity = nbFiles.wrapping_add(1) as size_t;
-    let fileNamesTable =
-        malloc(fntCapacity.wrapping_mul(::core::mem::size_of::<*const core::ffi::c_char>()))
-            as *mut *const core::ffi::c_char;
+    let fileNamesTable = malloc(fntCapacity.wrapping_mul(size_of::<*const core::ffi::c_char>()))
+        as *mut *const core::ffi::c_char;
     if fileNamesTable.is_null() {
         free(buf as *mut core::ffi::c_void);
         return core::ptr::null_mut();
@@ -2196,8 +2187,7 @@ pub unsafe fn UTIL_createFNT_fromROTable(
     filenames: *mut *const core::ffi::c_char,
     nbFilenames: size_t,
 ) -> *mut FileNamesTable {
-    let sizeof_FNTable =
-        nbFilenames.wrapping_mul(::core::mem::size_of::<*const core::ffi::c_char>());
+    let sizeof_FNTable = nbFilenames.wrapping_mul(size_of::<*const core::ffi::c_char>());
     let newFNTable = malloc(sizeof_FNTable) as *mut *const core::ffi::c_char;
     if newFNTable.is_null() {
         return core::ptr::null_mut();

--- a/programs/zstdcli.rs
+++ b/programs/zstdcli.rs
@@ -329,7 +329,7 @@ unsafe fn usageAdvanced(programName: *const core::ffi::c_char) {
         stdout,
         b"*** %s (%i-bit) %s, by %s ***\n\0" as *const u8 as *const core::ffi::c_char,
         b"Zstandard CLI\0" as *const u8 as *const core::ffi::c_char,
-        (::core::mem::size_of::<size_t>()).wrapping_mul(8) as core::ffi::c_int,
+        (size_of::<size_t>()).wrapping_mul(8) as core::ffi::c_int,
         b"v1.5.8\0" as *const u8 as *const core::ffi::c_char,
         b"Yann Collet\0" as *const u8 as *const core::ffi::c_char,
     );
@@ -865,11 +865,7 @@ unsafe fn parseCoverParameters(
     mut stringPtr: *const core::ffi::c_char,
     params: *mut ZDICT_cover_params_t,
 ) -> core::ffi::c_uint {
-    ptr::write_bytes(
-        params as *mut u8,
-        0,
-        ::core::mem::size_of::<ZDICT_cover_params_t>(),
-    );
+    ptr::write_bytes(params as *mut u8, 0, size_of::<ZDICT_cover_params_t>());
     loop {
         if longCommandWArg(
             &mut stringPtr,
@@ -952,11 +948,7 @@ unsafe fn parseFastCoverParameters(
     mut stringPtr: *const core::ffi::c_char,
     params: *mut ZDICT_fastCover_params_t,
 ) -> core::ffi::c_uint {
-    ptr::write_bytes(
-        params as *mut u8,
-        0,
-        ::core::mem::size_of::<ZDICT_fastCover_params_t>(),
-    );
+    ptr::write_bytes(params as *mut u8, 0, size_of::<ZDICT_fastCover_params_t>());
     loop {
         if longCommandWArg(
             &mut stringPtr,
@@ -1347,23 +1339,23 @@ unsafe fn parseCompressionParameters(
     1
 }
 unsafe fn setMaxCompression(params: *mut ZSTD_compressionParameters) {
-    (*params).windowLog = (if ::core::mem::size_of::<size_t>() == 4 {
+    (*params).windowLog = (if size_of::<size_t>() == 4 {
         ZSTD_WINDOWLOG_MAX_32
     } else {
         ZSTD_WINDOWLOG_MAX_64
     }) as core::ffi::c_uint;
-    (*params).chainLog = (if ::core::mem::size_of::<size_t>() == 4 {
+    (*params).chainLog = (if size_of::<size_t>() == 4 {
         ZSTD_CHAINLOG_MAX_32
     } else {
         ZSTD_CHAINLOG_MAX_64
     }) as core::ffi::c_uint;
-    (*params).hashLog = (if (if ::core::mem::size_of::<size_t>() == 4 {
+    (*params).hashLog = (if (if size_of::<size_t>() == 4 {
         ZSTD_WINDOWLOG_MAX_32
     } else {
         ZSTD_WINDOWLOG_MAX_64
     }) < 30
     {
-        if ::core::mem::size_of::<size_t>() == 4 {
+        if size_of::<size_t>() == 4 {
             ZSTD_WINDOWLOG_MAX_32
         } else {
             ZSTD_WINDOWLOG_MAX_64
@@ -1371,7 +1363,7 @@ unsafe fn setMaxCompression(params: *mut ZSTD_compressionParameters) {
     } else {
         30
     }) as core::ffi::c_uint;
-    (*params).searchLog = ((if ::core::mem::size_of::<size_t>() == 4 {
+    (*params).searchLog = ((if size_of::<size_t>() == 4 {
         ZSTD_WINDOWLOG_MAX_32
     } else {
         ZSTD_WINDOWLOG_MAX_64
@@ -1380,13 +1372,13 @@ unsafe fn setMaxCompression(params: *mut ZSTD_compressionParameters) {
     (*params).targetLength = ZSTD_TARGETLENGTH_MAX as core::ffi::c_uint;
     (*params).strategy = ZSTD_STRATEGY_MAX as ZSTD_strategy;
     g_overlapLog = ZSTD_OVERLAPLOG_MAX as u32;
-    g_ldmHashLog = (if (if ::core::mem::size_of::<size_t>() == 4 {
+    g_ldmHashLog = (if (if size_of::<size_t>() == 4 {
         ZSTD_WINDOWLOG_MAX_32
     } else {
         ZSTD_WINDOWLOG_MAX_64
     }) < 30
     {
-        if ::core::mem::size_of::<size_t>() == 4 {
+        if size_of::<size_t>() == 4 {
             ZSTD_WINDOWLOG_MAX_32
         } else {
             ZSTD_WINDOWLOG_MAX_64
@@ -1411,7 +1403,7 @@ unsafe fn printVersion() {
         stdout,
         b"*** %s (%i-bit) %s, by %s ***\n\0" as *const u8 as *const core::ffi::c_char,
         b"Zstandard CLI\0" as *const u8 as *const core::ffi::c_char,
-        (::core::mem::size_of::<size_t>()).wrapping_mul(8) as core::ffi::c_int,
+        (size_of::<size_t>()).wrapping_mul(8) as core::ffi::c_int,
         b"v1.5.8\0" as *const u8 as *const core::ffi::c_char,
         b"Yann Collet\0" as *const u8 as *const core::ffi::c_char,
     );
@@ -1878,7 +1870,7 @@ unsafe fn main_0(
     ptr::write_bytes(
         &mut compressionParams as *mut ZSTD_compressionParameters as *mut u8,
         0,
-        ::core::mem::size_of::<ZSTD_compressionParameters>(),
+        size_of::<ZSTD_compressionParameters>(),
     );
     FIO_addAbortHandler();
     argNb = 1;
@@ -2304,10 +2296,7 @@ unsafe fn main_0(
                                 b"--max\0" as *const u8 as *const core::ffi::c_char,
                             ) == 0
                             {
-                                if ::core::mem::size_of::<*mut core::ffi::c_void>()
-                                    as core::ffi::c_ulong
-                                    == 4
-                                {
+                                if size_of::<*mut core::ffi::c_void>() as core::ffi::c_ulong == 4 {
                                     if g_displayLevel >= 2 {
                                         fprintf(
                                             stderr,
@@ -2338,7 +2327,7 @@ unsafe fn main_0(
                                     ptr::write_bytes(
                                         &mut coverParams as *mut ZDICT_cover_params_t as *mut u8,
                                         0,
-                                        ::core::mem::size_of::<ZDICT_cover_params_t>(),
+                                        size_of::<ZDICT_cover_params_t>(),
                                     );
                                 } else {
                                     let fresh0 = argument;
@@ -2369,7 +2358,7 @@ unsafe fn main_0(
                                         &mut fastCoverParams as *mut ZDICT_fastCover_params_t
                                             as *mut u8,
                                         0,
-                                        ::core::mem::size_of::<ZDICT_fastCover_params_t>(),
+                                        size_of::<ZDICT_fastCover_params_t>(),
                                     );
                                 } else {
                                     let fresh1 = argument;
@@ -2570,7 +2559,7 @@ unsafe fn main_0(
                                 operation = zom_decompress;
                                 NEXT_FIELD!(patchFromDictFileName);
                                 memLimit = (1)
-                                    << (if ::core::mem::size_of::<size_t>() == 4 {
+                                    << (if size_of::<size_t>() == 4 {
                                         ZSTD_WINDOWLOG_MAX_32
                                     } else {
                                         ZSTD_WINDOWLOG_MAX_64
@@ -2805,7 +2794,7 @@ unsafe fn main_0(
                 stderr,
                 b"*** %s (%i-bit) %s, by %s ***\n\0" as *const u8 as *const core::ffi::c_char,
                 b"Zstandard CLI\0" as *const u8 as *const core::ffi::c_char,
-                (::core::mem::size_of::<size_t>()).wrapping_mul(8) as core::ffi::c_int,
+                (size_of::<size_t>()).wrapping_mul(8) as core::ffi::c_int,
                 b"v1.5.8\0" as *const u8 as *const core::ffi::c_char,
                 b"Yann Collet\0" as *const u8 as *const core::ffi::c_char,
             );

--- a/programs/zstdcli.rs
+++ b/programs/zstdcli.rs
@@ -329,7 +329,7 @@ unsafe fn usageAdvanced(programName: *const core::ffi::c_char) {
         stdout,
         b"*** %s (%i-bit) %s, by %s ***\n\0" as *const u8 as *const core::ffi::c_char,
         b"Zstandard CLI\0" as *const u8 as *const core::ffi::c_char,
-        (size_of::<size_t>()).wrapping_mul(8) as core::ffi::c_int,
+        size_of::<size_t>().wrapping_mul(8) as core::ffi::c_int,
         b"v1.5.8\0" as *const u8 as *const core::ffi::c_char,
         b"Yann Collet\0" as *const u8 as *const core::ffi::c_char,
     );
@@ -1403,7 +1403,7 @@ unsafe fn printVersion() {
         stdout,
         b"*** %s (%i-bit) %s, by %s ***\n\0" as *const u8 as *const core::ffi::c_char,
         b"Zstandard CLI\0" as *const u8 as *const core::ffi::c_char,
-        (size_of::<size_t>()).wrapping_mul(8) as core::ffi::c_int,
+        size_of::<size_t>().wrapping_mul(8) as core::ffi::c_int,
         b"v1.5.8\0" as *const u8 as *const core::ffi::c_char,
         b"Yann Collet\0" as *const u8 as *const core::ffi::c_char,
     );
@@ -2794,7 +2794,7 @@ unsafe fn main_0(
                 stderr,
                 b"*** %s (%i-bit) %s, by %s ***\n\0" as *const u8 as *const core::ffi::c_char,
                 b"Zstandard CLI\0" as *const u8 as *const core::ffi::c_char,
-                (size_of::<size_t>()).wrapping_mul(8) as core::ffi::c_int,
+                size_of::<size_t>().wrapping_mul(8) as core::ffi::c_int,
                 b"v1.5.8\0" as *const u8 as *const core::ffi::c_char,
                 b"Yann Collet\0" as *const u8 as *const core::ffi::c_char,
             );


### PR DESCRIPTION
`size_of` is in the Rust prelude, so use that instead.