### PR TITLE
Fix clippy lints

### DIFF
--- a/programs/datagen.rs
+++ b/programs/datagen.rs
@@ -151,7 +151,7 @@ pub unsafe fn RDG_genBuffer(
 ) {
     let mut seed32 = seed;
     let mut ldt: [u8; 8192] = [0; 8192];
-    ptr::write_bytes(ldt.as_mut_ptr() as *mut u8, b'0', size_of::<[u8; 8192]>());
+    ptr::write_bytes(ldt.as_mut_ptr(), b'0', size_of::<[u8; 8192]>());
     if litProba <= 0.0f64 {
         litProba = matchProba / 4.5f64;
     }
@@ -180,7 +180,7 @@ pub unsafe fn RDG_genStdout(
     if litProba <= 0.0f64 {
         litProba = matchProba / 4.5f64;
     }
-    ptr::write_bytes(ldt.as_mut_ptr() as *mut u8, b'0', size_of::<[u8; 8192]>());
+    ptr::write_bytes(ldt.as_mut_ptr(), b'0', size_of::<[u8; 8192]>());
     RDG_fillLiteralDistrib(
         ldt.as_mut_ptr(),
         (litProba * 256.0 + 0.001f64) as fixedPoint_24_8,

--- a/programs/datagen.rs
+++ b/programs/datagen.rs
@@ -19,7 +19,7 @@ unsafe fn RDG_rand(src: *mut u32) -> u32 {
     *src = rand32;
     rand32 >> 5
 }
-unsafe fn RDG_fillLiteralDistrib(ldt: *mut u8, mut ld: fixedPoint_24_8) {
+unsafe fn RDG_fillLiteralDistrib(ldt: *mut u8, ld: fixedPoint_24_8) {
     let firstChar = (if ld as core::ffi::c_double <= 0.0f64 {
         0
     } else {
@@ -36,9 +36,6 @@ unsafe fn RDG_fillLiteralDistrib(ldt: *mut u8, mut ld: fixedPoint_24_8) {
         '0' as i32
     }) as u8;
     let mut u: u32 = 0;
-    if ld <= 0 {
-        ld = 0;
-    }
     u = 0;
     while u < LTSIZE as u32 {
         let weight = (((LTSIZE as u32).wrapping_sub(u) * ld) >> 8).wrapping_add(1);

--- a/programs/dibio.rs
+++ b/programs/dibio.rs
@@ -450,11 +450,7 @@ pub unsafe fn DiB_trainFromFiles(
                 stderr,
                 b"!  Warning : setting manual memory limit for dictionary training data at %u MB \n\0"
                     as *const u8 as *const core::ffi::c_char,
-                memLimit
-                    .wrapping_div(
-                        (((1) << 20))
-                            as core::ffi::c_uint,
-                    ),
+                memLimit.wrapping_div(1 << 20),
             );
         }
         loadedSize = if loadedSize < memLimit as size_t {

--- a/programs/dibio.rs
+++ b/programs/dibio.rs
@@ -1,6 +1,8 @@
 use core::ptr;
 use std::ffi::CStr;
 use std::io;
+use std::num::NonZeroUsize;
+use std::ops::Div as _;
 
 use libc::{exit, fclose, fflush, fopen, fprintf, fread, free, fwrite, malloc, size_t, FILE};
 use libzstd_rs_sys::lib::zdict::experimental::{
@@ -337,9 +339,11 @@ unsafe fn DiB_fileStats(
                     *fileNamesTable.offset(n as isize),
                 );
             }
-        } else if chunkSize > 0 {
-            fs.nbSamples += ((fileSize as size_t).wrapping_add(chunkSize).wrapping_sub(1)
-                / chunkSize) as core::ffi::c_int;
+        } else if let Some(chunkSize) = NonZeroUsize::new(chunkSize) {
+            fs.nbSamples += (fileSize as size_t)
+                .wrapping_add(chunkSize.get())
+                .wrapping_sub(1)
+                .div(chunkSize) as core::ffi::c_int;
             fs.totalSizeToLoad += fileSize;
         } else {
             if fileSize > SAMPLESIZE_MAX as i64 {

--- a/programs/fileio.rs
+++ b/programs/fileio.rs
@@ -27,7 +27,7 @@ use libzstd_rs_sys::lib::decompress::zstd_decompress::{
 };
 use libzstd_rs_sys::lib::decompress::{ZSTD_DCtx, ZSTD_FrameHeader, ZSTD_frame};
 use libzstd_rs_sys::lib::zstd::{
-    ZSTD_ParamSwitch_e, ZSTD_ResetDirective, ZSTD_btlazy2, ZSTD_btopt, ZSTD_cParameter,
+    Format, ZSTD_ParamSwitch_e, ZSTD_ResetDirective, ZSTD_btlazy2, ZSTD_btopt, ZSTD_cParameter,
     ZSTD_compressionParameters, ZSTD_dParameter, ZSTD_error_frameParameter_windowTooLarge,
     ZSTD_frameProgression, ZSTD_inBuffer, ZSTD_inBuffer_s, ZSTD_outBuffer, ZSTD_outBuffer_s,
     ZSTD_strategy, ZSTD_BLOCKSIZE_MAX, ZSTD_CONTENTSIZE_ERROR, ZSTD_CONTENTSIZE_UNKNOWN,
@@ -6841,13 +6841,7 @@ unsafe fn FIO_analyzeFrames(info: *mut fileInfo_t, srcFile: *mut FILE) -> InfoEr
             size_of::<[u8; 18]>(),
             srcFile,
         );
-        if numBytesRead
-            < (if ZSTD_f_zstd1 as core::ffi::c_int == ZSTD_f_zstd1 as core::ffi::c_int {
-                6
-            } else {
-                2
-            }) as size_t
-        {
+        if numBytesRead < Format::ZSTD_f_zstd1.frame_header_size_min() {
             if feof(srcFile) != 0
                 && numBytesRead == 0
                 && (*info).compressedSize > 0

--- a/programs/fileio.rs
+++ b/programs/fileio.rs
@@ -4166,7 +4166,7 @@ unsafe fn FIO_compressZstdFrame(
                         );
                     }
                     if zfp.currentJobID > ((*prefs).nbWorkers + 1) as core::ffi::c_uint {
-                        if inputBlocked <= 0 {
+                        if inputBlocked == 0 {
                             if g_display_prefs.displayLevel >= 6 {
                                 fprintf(
                                     stderr,

--- a/programs/fileio.rs
+++ b/programs/fileio.rs
@@ -3560,12 +3560,7 @@ unsafe fn FIO_compressLzmaFrame(
     let mut action = LZMA_RUN;
     let mut ret = LZMA_OK;
     let mut writeJob = core::ptr::null_mut();
-    if compressionLevel < 0 {
-        compressionLevel = 0;
-    }
-    if compressionLevel > 9 {
-        compressionLevel = 9;
-    }
+    compressionLevel = compressionLevel.clamp(0, 9);
     if plain_lzma != 0 {
         let mut opt_lzma = lzma_options_lzma {
             dict_size: 0,

--- a/programs/fileio.rs
+++ b/programs/fileio.rs
@@ -4532,7 +4532,7 @@ unsafe fn FIO_compressFilename_internal(
             }
             exit(20);
         }
-        0 | _ => {
+        _ => {
             compressedfilesize = FIO_compressZstdFrame(
                 fCtx,
                 prefs,
@@ -7372,7 +7372,7 @@ unsafe fn FIO_listFile(
             }
             return 1;
         }
-        0 | _ => {}
+        _ => {}
     }
     displayInfo(inFileName, &info, displayLevel);
     *total = FIO_addFInfo(*total, info);

--- a/programs/fileio_asyncio.rs
+++ b/programs/fileio_asyncio.rs
@@ -531,7 +531,7 @@ unsafe fn AIO_IOPool_createThreadPool(ctx: *mut IOPoolCtx_t, prefs: *const FIO_p
             }
             exit(102);
         }
-        assert!(MAX_IO_JOBS >= 2);
+        const { assert!(MAX_IO_JOBS >= 2) };
         (*ctx).threadPool = POOL_create(1, (MAX_IO_JOBS - 2) as size_t);
         (*ctx).threadPoolActive = 1;
         if ((*ctx).threadPool).is_null() {

--- a/programs/main.rs
+++ b/programs/main.rs
@@ -7,6 +7,7 @@
 #![allow(clippy::all)]
 #![warn(clippy::absurd_extreme_comparisons)]
 #![warn(clippy::eq_op)]
+#![warn(clippy::unnecessary_cast)]
 extern crate libc;
 
 pub mod benchfn;

--- a/programs/main.rs
+++ b/programs/main.rs
@@ -5,6 +5,7 @@
 #![allow(unused_assignments)]
 // FIXME I guess
 #![allow(clippy::all)]
+#![warn(clippy::absurd_extreme_comparisons)]
 extern crate libc;
 
 pub mod benchfn;

--- a/programs/main.rs
+++ b/programs/main.rs
@@ -13,6 +13,7 @@
 #![warn(clippy::manual_checked_ops)]
 #![warn(clippy::double_parens)]
 #![warn(clippy::redundant_field_names)]
+#![warn(clippy::if_same_then_else)]
 extern crate libc;
 
 pub mod benchfn;

--- a/programs/main.rs
+++ b/programs/main.rs
@@ -8,6 +8,7 @@
 #![warn(clippy::absurd_extreme_comparisons)]
 #![warn(clippy::eq_op)]
 #![warn(clippy::unnecessary_cast)]
+#![warn(clippy::field_reassign_with_default)]
 extern crate libc;
 
 pub mod benchfn;

--- a/programs/main.rs
+++ b/programs/main.rs
@@ -4,19 +4,9 @@
 #![allow(non_upper_case_globals)]
 #![allow(unused_assignments)]
 // FIXME I guess
-#![allow(clippy::all)]
-#![warn(clippy::absurd_extreme_comparisons)]
-#![warn(clippy::eq_op)]
-#![warn(clippy::unnecessary_cast)]
-#![warn(clippy::field_reassign_with_default)]
-#![warn(clippy::manual_clamp)]
-#![warn(clippy::manual_checked_ops)]
-#![warn(clippy::double_parens)]
-#![warn(clippy::redundant_field_names)]
-#![warn(clippy::if_same_then_else)]
-#![warn(clippy::wildcard_in_or_patterns)]
-#![warn(clippy::collapsible_if)]
-#![warn(clippy::assertions_on_constants)]
+#![allow(clippy::missing_safety_doc)]
+#![allow(clippy::too_many_arguments)]
+#![allow(clippy::nonminimal_bool)]
 extern crate libc;
 
 pub mod benchfn;

--- a/programs/main.rs
+++ b/programs/main.rs
@@ -12,6 +12,7 @@
 #![warn(clippy::manual_clamp)]
 #![warn(clippy::manual_checked_ops)]
 #![warn(clippy::double_parens)]
+#![warn(clippy::redundant_field_names)]
 extern crate libc;
 
 pub mod benchfn;

--- a/programs/main.rs
+++ b/programs/main.rs
@@ -10,6 +10,7 @@
 #![warn(clippy::unnecessary_cast)]
 #![warn(clippy::field_reassign_with_default)]
 #![warn(clippy::manual_clamp)]
+#![warn(clippy::manual_checked_ops)]
 extern crate libc;
 
 pub mod benchfn;

--- a/programs/main.rs
+++ b/programs/main.rs
@@ -6,6 +6,7 @@
 // FIXME I guess
 #![allow(clippy::all)]
 #![warn(clippy::absurd_extreme_comparisons)]
+#![warn(clippy::eq_op)]
 extern crate libc;
 
 pub mod benchfn;

--- a/programs/main.rs
+++ b/programs/main.rs
@@ -9,6 +9,7 @@
 #![warn(clippy::eq_op)]
 #![warn(clippy::unnecessary_cast)]
 #![warn(clippy::field_reassign_with_default)]
+#![warn(clippy::manual_clamp)]
 extern crate libc;
 
 pub mod benchfn;

--- a/programs/main.rs
+++ b/programs/main.rs
@@ -14,6 +14,7 @@
 #![warn(clippy::double_parens)]
 #![warn(clippy::redundant_field_names)]
 #![warn(clippy::if_same_then_else)]
+#![warn(clippy::wildcard_in_or_patterns)]
 extern crate libc;
 
 pub mod benchfn;

--- a/programs/main.rs
+++ b/programs/main.rs
@@ -16,6 +16,7 @@
 #![warn(clippy::if_same_then_else)]
 #![warn(clippy::wildcard_in_or_patterns)]
 #![warn(clippy::collapsible_if)]
+#![warn(clippy::assertions_on_constants)]
 extern crate libc;
 
 pub mod benchfn;

--- a/programs/main.rs
+++ b/programs/main.rs
@@ -15,6 +15,7 @@
 #![warn(clippy::redundant_field_names)]
 #![warn(clippy::if_same_then_else)]
 #![warn(clippy::wildcard_in_or_patterns)]
+#![warn(clippy::collapsible_if)]
 extern crate libc;
 
 pub mod benchfn;

--- a/programs/main.rs
+++ b/programs/main.rs
@@ -11,6 +11,7 @@
 #![warn(clippy::field_reassign_with_default)]
 #![warn(clippy::manual_clamp)]
 #![warn(clippy::manual_checked_ops)]
+#![warn(clippy::double_parens)]
 extern crate libc;
 
 pub mod benchfn;

--- a/programs/util.rs
+++ b/programs/util.rs
@@ -1012,11 +1012,10 @@ pub unsafe fn UTIL_isConsole(file: *mut FILE) -> core::ffi::c_int {
         fprintf(stderr, b"\n\0" as *const u8 as *const core::ffi::c_char);
         g_traceDepth += 1;
     }
-    if file == stdin && g_fakeStdinIsConsole != 0 {
-        ret = 1;
-    } else if file == stderr && g_fakeStderrIsConsole != 0 {
-        ret = 1;
-    } else if file == stdout && g_fakeStdoutIsConsole != 0 {
+    if (file == stdin && g_fakeStdinIsConsole != 0)
+        || (file == stderr && g_fakeStderrIsConsole != 0)
+        || (file == stdout && g_fakeStdoutIsConsole != 0)
+    {
         ret = 1;
     } else {
         ret = isatty(fileno(file));

--- a/programs/util.rs
+++ b/programs/util.rs
@@ -1249,7 +1249,7 @@ unsafe fn UTIL_readFileContent(
             bufSize.wrapping_sub(totalRead).wrapping_sub(1),
             inFile,
         );
-        if bytesRead <= 0 {
+        if bytesRead == 0 {
             break;
         }
         totalRead = totalRead.wrapping_add(bytesRead);

--- a/programs/zstdcli.rs
+++ b/programs/zstdcli.rs
@@ -3042,7 +3042,7 @@ unsafe fn main_0(
             let zParams = ZDICT_params_t {
                 compressionLevel: dictCLevel,
                 notificationLevel: g_displayLevel as core::ffi::c_uint,
-                dictID: dictID,
+                dictID,
             };
             if dict as core::ffi::c_uint == cover as core::ffi::c_int as core::ffi::c_uint {
                 let optimize = (coverParams.k == 0 || coverParams.d == 0) as core::ffi::c_int;

--- a/programs/zstdcli.rs
+++ b/programs/zstdcli.rs
@@ -3149,20 +3149,20 @@ unsafe fn main_0(
                     }
                     cLevel = maxCLevel;
                 }
-                if showDefaultCParams != 0 {
-                    if operation as core::ffi::c_uint
+                if showDefaultCParams != 0
+                    && operation as core::ffi::c_uint
                         == zom_decompress as core::ffi::c_int as core::ffi::c_uint
-                    {
-                        if g_displayLevel >= 1 {
-                            fprintf(
+                {
+                    if g_displayLevel >= 1 {
+                        fprintf(
                             stderr,
                             b"error : can't use --show-default-cparams in decompression mode \n\0"
-                                as *const u8 as *const core::ffi::c_char,
+                                as *const u8
+                                as *const core::ffi::c_char,
                         );
-                        }
-                        operationResult = 1;
-                        break 'end;
                     }
+                    operationResult = 1;
+                    break 'end;
                 }
                 if !dictFileName.is_null() && !patchFromDictFileName.is_null() {
                     if g_displayLevel >= 1 {

--- a/programs/zstdcli.rs
+++ b/programs/zstdcli.rs
@@ -1079,25 +1079,27 @@ unsafe fn parseLegacyParameters(
 }
 
 fn defaultCoverParams() -> ZDICT_cover_params_t {
-    let mut params = ZDICT_cover_params_t::default();
-    params.d = 8;
-    params.steps = 4;
-    params.splitPoint = 1.0f64;
-    params.shrinkDict = 0;
-    params.shrinkDictMaxRegression = kDefaultRegression;
-    params
+    ZDICT_cover_params_t {
+        d: 8,
+        steps: 4,
+        splitPoint: 1.0f64,
+        shrinkDict: 0,
+        shrinkDictMaxRegression: kDefaultRegression,
+        ..Default::default()
+    }
 }
 
 fn defaultFastCoverParams() -> ZDICT_fastCover_params_t {
-    let mut params = ZDICT_fastCover_params_t::default();
-    params.d = 8;
-    params.f = 20;
-    params.steps = 4;
-    params.splitPoint = 0.75f64;
-    params.accel = DEFAULT_ACCEL as core::ffi::c_uint;
-    params.shrinkDict = 0;
-    params.shrinkDictMaxRegression = kDefaultRegression;
-    params
+    ZDICT_fastCover_params_t {
+        d: 8,
+        f: 20,
+        steps: 4,
+        splitPoint: 0.75f64,
+        accel: DEFAULT_ACCEL as core::ffi::c_uint,
+        shrinkDict: 0,
+        shrinkDictMaxRegression: kDefaultRegression,
+        ..Default::default()
+    }
 }
 
 unsafe fn parseAdaptParameters(
@@ -3078,9 +3080,10 @@ unsafe fn main_0(
                     memLimit,
                 );
             } else {
-                let mut dictParams = ZDICT_legacy_params_t::default();
-                dictParams.selectivityLevel = dictSelect;
-                dictParams.zParams = zParams;
+                let mut dictParams = ZDICT_legacy_params_t {
+                    selectivityLevel: dictSelect,
+                    zParams,
+                };
                 operationResult = DiB_trainFromFiles(
                     outFileName,
                     maxDictSize as size_t,

--- a/programs/zstdcli.rs
+++ b/programs/zstdcli.rs
@@ -1971,12 +1971,10 @@ unsafe fn main_0(
                             argument,
                             b"--decompress\0" as *const u8 as *const core::ffi::c_char,
                         ) == 0
-                        {
-                            operation = zom_decompress;
-                        } else if strcmp(
-                            argument,
-                            b"--uncompress\0" as *const u8 as *const core::ffi::c_char,
-                        ) == 0
+                            || strcmp(
+                                argument,
+                                b"--uncompress\0" as *const u8 as *const core::ffi::c_char,
+                            ) == 0
                         {
                             operation = zom_decompress;
                         } else if strcmp(
@@ -2334,11 +2332,8 @@ unsafe fn main_0(
                                 } else {
                                     let fresh0 = argument;
                                     argument = argument.offset(1);
-                                    if *fresh0 as core::ffi::c_int != '=' as i32 {
-                                        badUsage(programName, originalArgument);
-                                        operationResult = 1;
-                                        break 'end;
-                                    } else if parseCoverParameters(argument, &mut coverParams) == 0
+                                    if *fresh0 as core::ffi::c_int != '=' as i32
+                                        || parseCoverParameters(argument, &mut coverParams) == 0
                                     {
                                         badUsage(programName, originalArgument);
                                         operationResult = 1;
@@ -2365,14 +2360,9 @@ unsafe fn main_0(
                                 } else {
                                     let fresh1 = argument;
                                     argument = argument.offset(1);
-                                    if *fresh1 as core::ffi::c_int != '=' as i32 {
-                                        badUsage(programName, originalArgument);
-                                        operationResult = 1;
-                                        break 'end;
-                                    } else if parseFastCoverParameters(
-                                        argument,
-                                        &mut fastCoverParams,
-                                    ) == 0
+                                    if *fresh1 as core::ffi::c_int != '=' as i32
+                                        || parseFastCoverParameters(argument, &mut fastCoverParams)
+                                            == 0
                                     {
                                         badUsage(programName, originalArgument);
                                         operationResult = 1;
@@ -2392,11 +2382,8 @@ unsafe fn main_0(
                                 if *argument as core::ffi::c_int != 0 {
                                     let fresh2 = argument;
                                     argument = argument.offset(1);
-                                    if *fresh2 as core::ffi::c_int != '=' as i32 {
-                                        badUsage(programName, originalArgument);
-                                        operationResult = 1;
-                                        break 'end;
-                                    } else if parseLegacyParameters(argument, &mut dictSelect) == 0
+                                    if *fresh2 as core::ffi::c_int != '=' as i32
+                                        || parseLegacyParameters(argument, &mut dictSelect) == 0
                                     {
                                         badUsage(programName, originalArgument);
                                         operationResult = 1;
@@ -2414,36 +2401,29 @@ unsafe fn main_0(
                                 &mut argument,
                                 b"--memlimit\0" as *const u8 as *const core::ffi::c_char,
                             ) != 0
-                            {
-                                NEXT_UINT32!(memLimit);
-                            } else if longCommandWArg(
-                                &mut argument,
-                                b"--memory\0" as *const u8 as *const core::ffi::c_char,
-                            ) != 0
-                            {
-                                NEXT_UINT32!(memLimit);
-                            } else if longCommandWArg(
-                                &mut argument,
-                                b"--memlimit-decompress\0" as *const u8 as *const core::ffi::c_char,
-                            ) != 0
+                                || longCommandWArg(
+                                    &mut argument,
+                                    b"--memory\0" as *const u8 as *const core::ffi::c_char,
+                                ) != 0
+                                || longCommandWArg(
+                                    &mut argument,
+                                    b"--memlimit-decompress\0" as *const u8
+                                        as *const core::ffi::c_char,
+                                ) != 0
                             {
                                 NEXT_UINT32!(memLimit);
                             } else if longCommandWArg(
                                 &mut argument,
                                 b"--block-size\0" as *const u8 as *const core::ffi::c_char,
                             ) != 0
-                            {
-                                NEXT_TSIZE!(chunkSize);
-                            } else if longCommandWArg(
-                                &mut argument,
-                                b"--split\0" as *const u8 as *const core::ffi::c_char,
-                            ) != 0
-                            {
-                                NEXT_TSIZE!(chunkSize);
-                            } else if longCommandWArg(
-                                &mut argument,
-                                b"--jobsize\0" as *const u8 as *const core::ffi::c_char,
-                            ) != 0
+                                || longCommandWArg(
+                                    &mut argument,
+                                    b"--split\0" as *const u8 as *const core::ffi::c_char,
+                                ) != 0
+                                || longCommandWArg(
+                                    &mut argument,
+                                    b"--jobsize\0" as *const u8 as *const core::ffi::c_char,
+                                ) != 0
                             {
                                 NEXT_TSIZE!(chunkSize);
                             } else if longCommandWArg(


### PR DESCRIPTION
Fix a lot of Clippy lints. Mostly for files under `programs/`, but also enables `unused_assignments` for `lib/`.