### PR TITLE
Set minimum supported Rust version to 1.88

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -76,15 +76,22 @@ jobs:
           - target: "aarch64-pc-windows-msvc"
             rust: stable
             os: windows-11-arm
+
+          - target: "x86_64-unknown-linux-gnu"
+            rust: msrv
+            os: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
+      - name: Set target rust version
+        if: ${{ matrix.rust == 'msrv' }}
+        run: echo "MSRV=$(grep rust-version Cargo.toml | grep MSRV | awk -F '\"' '{print $2}')" >> $GITHUB_ENV
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
-          toolchain: stable
+          toolchain: ${{ env.MSRV || matrix.rust || 'stable' }}
           targets: "${{ matrix.target }}"
       - name: target
         run: "rustc -vV | sed -n 's|host: ||p'"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = [ "fuzz" ]
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.95"
+rust-version = "1.95" # MSRV
 
 [package]
 name = "libzstd-rs-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ exclude = [ "fuzz" ]
 
 [workspace.package]
 edition = "2021"
+rust-version = "1.88"
 
 [package]
 name = "libzstd-rs-sys"
@@ -13,7 +14,8 @@ repository = "https://github.com/trifectatechfoundation/libzstd-rs-sys"
 description = "a rust implementation of zstd compression and decompression"
 license = "BSD-3-Clause"
 publish = true
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 autobins = false
 include = [
     "Cargo.toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ exclude = [ "fuzz" ]
 
 [workspace.package]
 edition = "2021"
+rust-version = "1.95"
 
 [package]
 name = "libzstd-rs-sys"
@@ -13,7 +14,8 @@ repository = "https://github.com/trifectatechfoundation/libzstd-rs-sys"
 description = "a rust implementation of zstd compression and decompression"
 license = "BSD-3-Clause"
 publish = true
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 autobins = false
 include = [
     "Cargo.toml",

--- a/test-libzstd-rs-sys/Cargo.toml
+++ b/test-libzstd-rs-sys/Cargo.toml
@@ -8,7 +8,7 @@ edition.workspace = true
 # repository.workspace = true
 # homepage.workspace = true
 # publish.workspace = true
-# rust-version.workspace = true
+rust-version.workspace = true
 
 [dependencies.libzstd-rs-sys]
 path = ".."


### PR DESCRIPTION
Rust 1.88 is the lowest version that compiles. By setting MSRV we can get warnings when using newer futures.

For example `[T]::as_chunks()` that was introduces in Rust 1.88 is used.

Rust Edition 2024 was introduced in Rust 1.85, so it can be used (when ready).